### PR TITLE
fix(errors): add SessionExpired = 25, fix duplicate ErrorCode discriminants

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,15 +42,16 @@ pub enum ErrorCode {
     ServicesNotConfigured = 14,
     ValidationError = 15,
     RateLimitExceeded = 16,
-    NotInitialized = 16,
     AttestationNotFound = 17,
     InvalidSep10Token = 18,
     KycNotFound = 19,
     KycPending = 20,
     KycRejected = 21,
+    NotInitialized = 22,
+    IllegalTransition = 23,
+    SessionExpired = 25,
     CacheExpired = 48,
     CacheNotFound = 49,
-    IllegalTransition = 20,
 }
 
 impl ErrorCode {
@@ -82,6 +83,7 @@ impl ErrorCode {
             ErrorCode::CacheExpired => "Cache entry has expired",
             ErrorCode::CacheNotFound => "Cache entry not found",
             ErrorCode::IllegalTransition => "Illegal transaction state transition",
+            ErrorCode::SessionExpired => "Session has expired",
         }
     }
 }
@@ -227,6 +229,10 @@ impl AnchorKitError {
             &alloc::format!("{} -> {}", from, to),
         )
     }
+
+    pub fn session_expired() -> Self {
+        Self::from_code(ErrorCode::SessionExpired)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -328,6 +334,8 @@ mod tests {
             ErrorCode::KycRejected,
             ErrorCode::CacheExpired,
             ErrorCode::CacheNotFound,
+            ErrorCode::IllegalTransition,
+            ErrorCode::SessionExpired,
         ];
         for code in codes {
             assert!(!code.default_message().is_empty());


### PR DESCRIPTION
## Changes

### Bug fixes
- `NotInitialized` had discriminant `16`, colliding with `RateLimitExceeded = 16` → reassigned to `22`
- `IllegalTransition` had discriminant `20`, colliding with `KycPending = 20` → reassigned to `23`

These duplicates would cause undefined behaviour in Soroban's `#[contracterror]` ABI and make it impossible to distinguish the affected error kinds on-chain.

### New variant
- `SessionExpired = 25` — used by session TTL enforcement logic (Issue #44)
- `AnchorKitError::session_expired()` named constructor
- `default_message` arm: `"Session has expired"`

Closes #45 