### PR TITLE
Feat/kyc compliance 33 34 35 36

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -155,6 +155,37 @@ pub struct RoutingOptions {
 }
 
 // ---------------------------------------------------------------------------
+// KYC and Compliance types
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum KycStatus {
+    Pending = 0,
+    Approved = 1,
+    Rejected = 2,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct ComplianceCheck {
+    pub subject: Address,
+    pub check_type: String,
+    pub result: u32,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct KycRecord {
+    pub subject: Address,
+    pub status: u32,
+    pub timestamp: u64,
+    pub rejection_reason_hash: Option<Bytes>,
+}
+
+// ---------------------------------------------------------------------------
 // Metadata cache types
 // ---------------------------------------------------------------------------
 
@@ -287,6 +318,21 @@ pub struct EndpointUpdated {
     pub endpoint: String,
 }
 
+#[contracttype]
+#[derive(Clone)]
+struct KycApprovedEvent {
+    subject: Address,
+    timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+struct KycRejectedEvent {
+    subject: Address,
+    reason_hash: Bytes,
+    timestamp: u64,
+}
+
 // ---------------------------------------------------------------------------
 // TTLs (in ledgers)
 // ---------------------------------------------------------------------------
@@ -300,6 +346,14 @@ const INSTANCE_TTL: u32 = 518_400;
 
 fn admin_key(env: &Env) -> soroban_sdk::Vec<soroban_sdk::Symbol> {
     soroban_sdk::vec![env, symbol_short!("ADMIN")]
+}
+
+fn kyc_record_key(subject: &Address) -> (Symbol, Address) {
+    (symbol_short!("KYC"), subject.clone())
+}
+
+fn compliance_check_key(subject: &Address, check_type: &String) -> (Symbol, Address, String) {
+    (symbol_short!("COMP"), subject.clone(), check_type.clone())
 }
 
 // ---------------------------------------------------------------------------
@@ -1392,6 +1446,100 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         match Self::get_anchor_asset_info(env, anchor, asset_code) {
             asset => asset.withdrawal_enabled,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // KYC and Compliance
+    // -----------------------------------------------------------------------
+
+    pub fn approve_kyc(env: Env, subject: Address) {
+        Self::require_admin(&env);
+        let ts = env.ledger().timestamp();
+        let kyc_record = KycRecord {
+            subject: subject.clone(),
+            status: 1, // Approved
+            timestamp: ts,
+            rejection_reason_hash: None,
+        };
+        let key = kyc_record_key(&subject);
+        env.storage().persistent().set(&key, &kyc_record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("KYC_APPROVED"),),
+            KycApprovedEvent {
+                subject,
+                timestamp: ts,
+            },
+        );
+    }
+
+    pub fn reject_kyc(env: Env, subject: Address, reason_hash: Bytes) {
+        Self::require_admin(&env);
+        let ts = env.ledger().timestamp();
+        let kyc_record = KycRecord {
+            subject: subject.clone(),
+            status: 2, // Rejected
+            timestamp: ts,
+            rejection_reason_hash: Some(reason_hash.clone()),
+        };
+        let key = kyc_record_key(&subject);
+        env.storage().persistent().set(&key, &kyc_record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("KYC_REJECTED"),),
+            KycRejectedEvent {
+                subject,
+                reason_hash,
+                timestamp: ts,
+            },
+        );
+    }
+
+    pub fn get_kyc_status(env: Env, subject: Address) -> u32 {
+        let key = kyc_record_key(&subject);
+        env.storage()
+            .persistent()
+            .get::<_, KycRecord>(&key)
+            .map(|record| record.status)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::KycNotFound))
+    }
+
+    pub fn store_compliance_check(
+        env: Env,
+        subject: Address,
+        check_type: String,
+        result: u32,
+    ) {
+        let ts = env.ledger().timestamp();
+        let compliance_check = ComplianceCheck {
+            subject: subject.clone(),
+            check_type: check_type.clone(),
+            result,
+            timestamp: ts,
+        };
+        let key = compliance_check_key(&subject, &check_type);
+        env.storage().persistent().set(&key, &compliance_check);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    pub fn get_compliance_check(
+        env: Env,
+        subject: Address,
+        check_type: String,
+    ) -> ComplianceCheck {
+        let key = compliance_check_key(&subject, &check_type);
+        env.storage()
+            .persistent()
+            .get::<_, ComplianceCheck>(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ComplianceNotMet))
     }
 
     // -----------------------------------------------------------------------

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -633,6 +633,74 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
     }
 
     // -----------------------------------------------------------------------
+    // Attestation submission with KYC enforcement
+    // -----------------------------------------------------------------------
+
+    pub fn submit_attestation_with_kyc_check(
+        env: Env,
+        issuer: Address,
+        subject: Address,
+        timestamp: u64,
+        payload_hash: Bytes,
+        signature: Bytes,
+        require_kyc: bool,
+    ) -> u64 {
+        issuer.require_auth();
+        Self::check_attestor(&env, &issuer);
+        Self::check_timestamp(&env, timestamp);
+
+        // Check KYC if required
+        if require_kyc {
+            let key = kyc_record_key(&subject);
+            let kyc_record: KycRecord = env
+                .storage()
+                .persistent()
+                .get(&key)
+                .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::KycNotFound));
+
+            match kyc_record.status {
+                1 => {}, // Approved - continue
+                0 => panic_with_error!(&env, ErrorCode::KycPending),
+                2 => panic_with_error!(&env, ErrorCode::KycRejected),
+                _ => panic_with_error!(&env, ErrorCode::KycNotFound),
+            }
+        }
+
+        let used_key = (symbol_short!("USED"), payload_hash.clone());
+        if env.storage().persistent().has(&used_key) {
+            panic_with_error!(&env, ErrorCode::ReplayAttack);
+        }
+
+        let id = Self::next_attestation_id(&env);
+        Self::store_attestation(
+            &env,
+            id,
+            issuer.clone(),
+            subject.clone(),
+            timestamp,
+            payload_hash.clone(),
+            signature,
+        );
+
+        env.storage().persistent().set(&used_key, &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&used_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (
+                symbol_short!("attest"),
+                symbol_short!("recorded"),
+                id,
+                subject,
+            ),
+            AttestEvent { payload_hash, timestamp },
+        );
+
+        id
+    }
+
+    // -----------------------------------------------------------------------
     // Attestation submission with request ID + tracing span
     // -----------------------------------------------------------------------
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -45,6 +45,9 @@ pub enum ErrorCode {
     NotInitialized = 16,
     AttestationNotFound = 17,
     InvalidSep10Token = 18,
+    KycNotFound = 19,
+    KycPending = 20,
+    KycRejected = 21,
     CacheExpired = 48,
     CacheNotFound = 49,
 }
@@ -72,6 +75,9 @@ impl ErrorCode {
             ErrorCode::NotInitialized => "Contract is not initialized",
             ErrorCode::AttestationNotFound => "Attestation not found",
             ErrorCode::InvalidSep10Token => "SEP-10 JWT is missing, expired, or invalid",
+            ErrorCode::KycNotFound => "KYC record not found",
+            ErrorCode::KycPending => "KYC verification is pending",
+            ErrorCode::KycRejected => "KYC verification was rejected",
             ErrorCode::CacheExpired => "Cache entry has expired",
             ErrorCode::CacheNotFound => "Cache entry not found",
         }
@@ -192,6 +198,18 @@ impl AnchorKitError {
         Self::from_code(ErrorCode::InvalidSep10Token)
     }
 
+    pub fn kyc_not_found() -> Self {
+        Self::from_code(ErrorCode::KycNotFound)
+    }
+
+    pub fn kyc_pending() -> Self {
+        Self::from_code(ErrorCode::KycPending)
+    }
+
+    pub fn kyc_rejected() -> Self {
+        Self::from_code(ErrorCode::KycRejected)
+    }
+
     pub fn validation_error(context: &str) -> Self {
         Self::with_context(ErrorCode::ValidationError, ErrorCode::ValidationError.default_message(), context)
     }
@@ -261,6 +279,9 @@ mod tests {
         assert_eq!(AnchorKitError::no_quotes_available().code, ErrorCode::NoQuotesAvailable);
         assert_eq!(AnchorKitError::services_not_configured().code, ErrorCode::ServicesNotConfigured);
         assert_eq!(AnchorKitError::invalid_sep10_token().code, ErrorCode::InvalidSep10Token);
+        assert_eq!(AnchorKitError::kyc_not_found().code, ErrorCode::KycNotFound);
+        assert_eq!(AnchorKitError::kyc_pending().code, ErrorCode::KycPending);
+        assert_eq!(AnchorKitError::kyc_rejected().code, ErrorCode::KycRejected);
     }
 
     #[test]
@@ -292,6 +313,9 @@ mod tests {
             ErrorCode::NotInitialized,
             ErrorCode::AttestationNotFound,
             ErrorCode::InvalidSep10Token,
+            ErrorCode::KycNotFound,
+            ErrorCode::KycPending,
+            ErrorCode::KycRejected,
             ErrorCode::CacheExpired,
             ErrorCode::CacheNotFound,
         ];


### PR DESCRIPTION
 ## KYC and Compliance Features Implementation                                                                                                                                         
                                                                                                                                                                                        
  This PR implements comprehensive KYC (Know Your Customer) and compliance management features for the SorobanAnchor contract, addressing four related issues for enhanced user         
  verification and compliance tracking.                                                                                                                                                 
                                                                                                                                                                                        
  ### Changes Overview                                                                                                                                                                  
                                                                                                                                                                                        
  #### Issue #35: Add KYC Error Codes                                                                                                                                                   
  - Added three new error code variants to `ErrorCode` enum in `src/errors.rs`:                                                                                                         
    - `KycNotFound = 19`: Returned when a KYC record does not exist for a subject                                                                                                       
    - `KycPending = 20`: Returned when KYC verification is still pending                                                                                                                
    - `KycRejected = 21`: Returned when KYC verification has been rejected                                                                                                              
  - Added corresponding default messages and named constructors (`kyc_not_found()`, `kyc_pending()`, `kyc_rejected()`)                                                                  
  - Updated error code tests to validate all new variants                                                                                                                               
                                                                                                                                                                                        
  #### Issue #36: Implement ComplianceCheck Struct and Storage                                                                                                                          
  - Created `ComplianceCheck` struct with persistent storage:                                                                                                                           
    - `subject: Address` - The user being checked                                                                                                                                       
    - `check_type: String` - Type of compliance check performed                                                                                                                         
    - `result: u32` - Result of the compliance check                                                                                                                                    
    - `timestamp: u64` - When the check was performed                                                                                                                                   
  - Created `KycRecord` struct for KYC status tracking:                                                                                                                                 
    - `subject: Address` - The user's address                                                                                                                                           
    - `status: u32` - KYC status (0=Pending, 1=Approved, 2=Rejected)                                                                                                                    
    - `timestamp: u64` - When the status was set                                                                                                                                        
    - `rejection_reason_hash: Option<Bytes>` - Optional hash of rejection reason                                                                                                        
  - Created `KycStatus` enum with three states: Pending, Approved, Rejected                                                                                                             
  - Added storage key helpers:                                                                                                                                                          
    - `kyc_record_key(subject)` - For KYC record storage                                                                                                                                
    - `compliance_check_key(subject, check_type)` - For compliance check storage                                                                                                        
  - Implemented persistent storage methods:                                                                                                                                             
    - `store_compliance_check()` - Stores compliance check results                                                                                                                      
    - `get_compliance_check()` - Retrieves stored compliance checks                                                                                                                     
  - Added event structs for audit logging:                                                                                                                                              
    - `KycApprovedEvent` - Emitted when KYC is approved                                                                                                                                 
    - `KycRejectedEvent` - Emitted when KYC is rejected                                                                                                                                 
                                                                                                                                                                                        
  #### Issue #33: Add approve_kyc and reject_kyc Admin Methods                                                                                                                          
  - Implemented `approve_kyc(env, subject)` admin-only method:                                                                                                                          
    - Requires admin authorization                                                                                                                                                      
    - Updates KYC status to Approved (1)                                                                                                                                                
    - Stores record with current timestamp                                                                                                                                              
    - Emits `KycApprovedEvent` for audit trail                                                                                                                                          
  - Implemented `reject_kyc(env, subject, reason_hash)` admin-only method:                                                                                                              
    - Requires admin authorization                                                                                                                                                      
    - Updates KYC status to Rejected (2)                                                                                                                                                
    - Stores rejection reason hash for compliance documentation                                                                                                                         
    - Emits `KycRejectedEvent` for audit trail                                                                                                                                          
                                                                                                                                                                                        
  #### Issue #34: Enforce KYC Check in submit_attestation                                                                                                                               
  - Implemented `submit_attestation_with_kyc_check()` method:                                                                                                                           
    - Accepts `require_kyc: bool` parameter to conditionally enforce KYC verification                                                                                                   
    - When `require_kyc` is true, verifies subject has Approved KYC status before accepting attestation                                                                                 
    - Returns appropriate error codes based on KYC status:                                                                                                                              
      - `KycNotFound` - No KYC record exists for the subject                                                                                                                            
      - `KycPending` - KYC verification is still in progress                                                                                                                            
      - `KycRejected` - KYC verification was rejected                                                                                                                                   
    - Maintains existing replay attack protection and attestation storage                                                                                                               
    - Emits standard attestation events upon successful submission                                                                                                                      
                                                                                                                                                                                        
  ### Technical Details                                                                                                                                                                 
                                                                                                                                                                                        
  - All KYC and compliance data is stored in persistent contract storage with TTL management                                                                                            
  - Admin-only methods use `require_admin()` for authorization                                                                                                                          
  - Error handling uses the new KYC-specific error codes for clear, actionable feedback                                                                                                 
  - Events are emitted for all KYC status changes to enable audit logging and monitoring                                                                                                
  - Backward compatible - existing `submit_attestation()` method remains unchanged                                                                                                      
                                                                                                                                                                                        
  ### Testing                                                                                                                                                                           
                                                                                                                                                                                        
  - All new error codes have been added to existing error code tests                                                                                                                    
  - Error messages are non-empty and descriptive                                                                                                                                        
  - Named constructors for new error codes are tested                                                                                                                                   
                                                                                                                                                                                        
  ### Files Modified                                                                                                                                                                    
                                                                                                                                                                                        
  - `src/errors.rs` - Added KYC error codes and constructors                                                                                                                            
  - `src/contract.rs` - Added KYC/compliance structs, storage methods, and admin functions                                                                                              
                                                                                                                                                                                        
  Closes #33                                                                                                                                                                            
  Closes #34                                                                                                                                                                            
  Closes #35                                                                                                                                                                            
  Closes #36 