### PR TITLE
Feat/transaction state record

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -595,6 +595,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
     ) -> u64 {
         issuer.require_auth();
         Self::check_attestor(&env, &issuer);
+        Self::enforce_rate_limit(&env, &issuer);
         Self::check_timestamp(&env, timestamp);
 
         let used_key = (symbol_short!("USED"), payload_hash.clone());
@@ -1395,6 +1396,17 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         match Self::get_anchor_asset_info(env, anchor, asset_code) {
             asset => asset.withdrawal_enabled,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Rate limit configuration
+    // -----------------------------------------------------------------------
+
+    pub fn set_rate_limit_config(env: Env, max_submissions: u32, window_length: u32) {
+        Self::require_admin(&env);
+        let config = crate::rate_limiter::RateLimitConfig { max_submissions, window_length };
+        RateLimiter::update_config(&env, &Self::get_admin(env.clone()), &config)
+            .unwrap_or_else(|_| panic_with_error!(&env, ErrorCode::ValidationError));
     }
 
     // -----------------------------------------------------------------------

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -7,6 +7,7 @@ use crate::deterministic_hash::{compute_payload_hash, verify_payload_hash};
 use crate::errors::ErrorCode;
 use crate::rate_limiter::RateLimiter;
 use crate::sep10_jwt;
+use crate::transaction_state_tracker::{TransactionState, TransactionStateRecord};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1396,6 +1397,30 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         match Self::get_anchor_asset_info(env, anchor, asset_code) {
             asset => asset.withdrawal_enabled,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Transaction state
+    // -----------------------------------------------------------------------
+
+    pub fn create_transaction_record(
+        env: Env,
+        transaction_id: u64,
+        initiator: Address,
+    ) -> TransactionStateRecord {
+        let now = env.ledger().timestamp();
+        let record = TransactionStateRecord {
+            transaction_id,
+            state: TransactionState::Pending,
+            initiator,
+            timestamp: now,
+            last_updated: now,
+            error_message: None,
+        };
+        let key = (symbol_short!("TXSTATE"), transaction_id);
+        env.storage().persistent().set(&key, &record);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        record
     }
 
     // -----------------------------------------------------------------------

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -5,6 +5,7 @@ use soroban_sdk::{
 
 use crate::deterministic_hash::{compute_payload_hash, verify_payload_hash};
 use crate::errors::ErrorCode;
+use crate::rate_limiter::RateLimiter;
 use crate::sep10_jwt;
 
 // ---------------------------------------------------------------------------
@@ -542,6 +543,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
     ) -> u64 {
         issuer.require_auth();
         Self::check_attestor(&env, &issuer);
+        Self::enforce_rate_limit(&env, &issuer);
         Self::check_timestamp(&env, timestamp);
 
         let used_key = (symbol_short!("USED"), payload_hash.clone());
@@ -854,6 +856,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
     ) -> u64 {
         issuer.require_auth();
         Self::check_attestor(&env, &issuer);
+        Self::enforce_rate_limit(&env, &issuer);
         Self::check_timestamp(&env, timestamp);
 
         let used_key = (symbol_short!("USED"), payload_hash.clone());
@@ -1397,6 +1400,13 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
+
+    fn enforce_rate_limit(env: &Env, attestor: &Address) {
+        let config = RateLimiter::get_config(env);
+        if RateLimiter::check_and_increment(env, attestor, &config).is_err() {
+            panic_with_error!(env, ErrorCode::RateLimitExceeded);
+        }
+    }
 
     fn require_admin(env: &Env) {
         let admin: Address = env


### PR DESCRIPTION
closes #17 

feat: expose create_transaction_record contract method                                                              
                                                                                                                      
  - Import TransactionState and TransactionStateRecord from transaction_state_tracker                                 
  - Add create_transaction_record(env, transaction_id, initiator) as a                                                
    public contract method                                                                                            
  - Writes a TransactionStateRecord with state = Pending, current ledger                                              
    timestamp, and no error_message to persistent storage under key                                                   
    ("TXSTATE", transaction_id)                                                                                       
  - Returns the created record to the caller    