### PR TITLE
Feat: Add Session Expiry Validation with SessionExpired ErrorCode

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -21,6 +21,7 @@ pub struct Session {
     pub created_at: u64,
     pub nonce: u64,
     pub operation_count: u64,
+    pub session_ttl_seconds: u64,
 }
 
 #[contracttype]
@@ -982,6 +983,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
             created_at: now,
             nonce: 0,
             operation_count: 0,
+            session_ttl_seconds: 3600,
         };
         let sess_key = (symbol_short!("SESS"), session_id);
         env.storage().persistent().set(&sess_key, &session);
@@ -1087,6 +1089,16 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         signature: Bytes,
     ) -> u64 {
         issuer.require_auth();
+        let sess_key = (symbol_short!("SESS"), session_id);
+        let session: Session = env
+            .storage()
+            .persistent()
+            .get(&sess_key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::NotInitialized));
+        let now = env.ledger().timestamp();
+        if now > session.created_at + session.session_ttl_seconds {
+            panic_with_error!(&env, ErrorCode::SessionExpired);
+        }
         Self::check_attestor(&env, &issuer);
         Self::enforce_rate_limit(&env, &issuer);
         Self::check_timestamp(&env, timestamp);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,6 +50,7 @@ pub enum ErrorCode {
     WebhookDeliveryFailed = 24,
     NotInitialized = 25,
     IllegalTransition = 26,
+    SessionExpired = 27,
     CacheExpired = 48,
     CacheNotFound = 49,
 }
@@ -82,6 +83,7 @@ impl ErrorCode {
             ErrorCode::WebhookDeliveryFailed => "Webhook delivery failed validation",
             ErrorCode::NotInitialized => "Contract is not initialized",
             ErrorCode::IllegalTransition => "Illegal transaction state transition",
+            ErrorCode::SessionExpired => "Session has expired",
             ErrorCode::CacheExpired => "Cache entry has expired",
             ErrorCode::CacheNotFound => "Cache entry not found",
         }
@@ -233,6 +235,10 @@ impl AnchorKitError {
             &alloc::format!("{} -> {}", from, to),
         )
     }
+
+    pub fn session_expired() -> Self {
+        Self::from_code(ErrorCode::SessionExpired)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +305,7 @@ mod tests {
         assert_eq!(AnchorKitError::kyc_pending().code, ErrorCode::KycPending);
         assert_eq!(AnchorKitError::kyc_rejected().code, ErrorCode::KycRejected);
         assert_eq!(AnchorKitError::webhook_delivery_failed().code, ErrorCode::WebhookDeliveryFailed);
+        assert_eq!(AnchorKitError::session_expired().code, ErrorCode::SessionExpired);
     }
 
     #[test]
@@ -335,6 +342,7 @@ mod tests {
             ErrorCode::WebhookDeliveryFailed,
             ErrorCode::NotInitialized,
             ErrorCode::IllegalTransition,
+            ErrorCode::SessionExpired,
             ErrorCode::CacheExpired,
             ErrorCode::CacheNotFound,
         ];

--- a/tests/session_tests.rs
+++ b/tests/session_tests.rs
@@ -346,4 +346,109 @@ mod session_tests {
         assert_eq!(log2.operation.operation_index, 2);
         assert_eq!(log2.operation.result_data, 1); // attestation id 1
     }
+
+    // -----------------------------------------------------------------------
+    // Session TTL / expiry
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn test_submit_attestation_with_session_panics_when_session_expired() {
+        let env = make_env();
+        env.ledger().set(LedgerInfo {
+            timestamp: 0,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let session_id = client.create_session(&user);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(&env, &client, &attestor, &attestor, &sk);
+
+        // Advance ledger past the 3600s TTL
+        env.ledger().set(LedgerInfo {
+            timestamp: 3601,
+            protocol_version: 21,
+            sequence_number: 1,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+
+        // Should panic with SessionExpired
+        client.submit_attestation_with_session(
+            &session_id,
+            &attestor,
+            &subject,
+            &1700000001u64,
+            &payload(&env, 0x01),
+            &sig(&env, &[0x0a, 0x0b]),
+        );
+    }
+
+    #[test]
+    fn test_submit_attestation_with_session_succeeds_within_ttl() {
+        let env = make_env();
+        env.ledger().set(LedgerInfo {
+            timestamp: 0,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let session_id = client.create_session(&user);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(&env, &client, &attestor, &attestor, &sk);
+
+        // Advance to exactly the TTL boundary — should still be valid
+        env.ledger().set(LedgerInfo {
+            timestamp: 3600,
+            protocol_version: 21,
+            sequence_number: 1,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+
+        let id = client.submit_attestation_with_session(
+            &session_id,
+            &attestor,
+            &subject,
+            &1700000001u64,
+            &payload(&env, 0x01),
+            &sig(&env, &[0x0a, 0x0b]),
+        );
+        assert_eq!(id, 0);
+    }
 }


### PR DESCRIPTION
Summary

Adds session expiration checks to prevent stale sessions from being used in submit_attestation_with_session. Previously, sessions stored created_at but had no TTL enforcement, allowing old sessions to remain valid indefinitely.

Changes
- Added session_ttl_seconds field to Session
- Implemented expiry validation in submit_attestation_with_session
- Introduced new SessionExpired error code for expired sessions
- Triggered panic when a session exceeds its allowed lifetime

Impact
- Prevents reuse of stale or abandoned sessions
- Improves security and lifecycle management for attestations
- Ensures session validity is explicitly enforced rather than assumed

Acceptance Criteria
- [ ]  session_ttl_seconds added to Session
- [ ]  Expiry enforced in submit_attestation_with_session
- [ ]  SessionExpired error returned for expired sessions
- [ ]  No regressions in active session handling

CLoses #44 