### PR TITLE
feat(session): add close_session, closed flag, and session_closed event

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -21,6 +21,7 @@ pub struct Session {
     pub created_at: u64,
     pub nonce: u64,
     pub operation_count: u64,
+    pub closed: bool,
 }
 
 #[contracttype]
@@ -272,6 +273,14 @@ const MIN_TEMP_TTL: u32 = 15; // min_temp_entry_ttl - 1
 #[contracttype]
 #[derive(Clone)]
 struct SessionCreatedEvent {
+    session_id: u64,
+    initiator: Address,
+    timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+struct SessionClosedEvent {
     session_id: u64,
     initiator: Address,
     timestamp: u64,
@@ -982,6 +991,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
             created_at: now,
             nonce: 0,
             operation_count: 0,
+            closed: false,
         };
         let sess_key = (symbol_short!("SESS"), session_id);
         env.storage().persistent().set(&sess_key, &session);
@@ -997,6 +1007,38 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         );
 
         session_id
+    }
+
+    pub fn close_session(env: Env, session_id: u64, initiator: Address) {
+        initiator.require_auth();
+        let sess_key = (symbol_short!("SESS"), session_id);
+        let mut session: Session = env
+            .storage()
+            .persistent()
+            .get(&sess_key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestationNotFound));
+        if session.closed {
+            panic_with_error!(&env, ErrorCode::SessionClosed);
+        }
+        session.closed = true;
+        env.storage().persistent().set(&sess_key, &session);
+        let now = env.ledger().timestamp();
+        env.events().publish(
+            (symbol_short!("session"), symbol_short!("closed"), session_id),
+            SessionClosedEvent { session_id, initiator, timestamp: now },
+        );
+    }
+
+    fn require_session_open(env: &Env, session_id: u64) {
+        let sess_key = (symbol_short!("SESS"), session_id);
+        let session: Session = env
+            .storage()
+            .persistent()
+            .get(&sess_key)
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::AttestationNotFound));
+        if session.closed {
+            panic_with_error!(env, ErrorCode::SessionClosed);
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1087,6 +1129,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         signature: Bytes,
     ) -> u64 {
         issuer.require_auth();
+        Self::require_session_open(&env, session_id);
         Self::check_attestor(&env, &issuer);
         Self::enforce_rate_limit(&env, &issuer);
         Self::check_timestamp(&env, timestamp);
@@ -1167,6 +1210,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
 
     pub fn register_attestor_with_session(env: Env, session_id: u64, attestor: Address) {
         Self::require_admin(&env);
+        Self::require_session_open(&env, session_id);
         let key = (symbol_short!("ATTESTOR"), attestor.clone());
         if env.storage().persistent().has(&key) {
             panic_with_error!(&env, ErrorCode::AttestorAlreadyRegistered);
@@ -1224,6 +1268,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
 
     pub fn revoke_attestor_with_session(env: Env, session_id: u64, attestor: Address) {
         Self::require_admin(&env);
+        Self::require_session_open(&env, session_id);
         let key = (symbol_short!("ATTESTOR"), attestor.clone());
         if !env.storage().persistent().has(&key) {
             panic_with_error!(&env, ErrorCode::AttestorNotRegistered);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,15 +42,16 @@ pub enum ErrorCode {
     ServicesNotConfigured = 14,
     ValidationError = 15,
     RateLimitExceeded = 16,
-    NotInitialized = 16,
     AttestationNotFound = 17,
     InvalidSep10Token = 18,
     KycNotFound = 19,
     KycPending = 20,
     KycRejected = 21,
+    NotInitialized = 22,
+    IllegalTransition = 23,
+    SessionExpired = 25,
     CacheExpired = 48,
     CacheNotFound = 49,
-    IllegalTransition = 20,
 }
 
 impl ErrorCode {
@@ -82,6 +83,7 @@ impl ErrorCode {
             ErrorCode::CacheExpired => "Cache entry has expired",
             ErrorCode::CacheNotFound => "Cache entry not found",
             ErrorCode::IllegalTransition => "Illegal transaction state transition",
+            ErrorCode::SessionExpired => "Session has expired",
         }
     }
 }
@@ -227,6 +229,10 @@ impl AnchorKitError {
             &alloc::format!("{} -> {}", from, to),
         )
     }
+
+    pub fn session_expired() -> Self {
+        Self::from_code(ErrorCode::SessionExpired)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -328,6 +334,8 @@ mod tests {
             ErrorCode::KycRejected,
             ErrorCode::CacheExpired,
             ErrorCode::CacheNotFound,
+            ErrorCode::IllegalTransition,
+            ErrorCode::SessionExpired,
         ];
         for code in codes {
             assert!(!code.default_message().is_empty());

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,6 +50,7 @@ pub enum ErrorCode {
     NotInitialized = 22,
     IllegalTransition = 23,
     SessionExpired = 25,
+    SessionClosed = 26,
     CacheExpired = 48,
     CacheNotFound = 49,
 }
@@ -84,6 +85,7 @@ impl ErrorCode {
             ErrorCode::CacheNotFound => "Cache entry not found",
             ErrorCode::IllegalTransition => "Illegal transaction state transition",
             ErrorCode::SessionExpired => "Session has expired",
+            ErrorCode::SessionClosed => "Session is closed",
         }
     }
 }
@@ -233,6 +235,10 @@ impl AnchorKitError {
     pub fn session_expired() -> Self {
         Self::from_code(ErrorCode::SessionExpired)
     }
+
+    pub fn session_closed() -> Self {
+        Self::from_code(ErrorCode::SessionClosed)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -336,6 +342,7 @@ mod tests {
             ErrorCode::CacheNotFound,
             ErrorCode::IllegalTransition,
             ErrorCode::SessionExpired,
+            ErrorCode::SessionClosed,
         ];
         for code in codes {
             assert!(!code.default_message().is_empty());


### PR DESCRIPTION
## Summary



Adds the ability to permanently close a session. Once closed, no further operations can be performed against it, and a `session_closed` event is emitted on-chain.

## Changes

### `src/contract.rs`

- **`Session` struct** — new `closed: bool` field (initialized to `false` in `create_session`)
- **`SessionClosedEvent`** — new event struct `{ session_id, initiator, timestamp }`
- **`close_session(env, session_id, initiator)`** — public entry point:
  - Requires `initiator` auth
  - Panics with `SessionClosed` if already closed
  - Sets `session.closed = true` and persists the updated `Session`
  - Emits `("session", "closed", session_id)` event
- **`require_session_open(env, session_id)`** — private guard helper; panics with `SessionClosed` if `session.closed`
- **Guards added** to all three session-aware functions:
  - `submit_attestation_with_session`
  - `register_attestor_with_session`
  - `revoke_attestor_with_session`

### `src/errors.rs`

- `ErrorCode::SessionClosed = 26`
- `default_message`: `"Session is closed"`
- `AnchorKitError::session_closed()` named constructor
- Test array extended to cover `SessionClosed`

Closes #46