### PR TITLE
fix: resolve issues #37, #38, #39, #40 — error codes, compliance recording & enforcement

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -154,6 +154,8 @@ pub struct RoutingOptions {
     pub min_reputation: u32,
     pub max_anchors: u32,
     pub require_kyc: bool,
+    pub require_compliance: bool,
+    pub subject: Address,
 }
 
 // ---------------------------------------------------------------------------
@@ -967,6 +969,35 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Compliance check recording (#37)
+    // -----------------------------------------------------------------------
+
+    /// Record a compliance check result for a subject (admin-only).
+    /// Stores a `ComplianceCheck` record and emits a `compliance_checked` event.
+    pub fn record_compliance_check(
+        env: Env,
+        subject: Address,
+        check_type: String,
+        passed: bool,
+    ) {
+        Self::require_admin(&env);
+        let now = env.ledger().timestamp();
+        let record = ComplianceCheck {
+            subject: subject.clone(),
+            check_type: check_type.clone(),
+            result: if passed { 1u32 } else { 0u32 },
+            timestamp: now,
+        };
+        let key = compliance_check_key(&subject, &check_type);
+        env.storage().persistent().set(&key, &record);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        env.events().publish(
+            (symbol_short!("compliance"), symbol_short!("checked"), subject),
+            record,
+        );
+    }
+
     pub fn create_session(env: Env, initiator: Address) -> u64 {
         initiator.require_auth();
         let inst = env.storage().instance();
@@ -1452,6 +1483,20 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
 
         if candidates.is_empty() {
             panic_with_error!(&env, ErrorCode::NoQuotesAvailable);
+        }
+
+        // Enforce compliance check (#38)
+        if options.require_compliance {
+            // Look for any passing compliance record for this subject
+            // We check the generic "kyc" check_type as the standard compliance gate
+            let comp_key = compliance_check_key(&options.subject, &String::from_str(&env, "kyc"));
+            let passed = env.storage().persistent()
+                .get::<_, ComplianceCheck>(&comp_key)
+                .map(|r| r.result == 1u32)
+                .unwrap_or(false);
+            if !passed {
+                panic_with_error!(&env, ErrorCode::ComplianceNotMet);
+            }
         }
 
         // Apply strategy: pick best candidate

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,15 +42,15 @@ pub enum ErrorCode {
     ServicesNotConfigured = 14,
     ValidationError = 15,
     RateLimitExceeded = 16,
-    NotInitialized = 16,
     AttestationNotFound = 17,
     InvalidSep10Token = 18,
-    KycNotFound = 19,
-    KycPending = 20,
-    KycRejected = 21,
+    NotInitialized = 20,
+    KycNotFound = 21,
+    KycPending = 22,
+    KycRejected = 23,
+    IllegalTransition = 24,
     CacheExpired = 48,
     CacheNotFound = 49,
-    IllegalTransition = 20,
 }
 
 impl ErrorCode {
@@ -326,6 +326,7 @@ mod tests {
             ErrorCode::KycNotFound,
             ErrorCode::KycPending,
             ErrorCode::KycRejected,
+            ErrorCode::IllegalTransition,
             ErrorCode::CacheExpired,
             ErrorCode::CacheNotFound,
         ];

--- a/tests/routing_tests.rs
+++ b/tests/routing_tests.rs
@@ -125,6 +125,8 @@ mod routing_tests {
             min_reputation: 0,
             max_anchors: 2,
             require_kyc: false,
+            require_compliance: false,
+            subject: Address::generate(&env),
         };
 
         // anchor2 has faster settlement time (200 < 600)
@@ -166,6 +168,8 @@ mod routing_tests {
             min_reputation: 0,
             max_anchors: 2,
             require_kyc: false,
+            require_compliance: false,
+            subject: Address::generate(&env),
         };
 
         // anchor2 has higher reputation (8000 > 3000)


### PR DESCRIPTION
## Summary


### #39 — Fix duplicate `ErrorCode` discriminants

Both `RateLimitExceeded` and `NotInitialized` were assigned `16`, and `KycPending` and `IllegalTransition` both had `20`. Soroban's `#[contracterror]` requires unique discriminants. Updated layout:

| Variant | Old | New |
|---|---|---|
| `NotInitialized` | 16 (duplicate) | 20 |
| `KycPending` | 20 (duplicate) | 22 |
| `KycRejected` | 21 | 23 |
| `IllegalTransition` | 20 (duplicate) | 24 |

Also added `IllegalTransition` to the `test_error_code_default_messages_are_non_empty` test array where it was missing.

closes #39 
---

### #40 — Add `KycNotFound = 21`

`KycNotFound` was previously assigned `19`, which is now freed up. It is correctly placed at `21` in the deduplicated discriminant sequence.

closes #40 
---

### #37 — Add `record_compliance_check` contract method

New admin-only method:

```rust
pub fn record_compliance_check(env: Env, subject: Address, check_type: String, passed: bool)
```

- Requires admin auth
- Stores a `ComplianceCheck` record keyed by `(subject, check_type)` in persistent storage
- Emits a `compliance_checked` event with the full record

closes #37 
---

### #38 — Enforce compliance in `route_transaction`

- Added `require_compliance: bool` and `subject: Address` fields to `RoutingOptions`
- When `require_compliance` is `true`, `route_transaction` looks up the subject's `"kyc"` compliance record before returning a quote
- Panics with `ErrorCode::ComplianceNotMet` if no passing record exists
- Updated routing tests to include the two new `RoutingOptions` fields (`require_compliance: false`, `subject: Address::generate`)

closes #38 
---

## Files changed

- `src/errors.rs` — deduplicated discriminants, added `IllegalTransition` to test array
- `src/contract.rs` — added `record_compliance_check`, `require_compliance`/`subject` to `RoutingOptions`, compliance gate in `route_transaction`
- `tests/routing_tests.rs` — updated `RoutingOptions` struct literals for new fields