### PR TITLE
Feat/cli global flags and doctor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,29 @@
 use clap::{Parser, Subcommand};
+use std::env;
+
+// ---------------------------------------------------------------------------
+// CLI definition
+// ---------------------------------------------------------------------------
 
 #[derive(Parser)]
 #[command(name = "anchorkit", about = "SorobanAnchor CLI")]
 struct Cli {
+    /// Contract ID to invoke (or set ANCHOR_CONTRACT_ID)
+    #[arg(long, global = true, env = "ANCHOR_CONTRACT_ID")]
+    contract_id: Option<String>,
+
+    /// Stellar network: testnet | mainnet | futurenet (or set STELLAR_NETWORK)
+    #[arg(long, global = true, env = "STELLAR_NETWORK", default_value = "testnet")]
+    network: String,
+
     #[command(subcommand)]
     command: Commands,
 }
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Deploy contract to a network (testnet/mainnet/futurenet)
+    /// Deploy contract to a network
     Deploy {
-        #[arg(long, default_value = "testnet")]
-        network: String,
-        /// Source account key (secret key or identity name)
         #[arg(long, default_value = "default")]
         source: String,
     },
@@ -23,10 +33,6 @@ enum Commands {
         address: String,
         #[arg(long, value_delimiter = ',')]
         services: Vec<String>,
-        #[arg(long)]
-        contract_id: String,
-        #[arg(long, default_value = "testnet")]
-        network: String,
         #[arg(long, default_value = "default")]
         source: String,
         #[arg(long)]
@@ -40,10 +46,6 @@ enum Commands {
         subject: String,
         #[arg(long)]
         payload_hash: String,
-        #[arg(long)]
-        contract_id: String,
-        #[arg(long, default_value = "testnet")]
-        network: String,
         #[arg(long, default_value = "default")]
         source: String,
         #[arg(long)]
@@ -55,18 +57,39 @@ enum Commands {
     Doctor,
 }
 
-fn deploy(network: &str, source: &str) {
-    let rpc_url = match network {
-        "mainnet" => "https://horizon.stellar.org",
-        "futurenet" => "https://rpc-futurenet.stellar.org",
-        _ => "https://soroban-testnet.stellar.org",
-    };
-    let network_passphrase = match network {
-        "mainnet" => "Public Global Stellar Network ; September 2015",
-        "futurenet" => "Test SDF Future Network ; October 2022",
-        _ => "Test SDF Network ; September 2015",
-    };
+// ---------------------------------------------------------------------------
+// Network helpers
+// ---------------------------------------------------------------------------
 
+fn rpc_url(network: &str) -> &'static str {
+    match network {
+        "mainnet"   => "https://horizon.stellar.org",
+        "futurenet" => "https://rpc-futurenet.stellar.org",
+        _           => "https://soroban-testnet.stellar.org",
+    }
+}
+
+fn network_passphrase(network: &str) -> &'static str {
+    match network {
+        "mainnet"   => "Public Global Stellar Network ; September 2015",
+        "futurenet" => "Test SDF Future Network ; October 2022",
+        _           => "Test SDF Network ; September 2015",
+    }
+}
+
+/// Resolve contract_id from CLI flag or env var, exiting with an error if absent.
+fn require_contract_id(contract_id: &Option<String>) -> String {
+    contract_id.clone().unwrap_or_else(|| {
+        eprintln!("error: --contract-id or ANCHOR_CONTRACT_ID is required for this subcommand");
+        std::process::exit(1);
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand implementations
+// ---------------------------------------------------------------------------
+
+fn deploy(network: &str, source: &str) {
     println!("Building WASM for {network}...");
     let build = std::process::Command::new("cargo")
         .args(["build", "--release", "--target", "wasm32-unknown-unknown",
@@ -85,15 +108,14 @@ fn deploy(network: &str, source: &str) {
             "contract", "deploy",
             "--wasm", wasm,
             "--source", source,
-            "--rpc-url", rpc_url,
-            "--network-passphrase", network_passphrase,
+            "--rpc-url", rpc_url(network),
+            "--network-passphrase", network_passphrase(network),
         ])
         .output()
         .expect("failed to run stellar contract deploy — is the Stellar CLI installed?");
 
     if output.status.success() {
-        let contract_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        println!("Contract ID: {contract_id}");
+        println!("Contract ID: {}", String::from_utf8_lossy(&output.stdout).trim());
     } else {
         eprintln!("{}", String::from_utf8_lossy(&output.stderr).trim());
         std::process::exit(1);
@@ -119,65 +141,36 @@ fn register(
     sep10_token: &str,
     sep10_issuer: &str,
 ) {
-    let rpc_url = match network {
-        "mainnet"   => "https://horizon.stellar.org",
-        "futurenet" => "https://rpc-futurenet.stellar.org",
-        _           => "https://soroban-testnet.stellar.org",
-    };
-    let network_passphrase = match network {
-        "mainnet"   => "Public Global Stellar Network ; September 2015",
-        "futurenet" => "Test SDF Future Network ; October 2022",
-        _           => "Test SDF Network ; September 2015",
-    };
-
     let service_ids = parse_services(services);
-    let services_arg = service_ids.iter()
-        .map(|id| id.to_string())
-        .collect::<Vec<_>>()
-        .join(",");
+    let services_arg = service_ids.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(",");
 
     println!("Registering attestor {address} with services: {}", services.join(","));
 
-    // Step 1: register_attestor
-    let output = std::process::Command::new("stellar")
-        .args([
-            "contract", "invoke",
-            "--id", contract_id,
-            "--source", source,
-            "--rpc-url", rpc_url,
-            "--network-passphrase", network_passphrase,
-            "--", "register_attestor",
-            "--attestor", address,
-            "--sep10_token", sep10_token,
-            "--sep10_issuer", sep10_issuer,
-        ])
-        .output()
-        .expect("failed to run stellar contract invoke — is the Stellar CLI installed?");
+    let invoke = |extra_args: &[&str]| {
+        std::process::Command::new("stellar")
+            .args(["contract", "invoke",
+                   "--id", contract_id,
+                   "--source", source,
+                   "--rpc-url", rpc_url(network),
+                   "--network-passphrase", network_passphrase(network),
+                   "--"])
+            .args(extra_args)
+            .output()
+            .expect("failed to run stellar contract invoke — is the Stellar CLI installed?")
+    };
 
-    if !output.status.success() {
-        eprintln!("{}", String::from_utf8_lossy(&output.stderr).trim());
+    let out = invoke(&["register_attestor", "--attestor", address,
+                       "--sep10_token", sep10_token, "--sep10_issuer", sep10_issuer]);
+    if !out.status.success() {
+        eprintln!("{}", String::from_utf8_lossy(&out.stderr).trim());
         std::process::exit(1);
     }
 
-    // Step 2: configure_services
-    let svc_output = std::process::Command::new("stellar")
-        .args([
-            "contract", "invoke",
-            "--id", contract_id,
-            "--source", source,
-            "--rpc-url", rpc_url,
-            "--network-passphrase", network_passphrase,
-            "--", "configure_services",
-            "--anchor", address,
-            "--services", &services_arg,
-        ])
-        .output()
-        .expect("failed to run stellar contract invoke");
-
-    if svc_output.status.success() {
+    let out = invoke(&["configure_services", "--anchor", address, "--services", &services_arg]);
+    if out.status.success() {
         println!("Attestor {address} registered and services configured.");
     } else {
-        eprintln!("{}", String::from_utf8_lossy(&svc_output.stderr).trim());
+        eprintln!("{}", String::from_utf8_lossy(&out.stderr).trim());
         std::process::exit(1);
     }
 }
@@ -191,33 +184,22 @@ fn attest(
     issuer: &str,
     session_id: Option<u64>,
 ) {
-    let rpc_url = match network {
-        "mainnet"   => "https://horizon.stellar.org",
-        "futurenet" => "https://rpc-futurenet.stellar.org",
-        _           => "https://soroban-testnet.stellar.org",
-    };
-    let network_passphrase = match network {
-        "mainnet"   => "Public Global Stellar Network ; September 2015",
-        "futurenet" => "Test SDF Future Network ; October 2022",
-        _           => "Test SDF Network ; September 2015",
-    };
-
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("system time error")
         .as_secs()
         .to_string();
 
-    let mut args = vec![
+    let session_str;
+    let mut args: Vec<&str> = vec![
         "contract", "invoke",
         "--id", contract_id,
         "--source", source,
-        "--rpc-url", rpc_url,
-        "--network-passphrase", network_passphrase,
+        "--rpc-url", rpc_url(network),
+        "--network-passphrase", network_passphrase(network),
         "--",
     ];
 
-    let session_str;  // keep alive for the lifetime of args
     if let Some(sid) = session_id {
         session_str = sid.to_string();
         args.extend_from_slice(&[
@@ -227,7 +209,7 @@ fn attest(
             "--subject", subject,
             "--timestamp", &timestamp,
             "--payload_hash", payload_hash,
-            "--signature", payload_hash, // placeholder: real sig provided by Stellar CLI signer
+            "--signature", payload_hash,
         ]);
     } else {
         args.extend_from_slice(&[
@@ -236,7 +218,7 @@ fn attest(
             "--subject", subject,
             "--timestamp", &timestamp,
             "--payload_hash", payload_hash,
-            "--signature", payload_hash, // placeholder: real sig provided by Stellar CLI signer
+            "--signature", payload_hash,
         ]);
     }
 
@@ -246,33 +228,96 @@ fn attest(
         .expect("failed to run stellar contract invoke — is the Stellar CLI installed?");
 
     if output.status.success() {
-        let attestation_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        println!("Attestation ID: {attestation_id}");
+        println!("Attestation ID: {}", String::from_utf8_lossy(&output.stdout).trim());
     } else {
         eprintln!("{}", String::from_utf8_lossy(&output.stderr).trim());
         std::process::exit(1);
     }
 }
 
+// ---------------------------------------------------------------------------
+// Doctor
+// ---------------------------------------------------------------------------
+
+fn check(label: &str, ok: bool, detail: &str) {
+    let status = if ok { "PASS" } else { "FAIL" };
+    println!("  [{status}] {label}{}", if detail.is_empty() { String::new() } else { format!(": {detail}") });
+}
+
+fn doctor(contract_id: &Option<String>, network: &str) {
+    println!("anchorkit doctor\n");
+    let mut all_ok = true;
+
+    // --- Required env vars ---
+    for var in &["ANCHOR_ADMIN_SECRET", "ANCHOR_CONTRACT_ID", "STELLAR_NETWORK"] {
+        let present = env::var(var).is_ok();
+        if !present { all_ok = false; }
+        check(var, present, if present { "set" } else { "not set" });
+    }
+
+    // --- Stellar CLI ---
+    let stellar_ok = std::process::Command::new("stellar")
+        .arg("--version")
+        .output()
+        .map(|o| {
+            let v = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            check("stellar CLI", o.status.success(), &v);
+            o.status.success()
+        })
+        .unwrap_or_else(|_| {
+            check("stellar CLI", false, "not found");
+            false
+        });
+    if !stellar_ok { all_ok = false; }
+
+    // --- Contract reachable ---
+    match contract_id {
+        None => {
+            check("contract reachable", false, "ANCHOR_CONTRACT_ID not set — skipping");
+            all_ok = false;
+        }
+        Some(cid) => {
+            let reachable = std::process::Command::new("stellar")
+                .args([
+                    "contract", "invoke",
+                    "--id", cid,
+                    "--rpc-url", rpc_url(network),
+                    "--network-passphrase", network_passphrase(network),
+                    "--source", "default",
+                    "--", "get_admin",
+                ])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+            if !reachable { all_ok = false; }
+            check("contract reachable", reachable, cid);
+        }
+    }
+
+    println!("\n{}", if all_ok { "All checks passed." } else { "One or more checks failed." });
+    if !all_ok { std::process::exit(1); }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
 fn main() {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Deploy { network, source } => {
-            deploy(&network, &source);
+        Commands::Deploy { source } => {
+            deploy(&cli.network, &source);
         }
-        Commands::Register { address, services, contract_id, network, source, sep10_token, sep10_issuer } => {
-            register(&address, &services, &contract_id, &network, &source, &sep10_token, &sep10_issuer);
+        Commands::Register { address, services, source, sep10_token, sep10_issuer } => {
+            let cid = require_contract_id(&cli.contract_id);
+            register(&address, &services, &cid, &cli.network, &source, &sep10_token, &sep10_issuer);
         }
-        Commands::Attest { subject, payload_hash, contract_id, network, source, issuer, session_id } => {
-            attest(&subject, &payload_hash, &contract_id, &network, &source, &issuer, session_id);
+        Commands::Attest { subject, payload_hash, source, issuer, session_id } => {
+            let cid = require_contract_id(&cli.contract_id);
+            attest(&subject, &payload_hash, &cid, &cli.network, &source, &issuer, session_id);
         }
         Commands::Doctor => {
-            println!("Checking environment...");
-            println!("  cargo: {}", std::process::Command::new("cargo")
-                .arg("--version")
-                .output()
-                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-                .unwrap_or_else(|_| "not found".into()));
+            doctor(&cli.contract_id, &cli.network);
         }
     }
 }


### PR DESCRIPTION
closes #5 
closes #6 

feat: add global CLI flags and implement doctor subcommand                                                          
                                                                                                                      
  Global flags:                                                                                                       
  - Add --contract-id (env: ANCHOR_CONTRACT_ID) and --network                                                         
    (env: STELLAR_NETWORK, default: testnet) as global flags on the                                                   
    top-level Cli struct so every subcommand inherits them automatically.                                             
  - Remove per-subcommand contract_id and network args from Register                                                  
    and Attest; they now resolve via require_contract_id(&cli.contract_id).                                           
  - RPC endpoint and network passphrase are derived from --network in                                                 
    shared rpc_url() and network_passphrase() helpers.                                                                
                                                                                                                      
  Doctor subcommand:                                                                                                  
  - Checks ANCHOR_ADMIN_SECRET, ANCHOR_CONTRACT_ID, and STELLAR_NETWORK                                               
    are set in the environment.                                                                                       
  - Checks the Stellar CLI is installed by running `stellar --version`.                                               
  - Checks the contract is reachable by invoking get_admin over RPC;                                                  
    skips with FAIL if ANCHOR_CONTRACT_ID is not set.                                                                 
  - Prints a [PASS]/[FAIL] summary line for each check.                                                               
  - Exits with code 1 if any check fails.    