### PR TITLE
fix(#65,#66): expose verify_sep10_token_for_subject and reject IP hos…

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -494,6 +494,30 @@ impl AnchorKitContract {
         }
     }
 
+    /// Verify a SEP-10 JWT for an arbitrary subject without going through the
+    /// attestor registration flow. Useful for off-chain clients that hold a
+    /// stored verifying key and want to confirm token ownership.
+    ///
+    /// Panics with `InvalidSep10Token` if:
+    /// - no verifying key is stored for `issuer`
+    /// - the token signature, expiry, or `sub` claim does not match `subject`
+    pub fn verify_sep10_token_for_subject(
+        env: Env,
+        token: String,
+        issuer: Address,
+        subject: Address,
+    ) {
+        let pk: Bytes = env
+            .storage()
+            .persistent()
+            .get(&(symbol_short!("SEP10KEY"), issuer.clone()))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::InvalidSep10Token));
+        let expected = subject.to_string();
+        if sep10_jwt::verify_sep10_jwt(&env, &token, &pk, Some(&expected)).is_err() {
+            panic_with_error!(&env, ErrorCode::InvalidSep10Token);
+        }
+    }
+
     pub fn register_attestor(env: Env, attestor: Address, sep10_token: String, sep10_issuer: Address) {
         Self::require_admin(&env);
         Self::verify_sep10_token_matches_attestor(&env, &sep10_token, &sep10_issuer, &attestor);

--- a/src/domain_validator.rs
+++ b/src/domain_validator.rs
@@ -153,6 +153,12 @@ fn validate_host(host: &str) -> Result<(), AnchorKitError> {
 
     // Validate each label in the domain
     let labels: Vec<&str> = domain_without_port.split('.').collect();
+
+    // Reject IPv4-style hostnames: all labels purely numeric (e.g. 192.168.1.1)
+    if labels.iter().all(|l| l.chars().all(|c| c.is_ascii_digit())) {
+        return Err(AnchorKitError::invalid_endpoint_format());
+    }
+
     for label in labels {
         if label.is_empty() {
             return Err(AnchorKitError::invalid_endpoint_format());


### PR DESCRIPTION
Here's a summary of what was done:

Issue #65 — added pub fn verify_sep10_token_for_subject(env, token, issuer, subject) in contract.rs right after the private helper. It fetches the stored Ed25519 key for issuer and calls verify_sep10_jwt with subject.to_string() as the expected sub claim, panicking with InvalidSep10Token on any failure.

Issue #66 — added a single guard at the top of the label loop in validate_host in domain_validator.rs that rejects any hostname where all labels are purely numeric, catching IPv4 addresses like 192.168.1.1 that previously slipped through.

closes #65 closes #66 