### PR TITLE
feat: add quote, status, revoke commands and signing key resolution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ stress-tests = []
 [dependencies]
 soroban-sdk = "21.7.0"
 clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", features = ["blocking"] }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.7.0", features = ["testutils"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,78 @@
 use clap::{Parser, Subcommand};
+use serde::Serialize;
+
+// ── Key resolution ────────────────────────────────────────────────────────────
+
+/// Resolve the signing source from flags or environment.
+/// Priority: --secret-key > ANCHOR_ADMIN_SECRET > --keypair-file
+fn resolve_source(secret_key: Option<&str>, keypair_file: Option<&str>) -> String {
+    if let Some(sk) = secret_key {
+        return sk.to_string();
+    }
+    if let Ok(sk) = std::env::var("ANCHOR_ADMIN_SECRET") {
+        if !sk.is_empty() {
+            return sk;
+        }
+    }
+    if let Some(path) = keypair_file {
+        let raw = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| { eprintln!("error: cannot read keypair file '{path}': {e}"); std::process::exit(1); });
+        // Support JSON {"secret_key":"S..."} or plain text
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw) {
+            if let Some(sk) = v.get("secret_key").and_then(|s| s.as_str()) {
+                return sk.to_string();
+            }
+        }
+        return raw.trim().to_string();
+    }
+    eprintln!("error: signing key required — provide --secret-key, set ANCHOR_ADMIN_SECRET, or use --keypair-file");
+    std::process::exit(1);
+}
+
+// ── RPC helpers ───────────────────────────────────────────────────────────────
+
+fn rpc_url(network: &str) -> &'static str {
+    match network {
+        "mainnet"   => "https://horizon.stellar.org",
+        "futurenet" => "https://rpc-futurenet.stellar.org",
+        _           => "https://soroban-testnet.stellar.org",
+    }
+}
+
+fn passphrase(network: &str) -> &'static str {
+    match network {
+        "mainnet"   => "Public Global Stellar Network ; September 2015",
+        "futurenet" => "Test SDF Future Network ; October 2022",
+        _           => "Test SDF Network ; September 2015",
+    }
+}
+
+fn stellar_invoke(
+    contract_id: &str,
+    source: &str,
+    network: &str,
+    fn_args: &[&str],
+) -> String {
+    let output = std::process::Command::new("stellar")
+        .args(["contract", "invoke",
+               "--id", contract_id,
+               "--source", source,
+               "--rpc-url", rpc_url(network),
+               "--network-passphrase", passphrase(network),
+               "--"])
+        .args(fn_args)
+        .output()
+        .expect("failed to run stellar contract invoke — is the Stellar CLI installed?");
+
+    if output.status.success() {
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    } else {
+        eprintln!("{}", String::from_utf8_lossy(&output.stderr).trim());
+        std::process::exit(1);
+    }
+}
+
+// ── CLI definition ────────────────────────────────────────────────────────────
 
 #[derive(Parser)]
 #[command(name = "anchorkit", about = "SorobanAnchor CLI")]
@@ -9,91 +83,116 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Deploy contract to a network (testnet/mainnet/futurenet)
+    /// Deploy contract to a network
     Deploy {
         #[arg(long, default_value = "testnet")]
         network: String,
-        /// Source account key (secret key or identity name)
         #[arg(long, default_value = "default")]
         source: String,
     },
     /// Register an attestor
     Register {
-        #[arg(long)]
-        address: String,
-        #[arg(long, value_delimiter = ',')]
-        services: Vec<String>,
-        #[arg(long)]
-        contract_id: String,
-        #[arg(long, default_value = "testnet")]
-        network: String,
-        #[arg(long, default_value = "default")]
-        source: String,
-        #[arg(long)]
-        sep10_token: String,
-        #[arg(long)]
-        sep10_issuer: String,
+        #[arg(long)] address: String,
+        #[arg(long, value_delimiter = ',')] services: Vec<String>,
+        #[arg(long)] contract_id: String,
+        #[arg(long, default_value = "testnet")] network: String,
+        #[arg(long)] secret_key: Option<String>,
+        #[arg(long)] keypair_file: Option<String>,
+        #[arg(long)] sep10_token: String,
+        #[arg(long)] sep10_issuer: String,
     },
     /// Submit an attestation
     Attest {
-        #[arg(long)]
-        subject: String,
-        #[arg(long)]
-        payload_hash: String,
-        #[arg(long)]
-        contract_id: String,
-        #[arg(long, default_value = "testnet")]
-        network: String,
-        #[arg(long, default_value = "default")]
-        source: String,
-        #[arg(long)]
-        issuer: String,
-        #[arg(long)]
-        session_id: Option<u64>,
+        #[arg(long)] subject: String,
+        #[arg(long)] payload_hash: String,
+        #[arg(long)] contract_id: String,
+        #[arg(long, default_value = "testnet")] network: String,
+        #[arg(long)] secret_key: Option<String>,
+        #[arg(long)] keypair_file: Option<String>,
+        #[arg(long)] issuer: String,
+        #[arg(long)] session_id: Option<u64>,
+    },
+    /// Get the best quote for a currency pair
+    Quote {
+        /// Source asset code (e.g. USDC)
+        #[arg(long)] from: String,
+        /// Destination asset code (e.g. XLM)
+        #[arg(long)] to: String,
+        /// Amount in base asset units
+        #[arg(long)] amount: u64,
+        #[arg(long)] contract_id: String,
+        #[arg(long, default_value = "testnet")] network: String,
+        #[arg(long)] secret_key: Option<String>,
+        #[arg(long)] keypair_file: Option<String>,
+    },
+    /// Fetch SEP-6 transaction status from an anchor URL
+    Status {
+        /// Transaction ID to look up
+        #[arg(long)] tx_id: String,
+        /// Anchor base URL (e.g. https://anchor.example.com)
+        #[arg(long)] anchor_url: String,
+    },
+    /// Revoke an attestor
+    Revoke {
+        #[arg(long)] address: String,
+        #[arg(long)] contract_id: String,
+        #[arg(long, default_value = "testnet")] network: String,
+        #[arg(long)] secret_key: Option<String>,
+        #[arg(long)] keypair_file: Option<String>,
     },
     /// Check environment setup
     Doctor,
 }
 
-fn deploy(network: &str, source: &str) {
-    let rpc_url = match network {
-        "mainnet" => "https://horizon.stellar.org",
-        "futurenet" => "https://rpc-futurenet.stellar.org",
-        _ => "https://soroban-testnet.stellar.org",
-    };
-    let network_passphrase = match network {
-        "mainnet" => "Public Global Stellar Network ; September 2015",
-        "futurenet" => "Test SDF Future Network ; October 2022",
-        _ => "Test SDF Network ; September 2015",
-    };
+// ── Output types (JSON) ───────────────────────────────────────────────────────
 
+#[derive(Serialize)]
+struct QuoteOutput {
+    quote_id: u64,
+    anchor: String,
+    base_asset: String,
+    quote_asset: String,
+    rate: u64,
+    fee_percentage: u32,
+    minimum_amount: u64,
+    maximum_amount: u64,
+    valid_until: u64,
+}
+
+#[derive(Serialize)]
+struct StatusOutput {
+    transaction_id: String,
+    kind: String,
+    status: String,
+    amount_in: Option<u64>,
+    amount_out: Option<u64>,
+    amount_fee: Option<u64>,
+    message: Option<String>,
+}
+
+// ── Command implementations ───────────────────────────────────────────────────
+
+fn deploy(network: &str, source: &str) {
     println!("Building WASM for {network}...");
     let build = std::process::Command::new("cargo")
         .args(["build", "--release", "--target", "wasm32-unknown-unknown",
                "--no-default-features", "--features", "wasm"])
         .status()
         .expect("failed to run cargo build");
-    if !build.success() {
-        eprintln!("WASM build failed");
-        std::process::exit(1);
-    }
+    if !build.success() { eprintln!("WASM build failed"); std::process::exit(1); }
 
     let wasm = "target/wasm32-unknown-unknown/release/anchorkit.wasm";
     println!("Deploying {wasm} to {network}...");
     let output = std::process::Command::new("stellar")
-        .args([
-            "contract", "deploy",
-            "--wasm", wasm,
-            "--source", source,
-            "--rpc-url", rpc_url,
-            "--network-passphrase", network_passphrase,
-        ])
+        .args(["contract", "deploy", "--wasm", wasm,
+               "--source", source,
+               "--rpc-url", rpc_url(network),
+               "--network-passphrase", passphrase(network)])
         .output()
         .expect("failed to run stellar contract deploy — is the Stellar CLI installed?");
 
     if output.status.success() {
-        let contract_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        println!("Contract ID: {contract_id}");
+        println!("Contract ID: {}", String::from_utf8_lossy(&output.stdout).trim());
     } else {
         eprintln!("{}", String::from_utf8_lossy(&output.stderr).trim());
         std::process::exit(1);
@@ -111,148 +210,118 @@ fn parse_services(services: &[String]) -> Vec<u32> {
 }
 
 fn register(
-    address: &str,
-    services: &[String],
-    contract_id: &str,
-    network: &str,
-    source: &str,
-    sep10_token: &str,
-    sep10_issuer: &str,
+    address: &str, services: &[String], contract_id: &str,
+    network: &str, source: &str, sep10_token: &str, sep10_issuer: &str,
 ) {
-    let rpc_url = match network {
-        "mainnet"   => "https://horizon.stellar.org",
-        "futurenet" => "https://rpc-futurenet.stellar.org",
-        _           => "https://soroban-testnet.stellar.org",
-    };
-    let network_passphrase = match network {
-        "mainnet"   => "Public Global Stellar Network ; September 2015",
-        "futurenet" => "Test SDF Future Network ; October 2022",
-        _           => "Test SDF Network ; September 2015",
-    };
+    let service_ids = parse_services(services)
+        .iter().map(|id| id.to_string()).collect::<Vec<_>>().join(",");
 
-    let service_ids = parse_services(services);
-    let services_arg = service_ids.iter()
-        .map(|id| id.to_string())
-        .collect::<Vec<_>>()
-        .join(",");
-
-    println!("Registering attestor {address} with services: {}", services.join(","));
-
-    // Step 1: register_attestor
-    let output = std::process::Command::new("stellar")
-        .args([
-            "contract", "invoke",
-            "--id", contract_id,
-            "--source", source,
-            "--rpc-url", rpc_url,
-            "--network-passphrase", network_passphrase,
-            "--", "register_attestor",
-            "--attestor", address,
-            "--sep10_token", sep10_token,
-            "--sep10_issuer", sep10_issuer,
-        ])
-        .output()
-        .expect("failed to run stellar contract invoke — is the Stellar CLI installed?");
-
-    if !output.status.success() {
-        eprintln!("{}", String::from_utf8_lossy(&output.stderr).trim());
-        std::process::exit(1);
-    }
-
-    // Step 2: configure_services
-    let svc_output = std::process::Command::new("stellar")
-        .args([
-            "contract", "invoke",
-            "--id", contract_id,
-            "--source", source,
-            "--rpc-url", rpc_url,
-            "--network-passphrase", network_passphrase,
-            "--", "configure_services",
-            "--anchor", address,
-            "--services", &services_arg,
-        ])
-        .output()
-        .expect("failed to run stellar contract invoke");
-
-    if svc_output.status.success() {
-        println!("Attestor {address} registered and services configured.");
-    } else {
-        eprintln!("{}", String::from_utf8_lossy(&svc_output.stderr).trim());
-        std::process::exit(1);
-    }
+    stellar_invoke(contract_id, source, network, &[
+        "register_attestor",
+        "--attestor", address,
+        "--sep10_token", sep10_token,
+        "--sep10_issuer", sep10_issuer,
+    ]);
+    stellar_invoke(contract_id, source, network, &[
+        "configure_services",
+        "--anchor", address,
+        "--services", &service_ids,
+    ]);
+    println!("Attestor {address} registered and services configured.");
 }
 
 fn attest(
-    subject: &str,
-    payload_hash: &str,
-    contract_id: &str,
-    network: &str,
-    source: &str,
-    issuer: &str,
-    session_id: Option<u64>,
+    subject: &str, payload_hash: &str, contract_id: &str,
+    network: &str, source: &str, issuer: &str, session_id: Option<u64>,
 ) {
-    let rpc_url = match network {
-        "mainnet"   => "https://horizon.stellar.org",
-        "futurenet" => "https://rpc-futurenet.stellar.org",
-        _           => "https://soroban-testnet.stellar.org",
-    };
-    let network_passphrase = match network {
-        "mainnet"   => "Public Global Stellar Network ; September 2015",
-        "futurenet" => "Test SDF Future Network ; October 2022",
-        _           => "Test SDF Network ; September 2015",
-    };
-
     let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system time error")
-        .as_secs()
-        .to_string();
+        .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs().to_string();
 
-    let mut args = vec![
-        "contract", "invoke",
-        "--id", contract_id,
-        "--source", source,
-        "--rpc-url", rpc_url,
-        "--network-passphrase", network_passphrase,
-        "--",
-    ];
-
-    let session_str;  // keep alive for the lifetime of args
-    if let Some(sid) = session_id {
+    let session_str;
+    let result = if let Some(sid) = session_id {
         session_str = sid.to_string();
-        args.extend_from_slice(&[
+        stellar_invoke(contract_id, source, network, &[
             "submit_attestation_with_session",
             "--session_id", &session_str,
-            "--issuer", issuer,
-            "--subject", subject,
+            "--issuer", issuer, "--subject", subject,
             "--timestamp", &timestamp,
             "--payload_hash", payload_hash,
-            "--signature", payload_hash, // placeholder: real sig provided by Stellar CLI signer
-        ]);
+            "--signature", payload_hash,
+        ])
     } else {
-        args.extend_from_slice(&[
+        stellar_invoke(contract_id, source, network, &[
             "submit_attestation",
-            "--issuer", issuer,
-            "--subject", subject,
+            "--issuer", issuer, "--subject", subject,
             "--timestamp", &timestamp,
             "--payload_hash", payload_hash,
-            "--signature", payload_hash, // placeholder: real sig provided by Stellar CLI signer
-        ]);
-    }
+            "--signature", payload_hash,
+        ])
+    };
+    println!("Attestation ID: {result}");
+}
 
-    let output = std::process::Command::new("stellar")
-        .args(&args)
-        .output()
-        .expect("failed to run stellar contract invoke — is the Stellar CLI installed?");
+fn quote(from: &str, to: &str, amount: u64, contract_id: &str, network: &str, source: &str) {
+    let amount_str = amount.to_string();
+    // route_transaction takes a RoutingOptions XDR; pass individual fields via stellar CLI args
+    let raw = stellar_invoke(contract_id, source, network, &[
+        "route_transaction",
+        "--base_asset", from,
+        "--quote_asset", to,
+        "--amount", &amount_str,
+        "--operation_type", "1",   // 1 = deposit
+        "--strategy", "lowest_fee",
+        "--min_reputation", "0",
+        "--max_anchors", "10",
+        "--require_kyc", "false",
+    ]);
 
-    if output.status.success() {
-        let attestation_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        println!("Attestation ID: {attestation_id}");
-    } else {
-        eprintln!("{}", String::from_utf8_lossy(&output.stderr).trim());
+    // The stellar CLI returns XDR or JSON; parse as JSON first, fall back to raw print
+    let out: QuoteOutput = serde_json::from_str(&raw).unwrap_or_else(|_| {
+        // stellar CLI may return a plain contract-encoded value; surface it as-is
+        eprintln!("note: could not parse quote as JSON, raw output:\n{raw}");
+        std::process::exit(1);
+    });
+    println!("{}", serde_json::to_string_pretty(&out).unwrap());
+}
+
+fn status(tx_id: &str, anchor_url: &str) {
+    let url = format!("{}/sep6/transaction?id={}", anchor_url.trim_end_matches('/'), tx_id);
+    let resp = reqwest::blocking::get(&url)
+        .unwrap_or_else(|e| { eprintln!("error: request failed: {e}"); std::process::exit(1); });
+
+    if !resp.status().is_success() {
+        eprintln!("error: anchor returned HTTP {}", resp.status());
         std::process::exit(1);
     }
+
+    let body: serde_json::Value = resp.json()
+        .unwrap_or_else(|e| { eprintln!("error: invalid JSON from anchor: {e}"); std::process::exit(1); });
+
+    // SEP-6 wraps the transaction under a "transaction" key
+    let tx = body.get("transaction").unwrap_or(&body);
+
+    let kind = tx.get("kind").and_then(|v| v.as_str()).unwrap_or("deposit").to_string();
+    let out = StatusOutput {
+        transaction_id: tx.get("id").and_then(|v| v.as_str()).unwrap_or(tx_id).to_string(),
+        kind,
+        status: tx.get("status").and_then(|v| v.as_str()).unwrap_or("unknown").to_string(),
+        amount_in:  tx.get("amount_in").and_then(|v| v.as_str()).and_then(|s| s.parse().ok()),
+        amount_out: tx.get("amount_out").and_then(|v| v.as_str()).and_then(|s| s.parse().ok()),
+        amount_fee: tx.get("amount_fee").and_then(|v| v.as_str()).and_then(|s| s.parse().ok()),
+        message:    tx.get("message").and_then(|v| v.as_str()).map(|s| s.to_string()),
+    };
+    println!("{}", serde_json::to_string_pretty(&out).unwrap());
 }
+
+fn revoke(address: &str, contract_id: &str, network: &str, source: &str) {
+    stellar_invoke(contract_id, source, network, &[
+        "revoke_attestor",
+        "--attestor", address,
+    ]);
+    println!("{{\"revoked\": true, \"address\": \"{address}\"}}");
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
 
 fn main() {
     let cli = Cli::parse();
@@ -260,17 +329,33 @@ fn main() {
         Commands::Deploy { network, source } => {
             deploy(&network, &source);
         }
-        Commands::Register { address, services, contract_id, network, source, sep10_token, sep10_issuer } => {
+        Commands::Register { address, services, contract_id, network, secret_key, keypair_file, sep10_token, sep10_issuer } => {
+            let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref());
             register(&address, &services, &contract_id, &network, &source, &sep10_token, &sep10_issuer);
         }
-        Commands::Attest { subject, payload_hash, contract_id, network, source, issuer, session_id } => {
+        Commands::Attest { subject, payload_hash, contract_id, network, secret_key, keypair_file, issuer, session_id } => {
+            let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref());
             attest(&subject, &payload_hash, &contract_id, &network, &source, &issuer, session_id);
+        }
+        Commands::Quote { from, to, amount, contract_id, network, secret_key, keypair_file } => {
+            let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref());
+            quote(&from, &to, amount, &contract_id, &network, &source);
+        }
+        Commands::Status { tx_id, anchor_url } => {
+            status(&tx_id, &anchor_url);
+        }
+        Commands::Revoke { address, contract_id, network, secret_key, keypair_file } => {
+            let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref());
+            revoke(&address, &contract_id, &network, &source);
         }
         Commands::Doctor => {
             println!("Checking environment...");
             println!("  cargo: {}", std::process::Command::new("cargo")
-                .arg("--version")
-                .output()
+                .arg("--version").output()
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                .unwrap_or_else(|_| "not found".into()));
+            println!("  stellar: {}", std::process::Command::new("stellar")
+                .arg("--version").output()
                 .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
                 .unwrap_or_else(|_| "not found".into()));
         }


### PR DESCRIPTION
closes #7 
closes #8 
closes #9 
closes #10 

feat(cli): add quote, status, revoke commands and signing key resolution                                            
                                                                                                                      
  Add four new capabilities to the anchorkit CLI:                                                                     
                                                                                                                      
  ## anchorkit quote --from --to --amount                                                                             
  - Calls `route_transaction` on the Soroban contract via `stellar contract invoke`                                   
  - Accepts --from (base asset), --to (quote asset), --amount (u64)                                                   
  - Prints the best Quote as formatted JSON: anchor address, rate,                                                    
    fee_percentage, minimum_amount, maximum_amount, valid_until                                                       
                                                                                                                      
  ## anchorkit status --tx-id --anchor-url                                                                            
  - Performs a blocking HTTP GET to {anchor_url}/sep6/transaction?id={tx_id}                                          
  - Unwraps the SEP-6 "transaction" envelope from the response                                                        
  - Prints a normalized TransactionStatusResponse as formatted JSON:                                                  
    transaction_id, kind, status, amount_in, amount_out, amount_fee, message                                          
                                                                                                                      
  ## anchorkit revoke --address                                                                                       
  - Calls `revoke_attestor` on AnchorKitContract via `stellar contract invoke`                                        
  - Prints a JSON confirmation: {"revoked": true, "address": "..."}                                                   
                                                                                                                      
  ## Signing key resolution                                                                                           
  - All mutating commands (register, attest, quote, revoke) now require                                               
    a signing key resolved in priority order:                                                                         
      1. --secret-key flag                                                                                            
      2. ANCHOR_ADMIN_SECRET environment variable                                                                     
      3. --keypair-file flag (supports JSON {"secret_key":"S..."} or plaintext)                                       
  - Fails with a clear error message if none of the above are provided                                                
                                                                                                                      
  ## Dependencies added (Cargo.toml)                                                                                  
  - serde + serde_json: JSON serialization for CLI output                                                             
  - reqwest (blocking): HTTP client for SEP-6 status fetch     