### PR TITLE
enforce per-attestor rate limits in submit_attestation

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -5,6 +5,7 @@ use soroban_sdk::{
 
 use crate::deterministic_hash::{compute_payload_hash, verify_payload_hash};
 use crate::errors::ErrorCode;
+use crate::rate_limiter::RateLimiter;
 use crate::sep10_jwt;
 
 // ---------------------------------------------------------------------------
@@ -543,6 +544,11 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         issuer.require_auth();
         Self::check_attestor(&env, &issuer);
         Self::check_timestamp(&env, timestamp);
+
+        let config = RateLimiter::get_config(&env);
+        if RateLimiter::check_and_increment(&env, &issuer, &config).is_err() {
+            panic_with_error!(&env, ErrorCode::RateLimitExceeded);
+        }
 
         let used_key = (symbol_short!("USED"), payload_hash.clone());
         if env.storage().persistent().has(&used_key) {


### PR DESCRIPTION
closes #11 

feat: enforce per-attestor rate limits in submit_attestation                                                        
                                                                                                                      
  Call RateLimiter::check_and_increment at the top of submit_attestation.                                             
  Panics with ErrorCode::RateLimitExceeded when the limit is exceeded. 