### PR TITLE
fix(sep10): replace mocks with real SEP-10 auth flow (#79-#82)

### DIFF
--- a/ui/components/Sep10AuthFlow.test.tsx
+++ b/ui/components/Sep10AuthFlow.test.tsx
@@ -3,12 +3,44 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import '@testing-library/jest-dom';
 import SEP10AuthFlow from './Sep10AuthFlow';
 
+// Mock Freighter
+jest.mock('@stellar/freighter-api', () => ({
+  signTransaction: jest.fn(() =>
+    Promise.resolve({ signedTxXdr: 'SIGNED_XDR_MOCK', signerAddress: 'GTEST' })
+  ),
+}));
+
 // Mock clipboard API
 Object.assign(navigator, {
   clipboard: {
     writeText: jest.fn(() => Promise.resolve()),
   },
 });
+
+// Mock fetch for SEP-10 challenge and token exchange
+const MOCK_XDR = 'AAAAAQAAAAC' + 'A'.repeat(200) + '==';
+const MOCK_JWT = 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHVEVTVCIsImlhdCI6MTcwMDAwMDAwMCwiZXhwIjoxNzAwMDg2NDAwfQ.SIGNATURE';
+global.fetch = jest.fn((url: string, opts?: RequestInit) => {
+  if (String(url).includes('stellar.toml')) {
+    return Promise.resolve({
+      ok: true,
+      text: () => Promise.resolve('WEB_AUTH_ENDPOINT="https://testanchor.stellar.org/auth"'),
+    });
+  }
+  if (String(url).includes('/auth')) {
+    if (opts?.method === 'POST') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ token: MOCK_JWT }),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ transaction: MOCK_XDR, network_passphrase: 'Test SDF Network ; September 2015' }),
+    });
+  }
+  return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+}) as jest.Mock;
 
 // Mock crypto.randomUUID
 Object.defineProperty(global, 'crypto', {
@@ -21,6 +53,19 @@ describe('SEP10AuthFlow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    // Restore default fetch mock after clearAllMocks wipes the implementation
+    (global.fetch as jest.Mock).mockImplementation((url: string, opts?: RequestInit) => {
+      if (String(url).includes('stellar.toml')) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve('WEB_AUTH_ENDPOINT="https://testanchor.stellar.org/auth"') });
+      }
+      if (String(url).includes('/auth')) {
+        if (opts?.method === 'POST') {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ token: MOCK_JWT }) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ transaction: MOCK_XDR, network_passphrase: 'Test SDF Network ; September 2015' }) });
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
   });
 
   afterEach(() => {
@@ -595,6 +640,90 @@ describe('SEP10AuthFlow', () => {
       await waitFor(() => {
         expect(screen.getByText(/AUTHENTICATED/)).toBeInTheDocument();
       }, { timeout: 3000 });
+    });
+  });
+
+  describe('Error Banner', () => {
+    // Flush all pending timers and microtasks to complete connectWallet's sleep chain
+    const connectWalletFake = async () => {
+      await act(async () => { await jest.runAllTimersAsync(); });
+    };
+
+    const clickConnectBtn = () => {
+      const btn = screen.getAllByText(/Connect Wallet/)
+        .map(el => el.closest('button') as HTMLButtonElement | null)
+        .find(b => b !== null && !b.disabled);
+      if (!btn) throw new Error('Connect Wallet button not found');
+      fireEvent.click(btn);
+    };
+
+    const getEnabledBtn = (label: RegExp) => {
+      const btn = screen.getAllByText(label)
+        .map(el => el.closest('button') as HTMLButtonElement | null)
+        .find(b => b !== null && !b.disabled);
+      if (!btn) throw new Error(`${label} not enabled`);
+      return btn;
+    };
+
+    it('shows error banner when challenge fetch fails', async () => {
+      (global.fetch as jest.Mock)
+        .mockImplementationOnce(() => Promise.resolve({ ok: true, text: () => Promise.resolve('WEB_AUTH_ENDPOINT="https://testanchor.stellar.org/auth"') }))
+        .mockImplementationOnce(() => Promise.resolve({ ok: false, status: 503, json: () => Promise.resolve({}) }));
+
+      render(<SEP10AuthFlow />);
+      clickConnectBtn();
+      await connectWalletFake();
+
+      await act(async () => { fireEvent.click(getEnabledBtn(/Fetch Challenge/)); });
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(/↺ Try Again/)).toBeInTheDocument();
+      }, { timeout: 3000 });
+    });
+
+    it('shows error banner when token exchange fails', async () => {
+      const { signTransaction: mockSign } = require('@stellar/freighter-api');
+      mockSign.mockResolvedValueOnce({ signedTxXdr: 'SIGNED', signerAddress: 'GTEST' });
+      (global.fetch as jest.Mock)
+        .mockImplementationOnce(() => Promise.resolve({ ok: true, text: () => Promise.resolve('WEB_AUTH_ENDPOINT="https://testanchor.stellar.org/auth"') }))
+        .mockImplementationOnce(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ transaction: MOCK_XDR, network_passphrase: 'Test SDF Network ; September 2015' }) }))
+        .mockImplementationOnce(() => Promise.resolve({ ok: false, status: 400, json: () => Promise.resolve({ error: 'expired challenge' }) }));
+
+      render(<SEP10AuthFlow />);
+      clickConnectBtn();
+      await connectWalletFake();
+
+      await act(async () => { fireEvent.click(getEnabledBtn(/Fetch Challenge/)); });
+      await waitFor(() => getEnabledBtn(/Sign with Wallet/), { timeout: 3000 })
+        .then(async btn => { await act(async () => { fireEvent.click(btn); }); });
+      await waitFor(() => getEnabledBtn(/Submit & Get Token/), { timeout: 3000 })
+        .then(async btn => { await act(async () => { fireEvent.click(btn); }); });
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByRole('alert')).toHaveTextContent('expired challenge');
+        expect(screen.getByText(/↺ Try Again/)).toBeInTheDocument();
+      }, { timeout: 3000 });
+    });
+
+    it('clears error and retries when Try Again is clicked', async () => {
+      (global.fetch as jest.Mock)
+        .mockImplementationOnce(() => Promise.resolve({ ok: true, text: () => Promise.resolve('WEB_AUTH_ENDPOINT="https://testanchor.stellar.org/auth"') }))
+        .mockImplementationOnce(() => Promise.resolve({ ok: false, status: 503, json: () => Promise.resolve({}) }));
+
+      render(<SEP10AuthFlow />);
+      clickConnectBtn();
+      await connectWalletFake();
+
+      await act(async () => { fireEvent.click(getEnabledBtn(/Fetch Challenge/)); });
+
+      await waitFor(() => screen.getByText(/↺ Try Again/), { timeout: 3000 });
+      await act(async () => { fireEvent.click(screen.getByText(/↺ Try Again/)); });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      }, { timeout: 1000 });
     });
   });
 });

--- a/ui/components/Sep10AuthFlow.tsx
+++ b/ui/components/Sep10AuthFlow.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { signTransaction } from "@stellar/freighter-api";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 type Step =
@@ -440,10 +441,13 @@ export default function SEP10AuthFlow() {
   const [step, setStep] = useState<Step>("idle");
   const [wallet, setWallet] = useState<WalletInfo | null>(null);
   const [challenge, setChallenge] = useState<string | null>(null);
+  const [networkPassphrase, setNetworkPassphrase] = useState<string>("Test SDF Network ; September 2015");
+  const [webAuthEndpoint, setWebAuthEndpoint] = useState<string | null>(null);
   const [signedXdr, setSignedXdr] = useState<string | null>(null);
   const [jwt, setJwt] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorStep, setErrorStep] = useState<Step | null>(null);
   const [domain, setDomain] = useState("testanchor.stellar.org");
   const [log, setLog] = useState<string[]>([]);
   const logRef = useRef<HTMLDivElement>(null);
@@ -483,6 +487,7 @@ export default function SEP10AuthFlow() {
   const connectWallet = async () => {
     setLoading(true);
     setError(null);
+    setErrorStep(null);
     addLog("Requesting wallet connection...");
     await sleep(900);
     addLog("Scanning for available wallets...");
@@ -499,57 +504,112 @@ export default function SEP10AuthFlow() {
   const fetchChallenge = async () => {
     setLoading(true);
     setError(null);
-    addLog(
-      `GET https://${domain}/auth?account=${wallet?.address.slice(0, 8)}...`,
-    );
-    await sleep(600);
-    addLog("Response: 200 OK");
-    await sleep(300);
-    const xdr = mockXDR();
-    addLog(`Challenge XDR received (${xdr.length} chars)`);
-    setChallenge(xdr);
-    setStep("sign");
-    setLoading(false);
+    setErrorStep(null);
+    try {
+      addLog(`GET https://${domain}/.well-known/stellar.toml`);
+      const tomlRes = await fetch(`https://${domain}/.well-known/stellar.toml`);
+      if (!tomlRes.ok) throw new Error(`stellar.toml fetch failed: ${tomlRes.status}`);
+      const toml = await tomlRes.text();
+      const match = toml.match(/WEB_AUTH_ENDPOINT\s*=\s*"([^"]+)"/);
+      if (!match) throw new Error("WEB_AUTH_ENDPOINT not found in stellar.toml");
+      const endpoint = match[1];
+      addLog(`web_auth_endpoint: ${endpoint}`);
+      setWebAuthEndpoint(endpoint);
+
+      const url = `${endpoint}?account=${wallet!.address}`;
+      addLog(`GET ${url}`);
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`Challenge fetch failed: ${res.status}`);
+      const data = await res.json();
+      if (!data.transaction) throw new Error("No transaction field in challenge response");
+      addLog(`Response: 200 OK`);
+      addLog(`Challenge XDR received (${data.transaction.length} chars)`);
+      setChallenge(data.transaction);
+      if (data.network_passphrase) setNetworkPassphrase(data.network_passphrase);
+      setStep("sign");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      addLog(`Error: ${msg}`);
+      setError(msg);
+      setErrorStep("challenge");
+    } finally {
+      setLoading(false);
+    }
   };
 
   const signChallenge = async () => {
     setLoading(true);
     setError(null);
-    addLog("Sending challenge XDR to wallet for signing...");
-    await sleep(800);
-    addLog("User approved signature request");
-    await sleep(600);
-    const signed = mockXDR();
-    addLog("Transaction signed with ED25519 key ✓");
-    setSignedXdr(signed);
-    setStep("token");
-    setLoading(false);
+    setErrorStep(null);
+    try {
+      addLog("Sending challenge XDR to Freighter for signing...");
+      const result = await signTransaction(challenge!, { networkPassphrase });
+      if (result.error) throw new Error(String(result.error));
+      addLog("User approved signature request");
+      addLog("Transaction signed with ED25519 key ✓");
+      setSignedXdr(result.signedTxXdr);
+      setStep("token");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      addLog(`Error: ${msg}`);
+      setError(msg);
+      setErrorStep("sign");
+    } finally {
+      setLoading(false);
+    }
   };
 
   const submitChallenge = async () => {
     setLoading(true);
     setError(null);
-    addLog(`POST https://${domain}/auth`);
-    addLog("Sending signed XDR...");
-    await sleep(700);
-    addLog("Response: 200 OK");
-    await sleep(300);
-    const token = mockJWT();
-    addLog("JWT received ✓");
-    addLog("Auth session established — expires in 24h");
-    setJwt(token);
-    setStep("authenticated");
-    setLoading(false);
+    setErrorStep(null);
+    try {
+      const endpoint = webAuthEndpoint ?? `https://${domain}/auth`;
+      addLog(`POST ${endpoint}`);
+      addLog("Sending signed XDR...");
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transaction: signedXdr }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? `POST /auth failed: ${res.status}`);
+      if (!data.token) throw new Error("No token in auth response");
+      addLog("Response: 200 OK");
+      addLog("JWT received ✓");
+      addLog("Auth session established — expires in 24h");
+      setJwt(data.token);
+      setStep("authenticated");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      addLog(`Error: ${msg}`);
+      setError(msg);
+      setErrorStep("token");
+    } finally {
+      setLoading(false);
+    }
   };
 
   const reset = () => {
     setStep("idle");
     setWallet(null);
     setChallenge(null);
+    setNetworkPassphrase("Test SDF Network ; September 2015");
+    setWebAuthEndpoint(null);
     setSignedXdr(null);
     setJwt(null);
     setError(null);
+    setErrorStep(null);
     addLog("─── Session reset ───");
+  };
+
+  const retryFromStep = () => {
+    setError(null);
+    if (errorStep === "challenge") { setChallenge(null); setStep("challenge"); }
+    else if (errorStep === "sign") { setSignedXdr(null); setStep("sign"); }
+    else if (errorStep === "token") { setSignedXdr(null); setStep("token"); }
+    else reset();
+    setErrorStep(null);
   };
 
   // ─ Step cards config ─
@@ -1115,6 +1175,49 @@ export default function SEP10AuthFlow() {
             );
           })}
         </div>
+
+        {/* ── Error Banner ── */}
+        {error && (
+          <div
+            role="alert"
+            style={{
+              marginBottom: 16,
+              padding: "14px 16px",
+              borderRadius: 10,
+              border: "1px solid rgba(255,80,80,0.4)",
+              background: "rgba(255,80,80,0.07)",
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 12,
+              animation: "sep10-slide-in 0.3s ease",
+            }}
+          >
+            <span style={{ fontSize: 16, flexShrink: 0, color: "#ff5050" }}>⚠</span>
+            <div style={{ flex: 1, fontSize: 11, color: "#ff9090", lineHeight: 1.5 }}>
+              {error}
+            </div>
+            <button
+              onClick={retryFromStep}
+              style={{
+                flexShrink: 0,
+                padding: "5px 12px",
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: "0.15em",
+                textTransform: "uppercase",
+                fontFamily: "inherit",
+                cursor: "pointer",
+                borderRadius: 5,
+                border: "1px solid rgba(255,80,80,0.5)",
+                background: "rgba(255,80,80,0.12)",
+                color: "#ff7070",
+                transition: "all 0.2s",
+              }}
+            >
+              ↺ Try Again
+            </button>
+          </div>
+        )}
 
         {/* ── Step Cards Grid ── */}
         <div

--- a/ui/jest.setup.js
+++ b/ui/jest.setup.js
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom';
+require('@testing-library/jest-dom');
 
 // Mock clipboard API for tests
 Object.assign(navigator, {

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,6 +24,8 @@
     "ui"
   ],
   "dependencies": {
+    "@stellar/freighter-api": "^6.0.1",
+    "ts-jest": "^29.4.9",
     "zod": "^3.22.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
- Replace mock challenge fetch with real GET /auth via web_auth_endpoint from stellar.toml (closes #79)
- Replace mock signing with real freighter.signTransaction call (closes #80)
- Replace mock JWT with real POST /auth token exchange (closes #81)
- Add error banner with failure reason and Try Again retry UI (closes #82)

Closes #79 
Closes #80 
Closes #81 
Closes #82 