### PR TITLE
feat: implement anchorkit register subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,13 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Deploy contract to a network
+    /// Deploy contract to a network (testnet/mainnet/futurenet)
     Deploy {
         #[arg(long, default_value = "testnet")]
         network: String,
+        /// Source account key (secret key or identity name)
+        #[arg(long, default_value = "default")]
+        source: String,
     },
     /// Register an attestor
     Register {
@@ -32,11 +35,56 @@ enum Commands {
     Doctor,
 }
 
+fn deploy(network: &str, source: &str) {
+    let rpc_url = match network {
+        "mainnet" => "https://horizon.stellar.org",
+        "futurenet" => "https://rpc-futurenet.stellar.org",
+        _ => "https://soroban-testnet.stellar.org",
+    };
+    let network_passphrase = match network {
+        "mainnet" => "Public Global Stellar Network ; September 2015",
+        "futurenet" => "Test SDF Future Network ; October 2022",
+        _ => "Test SDF Network ; September 2015",
+    };
+
+    println!("Building WASM for {network}...");
+    let build = std::process::Command::new("cargo")
+        .args(["build", "--release", "--target", "wasm32-unknown-unknown",
+               "--no-default-features", "--features", "wasm"])
+        .status()
+        .expect("failed to run cargo build");
+    if !build.success() {
+        eprintln!("WASM build failed");
+        std::process::exit(1);
+    }
+
+    let wasm = "target/wasm32-unknown-unknown/release/anchorkit.wasm";
+    println!("Deploying {wasm} to {network}...");
+    let output = std::process::Command::new("stellar")
+        .args([
+            "contract", "deploy",
+            "--wasm", wasm,
+            "--source", source,
+            "--rpc-url", rpc_url,
+            "--network-passphrase", network_passphrase,
+        ])
+        .output()
+        .expect("failed to run stellar contract deploy — is the Stellar CLI installed?");
+
+    if output.status.success() {
+        let contract_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        println!("Contract ID: {contract_id}");
+    } else {
+        eprintln!("{}", String::from_utf8_lossy(&output.stderr).trim());
+        std::process::exit(1);
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Deploy { network } => {
-            println!("Deploying to {network}...");
+        Commands::Deploy { network, source } => {
+            deploy(&network, &source);
         }
         Commands::Register { address, services } => {
             println!("Registering attestor {address} with services: {services}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,56 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "anchorkit", about = "SorobanAnchor CLI")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Deploy contract to a network
+    Deploy {
+        #[arg(long, default_value = "testnet")]
+        network: String,
+    },
+    /// Register an attestor
+    Register {
+        #[arg(long)]
+        address: String,
+        #[arg(long)]
+        services: String,
+    },
+    /// Submit an attestation
+    Attest {
+        #[arg(long)]
+        subject: String,
+        #[arg(long)]
+        payload_hash: String,
+    },
+    /// Check environment setup
+    Doctor,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Deploy { network } => {
+            println!("Deploying to {network}...");
+        }
+        Commands::Register { address, services } => {
+            println!("Registering attestor {address} with services: {services}");
+        }
+        Commands::Attest { subject, payload_hash } => {
+            println!("Attesting subject {subject} with payload hash {payload_hash}");
+        }
+        Commands::Doctor => {
+            println!("Checking environment...");
+            println!("  cargo: {}", std::process::Command::new("cargo")
+                .arg("--version")
+                .output()
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                .unwrap_or_else(|_| "not found".into()));
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,18 @@ enum Commands {
     Register {
         #[arg(long)]
         address: String,
+        #[arg(long, value_delimiter = ',')]
+        services: Vec<String>,
         #[arg(long)]
-        services: String,
+        contract_id: String,
+        #[arg(long, default_value = "testnet")]
+        network: String,
+        #[arg(long, default_value = "default")]
+        source: String,
+        #[arg(long)]
+        sep10_token: String,
+        #[arg(long)]
+        sep10_issuer: String,
     },
     /// Submit an attestation
     Attest {
@@ -80,14 +90,96 @@ fn deploy(network: &str, source: &str) {
     }
 }
 
+fn parse_services(services: &[String]) -> Vec<u32> {
+    services.iter().map(|s| match s.trim() {
+        "deposits"    => 1,
+        "withdrawals" => 2,
+        "quotes"      => 3,
+        "kyc"         => 4,
+        other => { eprintln!("Unknown service: {other}"); std::process::exit(1); }
+    }).collect()
+}
+
+fn register(
+    address: &str,
+    services: &[String],
+    contract_id: &str,
+    network: &str,
+    source: &str,
+    sep10_token: &str,
+    sep10_issuer: &str,
+) {
+    let rpc_url = match network {
+        "mainnet"   => "https://horizon.stellar.org",
+        "futurenet" => "https://rpc-futurenet.stellar.org",
+        _           => "https://soroban-testnet.stellar.org",
+    };
+    let network_passphrase = match network {
+        "mainnet"   => "Public Global Stellar Network ; September 2015",
+        "futurenet" => "Test SDF Future Network ; October 2022",
+        _           => "Test SDF Network ; September 2015",
+    };
+
+    let service_ids = parse_services(services);
+    let services_arg = service_ids.iter()
+        .map(|id| id.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    println!("Registering attestor {address} with services: {}", services.join(","));
+
+    // Step 1: register_attestor
+    let output = std::process::Command::new("stellar")
+        .args([
+            "contract", "invoke",
+            "--id", contract_id,
+            "--source", source,
+            "--rpc-url", rpc_url,
+            "--network-passphrase", network_passphrase,
+            "--", "register_attestor",
+            "--attestor", address,
+            "--sep10_token", sep10_token,
+            "--sep10_issuer", sep10_issuer,
+        ])
+        .output()
+        .expect("failed to run stellar contract invoke — is the Stellar CLI installed?");
+
+    if !output.status.success() {
+        eprintln!("{}", String::from_utf8_lossy(&output.stderr).trim());
+        std::process::exit(1);
+    }
+
+    // Step 2: configure_services
+    let svc_output = std::process::Command::new("stellar")
+        .args([
+            "contract", "invoke",
+            "--id", contract_id,
+            "--source", source,
+            "--rpc-url", rpc_url,
+            "--network-passphrase", network_passphrase,
+            "--", "configure_services",
+            "--anchor", address,
+            "--services", &services_arg,
+        ])
+        .output()
+        .expect("failed to run stellar contract invoke");
+
+    if svc_output.status.success() {
+        println!("Attestor {address} registered and services configured.");
+    } else {
+        eprintln!("{}", String::from_utf8_lossy(&svc_output.stderr).trim());
+        std::process::exit(1);
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
     match cli.command {
         Commands::Deploy { network, source } => {
             deploy(&network, &source);
         }
-        Commands::Register { address, services } => {
-            println!("Registering attestor {address} with services: {services}");
+        Commands::Register { address, services, contract_id, network, source, sep10_token, sep10_issuer } => {
+            register(&address, &services, &contract_id, &network, &source, &sep10_token, &sep10_issuer);
         }
         Commands::Attest { subject, payload_hash } => {
             println!("Attesting subject {subject} with payload hash {payload_hash}");


### PR DESCRIPTION


Problem
The register subcommand existed as a stub that only printed a placeholder message. It had no connection to the deployed contract.

Changes

Added --contract-id, --network, --source, --sep10-token, --sep10-issuer args to the register subcommand

--services now accepts a comma-separated list via clap value_delimiter (deposits,withdrawals,kyc,quotes)

parse_services maps service names to on-chain u32 discriminants matching contract.rs constants

Calls stellar contract invoke register_attestor with SEP-10 JWT for authentication

Calls stellar contract invoke configure_services to set allowed services on-chain

Exits with non-zero status and prints stderr on any failure

Testing

anchorkit register \
  --address GANCHOR123... \
  --services deposits,withdrawals,kyc \
  --contract-id CXXX... \
  --network testnet \
  --source my-identity \
  --sep10-token eyJ... \
  --sep10-issuer GISSUER...

Copy
bash
Notes
The smart contract (register_attestor, configure_services) was already implemented in contract.rs and is unaffected. This change only wires the CLI to the existing on-chain functions.

Closes #3