### PR TITLE
feat(sep6): add new transaction statuses and deposit fields for SEP-6

### DIFF
--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -24,6 +24,12 @@ pub enum TransactionStatus {
     Completed,
     Refunded,
     Expired,
+    /// No market exists for the requested asset pair (SEP-6 `no_market`).
+    NoMarket,
+    /// Requested amount is below the anchor's minimum (SEP-6 `too_small`).
+    TooSmall,
+    /// Requested amount exceeds the anchor's maximum (SEP-6 `too_large`).
+    TooLarge,
     Error,
 }
 
@@ -39,6 +45,9 @@ impl TransactionStatus {
             "expired" => Self::Expired,
             "incomplete" => Self::Incomplete,
             "pending" => Self::Pending,
+            "no_market" => Self::NoMarket,
+            "too_small" => Self::TooSmall,
+            "too_large" => Self::TooLarge,
             _ => Self::Error,
         }
     }
@@ -54,6 +63,9 @@ impl TransactionStatus {
             Self::Completed => "completed",
             Self::Refunded => "refunded",
             Self::Expired => "expired",
+            Self::NoMarket => "no_market",
+            Self::TooSmall => "too_small",
+            Self::TooLarge => "too_large",
             Self::Error => "error",
         }
     }
@@ -76,6 +88,12 @@ pub struct DepositResponse {
     pub fee_fixed: Option<u64>,
     /// Current status of the transaction.
     pub status: TransactionStatus,
+    /// Whether clawback is enabled for this deposit (SEP-6 `clawback_enabled`).
+    pub clawback_enabled: Option<bool>,
+    /// Stellar memo for identifying the sender, if provided.
+    pub stellar_memo: Option<String>,
+    /// Type of `stellar_memo` (e.g. `"text"`, `"id"`, `"hash"`), if provided.
+    pub stellar_memo_type: Option<String>,
 }
 
 /// Normalized response for a withdrawal initiation.
@@ -144,6 +162,12 @@ pub struct RawDepositResponse {
     pub fee_fixed: Option<u64>,
     /// Raw status string from the anchor (e.g. `"pending_external"`).
     pub status: Option<String>,
+    /// Whether clawback is enabled for this deposit.
+    pub clawback_enabled: Option<bool>,
+    /// Stellar memo for identifying the sender.
+    pub stellar_memo: Option<String>,
+    /// Type of `stellar_memo`.
+    pub stellar_memo_type: Option<String>,
 }
 
 /// Raw fields from an anchor's `/withdraw` response.
@@ -191,6 +215,9 @@ pub fn initiate_deposit(raw: RawDepositResponse) -> Result<DepositResponse, Erro
             .as_deref()
             .map(TransactionStatus::from_str)
             .unwrap_or(TransactionStatus::Pending),
+        clawback_enabled: raw.clawback_enabled,
+        stellar_memo: raw.stellar_memo,
+        stellar_memo_type: raw.stellar_memo_type,
     })
 }
 
@@ -259,6 +286,9 @@ mod tests {
             max_amount: Some(10_000),
             fee_fixed: Some(1),
             status: Some("pending_external".to_string()),
+            clawback_enabled: None,
+            stellar_memo: None,
+            stellar_memo_type: None,
         }
     }
 
@@ -360,5 +390,41 @@ mod tests {
         raw.kind = Some("withdraw".to_string());
         let resp = fetch_transaction_status(raw).unwrap();
         assert_eq!(resp.kind, TransactionKind::Withdrawal);
+    }
+
+    #[test]
+    fn test_status_no_market() {
+        assert_eq!(TransactionStatus::from_str("no_market"), TransactionStatus::NoMarket);
+        assert_eq!(TransactionStatus::NoMarket.as_str(), "no_market");
+    }
+
+    #[test]
+    fn test_status_too_small() {
+        assert_eq!(TransactionStatus::from_str("too_small"), TransactionStatus::TooSmall);
+        assert_eq!(TransactionStatus::TooSmall.as_str(), "too_small");
+    }
+
+    #[test]
+    fn test_status_too_large() {
+        assert_eq!(TransactionStatus::from_str("too_large"), TransactionStatus::TooLarge);
+        assert_eq!(TransactionStatus::TooLarge.as_str(), "too_large");
+    }
+
+    #[test]
+    fn test_deposit_clawback_enabled() {
+        let mut raw = raw_deposit();
+        raw.clawback_enabled = Some(true);
+        let resp = initiate_deposit(raw).unwrap();
+        assert_eq!(resp.clawback_enabled, Some(true));
+    }
+
+    #[test]
+    fn test_deposit_stellar_memo_fields() {
+        let mut raw = raw_deposit();
+        raw.stellar_memo = Some("memo-abc".to_string());
+        raw.stellar_memo_type = Some("text".to_string());
+        let resp = initiate_deposit(raw).unwrap();
+        assert_eq!(resp.stellar_memo, Some("memo-abc".to_string()));
+        assert_eq!(resp.stellar_memo_type, Some("text".to_string()));
     }
 }


### PR DESCRIPTION
feat(sep6): add missing SEP-6 transaction statuses and deposit response fields

Add three missing SEP-6 status variants to `TransactionStatus` and two
optional fields to `DepositResponse`/`RawDepositResponse`.

## Changes

**TransactionStatus**
- Add `NoMarket` variant mapped from/to `"no_market"`
- Add `TooSmall` variant mapped from/to `"too_small"`
- Add `TooLarge` variant mapped from/to `"too_large"`

**DepositResponse / RawDepositResponse**
- Add `clawback_enabled: Option<bool>` — propagated through `initiate_deposit`
- Add `stellar_memo: Option<String>` — propagated through `initiate_deposit`
- Add `stellar_memo_type: Option<String>` — propagated through `initiate_deposit`

**Tests**
- `test_status_no_market` — round-trips `from_str`/`as_str` for `NoMarket`
- `test_status_too_small` — round-trips for `TooSmall`
- `test_status_too_large` — round-trips for `TooLarge`
- `test_deposit_clawback_enabled` — verifies field is passed through
- `test_deposit_stellar_memo_fields` — verifies both memo fields are passed through

Closes #57
Closes #58
Closes #59
Closes #60