### PR TITLE
feat: expose advance_transaction_state with legal transition guard

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -5,6 +5,7 @@ use soroban_sdk::{
 
 use crate::deterministic_hash::{compute_payload_hash, verify_payload_hash};
 use crate::errors::ErrorCode;
+use crate::rate_limiter::{RateLimiter, RateLimitState};
 use crate::sep10_jwt;
 use crate::transaction_state_tracker::{TransactionState, TransactionStateRecord};
 
@@ -1402,6 +1403,16 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         match Self::get_anchor_asset_info(env, anchor, asset_code) {
             asset => asset.withdrawal_enabled,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Rate limit inspection
+    // -----------------------------------------------------------------------
+
+    /// Return the current RateLimitState for `attestor` (submission count + window start).
+    /// Returns a zeroed state if the attestor has never submitted.
+    pub fn get_rate_limit_state(env: Env, attestor: Address) -> RateLimitState {
+        RateLimiter::get_state(&env, &attestor)
     }
 
     // -----------------------------------------------------------------------

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -6,6 +6,7 @@ use soroban_sdk::{
 use crate::deterministic_hash::{compute_payload_hash, verify_payload_hash};
 use crate::errors::ErrorCode;
 use crate::sep10_jwt;
+use crate::transaction_state_tracker::{TransactionState, TransactionStateRecord};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -285,6 +286,15 @@ struct AttestEvent {
 pub struct EndpointUpdated {
     pub attestor: Address,
     pub endpoint: String,
+}
+
+#[contracttype]
+#[derive(Clone)]
+struct TxStateChangedEvent {
+    transaction_id: u64,
+    old_state: u32,
+    new_state: u32,
+    timestamp: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -1392,6 +1402,90 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         match Self::get_anchor_asset_info(env, anchor, asset_code) {
             asset => asset.withdrawal_enabled,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Transaction state tracking
+    // -----------------------------------------------------------------------
+
+    /// Advance a stored transaction to `new_state`, enforcing legal transitions:
+    /// Pending → InProgress → Completed | Failed.
+    /// Panics with `IllegalTransition` if the transition is not allowed.
+    pub fn advance_transaction_state(
+        env: Env,
+        transaction_id: u64,
+        new_state: TransactionState,
+    ) -> TransactionStateRecord {
+        let key = (symbol_short!("TXSTATE"), transaction_id);
+        let record: TransactionStateRecord = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestationNotFound));
+
+        if !record.state.is_valid_transition(new_state) {
+            panic_with_error!(&env, ErrorCode::IllegalTransition);
+        }
+
+        let now = env.ledger().timestamp();
+        let old_state = record.state;
+        let updated = TransactionStateRecord {
+            state: new_state,
+            last_updated: now,
+            ..record
+        };
+
+        env.storage().persistent().set(&key, &updated);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("tx"), symbol_short!("state"), transaction_id),
+            TxStateChangedEvent {
+                transaction_id,
+                old_state: old_state as u32,
+                new_state: new_state as u32,
+                timestamp: now,
+            },
+        );
+
+        updated
+    }
+
+    /// Store a new transaction record in persistent storage (Pending state).
+    pub fn create_transaction_record(
+        env: Env,
+        transaction_id: u64,
+        initiator: Address,
+    ) -> TransactionStateRecord {
+        initiator.require_auth();
+        let key = (symbol_short!("TXSTATE"), transaction_id);
+        if env.storage().persistent().has(&key) {
+            panic_with_error!(&env, ErrorCode::AlreadyInitialized);
+        }
+        let now = env.ledger().timestamp();
+        let record = TransactionStateRecord {
+            transaction_id,
+            state: TransactionState::Pending,
+            initiator,
+            timestamp: now,
+            last_updated: now,
+            error_message: None,
+        };
+        env.storage().persistent().set(&key, &record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        record
+    }
+
+    /// Retrieve a stored transaction record.
+    pub fn get_transaction_record(env: Env, transaction_id: u64) -> TransactionStateRecord {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("TXSTATE"), transaction_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestationNotFound))
     }
 
     // -----------------------------------------------------------------------

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,6 +47,7 @@ pub enum ErrorCode {
     InvalidSep10Token = 18,
     CacheExpired = 48,
     CacheNotFound = 49,
+    IllegalTransition = 20,
 }
 
 impl ErrorCode {
@@ -74,6 +75,7 @@ impl ErrorCode {
             ErrorCode::InvalidSep10Token => "SEP-10 JWT is missing, expired, or invalid",
             ErrorCode::CacheExpired => "Cache entry has expired",
             ErrorCode::CacheNotFound => "Cache entry not found",
+            ErrorCode::IllegalTransition => "Illegal transaction state transition",
         }
     }
 }
@@ -198,6 +200,14 @@ impl AnchorKitError {
 
     pub fn rate_limit_exceeded() -> Self {
         Self::from_code(ErrorCode::RateLimitExceeded)
+    }
+
+    pub fn illegal_transition(from: &str, to: &str) -> Self {
+        Self::with_context(
+            ErrorCode::IllegalTransition,
+            ErrorCode::IllegalTransition.default_message(),
+            &alloc::format!("{} -> {}", from, to),
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub use sep6::{
     TransactionStatus, TransactionStatusResponse, WithdrawalResponse,
 };
 pub use contract::{AnchorKitContract, EndpointUpdated, get_endpoint, set_endpoint};
+pub use transaction_state_tracker::{TransactionState, TransactionStateRecord};
 
 #[cfg(test)]
 mod request_id_tests;

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -1,6 +1,8 @@
-use soroban_sdk::{contracttype, Address, Env, String};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, String};
 
 use crate::errors::AnchorKitError;
+
+const TXSTATE_TTL: u32 = 1_555_200;
 
 /// Transaction states for the state tracker
 #[contracttype]
@@ -93,6 +95,10 @@ impl TransactionStateTracker {
 
         if self.is_dev_mode {
             self.cache.push(record.clone());
+        } else {
+            let key = (symbol_short!("TXSTATE"), transaction_id);
+            env.storage().persistent().set(&key, &record);
+            env.storage().persistent().extend_ttl(&key, TXSTATE_TTL, TXSTATE_TTL);
         }
 
         Ok(record)
@@ -167,17 +173,32 @@ impl TransactionStateTracker {
                 "Transaction not found in cache",
             ));
         } else {
-            // In production, data would be persisted to DB
-            // For dev mode, use a dummy address
-            let dummy_address = Address::from_string(&String::from_str(env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"));
-            let record = TransactionStateRecord {
-                transaction_id,
-                state: new_state,
-                initiator: dummy_address,
-                timestamp: current_time,
-                last_updated: current_time,
-                error_message,
-            };
+            let key = (symbol_short!("TXSTATE"), transaction_id);
+            let mut record: TransactionStateRecord = env
+                .storage()
+                .persistent()
+                .get(&key)
+                .ok_or_else(|| String::from_str(env, "Transaction not found"))?;
+
+            if !record.state.is_valid_transition(new_state) {
+                return Err(String::from_str(
+                    env,
+                    AnchorKitError::illegal_transition(
+                        record.state.as_str(),
+                        new_state.as_str(),
+                    )
+                    .message
+                    .as_str(),
+                ));
+            }
+
+            record.state = new_state;
+            record.last_updated = current_time;
+            record.error_message = error_message;
+
+            env.storage().persistent().set(&key, &record);
+            env.storage().persistent().extend_ttl(&key, TXSTATE_TTL, TXSTATE_TTL);
+
             Ok(record)
         }
     }
@@ -207,8 +228,10 @@ impl TransactionStateTracker {
             }
             Ok(None)
         } else {
-            // In production, this would query the DB
-            Ok(None)
+            Ok(env
+                .storage()
+                .persistent()
+                .get(&(symbol_short!("TXSTATE"), transaction_id)))
         }
     }
 

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -1,5 +1,7 @@
 use soroban_sdk::{contracttype, Address, Env, String};
 
+use crate::errors::AnchorKitError;
+
 /// Transaction states for the state tracker
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -29,6 +31,17 @@ impl TransactionState {
             "failed" => Some(TransactionState::Failed),
             _ => None,
         }
+    }
+
+    /// Returns true only for legal forward transitions:
+    /// Pending → InProgress, InProgress → Completed, InProgress → Failed
+    pub fn is_valid_transition(&self, to: TransactionState) -> bool {
+        matches!(
+            (self, to),
+            (TransactionState::Pending, TransactionState::InProgress)
+                | (TransactionState::InProgress, TransactionState::Completed)
+                | (TransactionState::InProgress, TransactionState::Failed)
+        )
     }
 }
 
@@ -132,6 +145,17 @@ impl TransactionStateTracker {
             // Search and update in cache
             for record in self.cache.iter_mut() {
                 if record.transaction_id == transaction_id {
+                    if !record.state.is_valid_transition(new_state) {
+                        return Err(String::from_str(
+                            env,
+                            AnchorKitError::illegal_transition(
+                                record.state.as_str(),
+                                new_state.as_str(),
+                            )
+                            .message
+                            .as_str(),
+                        ));
+                    }
                     record.state = new_state;
                     record.last_updated = current_time;
                     record.error_message = error_message;
@@ -146,7 +170,7 @@ impl TransactionStateTracker {
             // In production, data would be persisted to DB
             // For dev mode, use a dummy address
             let dummy_address = Address::from_string(&String::from_str(env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"));
-            let mut record = TransactionStateRecord {
+            let record = TransactionStateRecord {
                 transaction_id,
                 state: new_state,
                 initiator: dummy_address,
@@ -156,6 +180,17 @@ impl TransactionStateTracker {
             };
             Ok(record)
         }
+    }
+
+    /// Advance a transaction to `new_state`, enforcing legal transition rules.
+    /// Returns an error if the transition is illegal or the transaction is not found.
+    pub fn advance_transaction_state(
+        &mut self,
+        transaction_id: u64,
+        new_state: TransactionState,
+        env: &Env,
+    ) -> Result<TransactionStateRecord, String> {
+        self.update_state(transaction_id, new_state, None, env)
     }
 
     /// Get transaction state by ID
@@ -357,5 +392,50 @@ mod tests {
 
         assert!(clear_result.is_ok());
         assert_eq!(tracker.cache_size(), 0);
+    }
+
+    #[test]
+    fn test_is_valid_transition() {
+        assert!(TransactionState::Pending.is_valid_transition(TransactionState::InProgress));
+        assert!(TransactionState::InProgress.is_valid_transition(TransactionState::Completed));
+        assert!(TransactionState::InProgress.is_valid_transition(TransactionState::Failed));
+
+        assert!(!TransactionState::Pending.is_valid_transition(TransactionState::Completed));
+        assert!(!TransactionState::Pending.is_valid_transition(TransactionState::Failed));
+        assert!(!TransactionState::Completed.is_valid_transition(TransactionState::InProgress));
+        assert!(!TransactionState::Failed.is_valid_transition(TransactionState::InProgress));
+        assert!(!TransactionState::Completed.is_valid_transition(TransactionState::Pending));
+    }
+
+    #[test]
+    fn test_advance_transaction_state_legal() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator.clone(), &env).ok();
+
+        let r = tracker.advance_transaction_state(1, TransactionState::InProgress, &env);
+        assert!(r.is_ok());
+        assert_eq!(r.unwrap().state, TransactionState::InProgress);
+
+        let r = tracker.advance_transaction_state(1, TransactionState::Completed, &env);
+        assert!(r.is_ok());
+        assert_eq!(r.unwrap().state, TransactionState::Completed);
+    }
+
+    #[test]
+    fn test_advance_transaction_state_illegal() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator.clone(), &env).ok();
+        tracker.advance_transaction_state(1, TransactionState::InProgress, &env).ok();
+        tracker.advance_transaction_state(1, TransactionState::Completed, &env).ok();
+
+        // Completed → InProgress must be rejected
+        let r = tracker.advance_transaction_state(1, TransactionState::InProgress, &env);
+        assert!(r.is_err());
     }
 }


### PR DESCRIPTION
closes #18 
closes #19 

- Add ErrorCode::IllegalTransition (20) and illegal_transition(from, to) constructor
- Add TransactionState::is_valid_transition() enforcing Pending→InProgress→Completed|Failed
- Guard update_state to reject illegal transitions with descriptive error
- Add public advance_transaction_state() on TransactionStateTracker
- Expose advance_transaction_state, create_transaction_record, get_transaction_record on AnchorKitContract
- Emit TxStateChangedEvent on every legal state change
- Re-export TransactionState and TransactionStateRecord from lib.rs