### PR TITLE
feat(ui): add JsonViewer tests, maxDepth prop, and Storybook stories

### DIFF
--- a/storybook/json-viewer.html
+++ b/storybook/json-viewer.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>JsonViewer Stories</title>
+  <style>
+    body { font-family: monospace; background: #0e0c0a; color: #e7e5e0; padding: 32px; }
+    h1 { font-size: 22px; margin-bottom: 8px; }
+    .story-label { font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase;
+      color: #57534e; margin: 32px 0 8px; }
+    pre { background: #1c1916; border-radius: 10px; padding: 16px;
+      font-size: 11px; overflow-x: auto; margin-top: 12px; color: #78716c; }
+  </style>
+</head>
+<body>
+  <h1>JsonViewer — Storybook</h1>
+
+  <div class="story-label">Story 1 · Flat Object (ember theme)</div>
+  <pre>&lt;JsonViewer
+  data={{ name: "Alice", age: 30, active: true }}
+  title="Flat Object"
+  theme="ember"
+  defaultExpandDepth={2}
+/&gt;</pre>
+
+  <div class="story-label">Story 2 · Deeply Nested Object (arctic theme)</div>
+  <pre>&lt;JsonViewer
+  data={deeplyNestedObject}  // 10+ levels
+  title="Deep Nesting"
+  theme="arctic"
+  maxDepth={3}
+/&gt;</pre>
+
+  <div class="story-label">Story 3 · Large Array — 1000 elements (forest theme)</div>
+  <pre>&lt;JsonViewer
+  data={Array.from({ length: 1000 }, (_, i) =&gt; i)}
+  title="Large Array"
+  theme="forest"
+  maxDepth={0}
+/&gt;</pre>
+
+  <div class="story-label">Story 4 · Special Characters &amp; Unicode</div>
+  <pre>&lt;JsonViewer
+  data={{ unicode: "こんにちは 🌟", escaped: 'say "hello"' }}
+  title="Special Characters"
+  theme="ember"
+  defaultExpandDepth={2}
+/&gt;</pre>
+
+  <div class="story-label">Story 5 · All Primitive Types</div>
+  <pre>&lt;JsonViewer
+  data={{
+    str: "hello",
+    num: 42,
+    float: 3.14,
+    bool_true: true,
+    bool_false: false,
+    nil: null
+  }}
+  title="Primitive Types"
+  theme="arctic"
+  defaultExpandDepth={2}
+/&gt;</pre>
+
+  <div class="story-label">Story 6 · HTTP Error Response (400)</div>
+  <pre>&lt;JsonViewer
+  data={{ error: "Missing required field", field: "asset_code" }}
+  title="POST /sep24/deposit"
+  subtitle="Missing required parameter"
+  status={400}
+  responseTime={22}
+  theme="forest"
+/&gt;</pre>
+
+  <div class="story-label">Story 7 · maxDepth=0 (all collapsed)</div>
+  <pre>&lt;JsonViewer
+  data={{ a: { b: { c: 1 } } }}
+  title="Collapsed"
+  maxDepth={0}
+  theme="ember"
+/&gt;</pre>
+</body>
+</html>

--- a/ui/components/JsonViewer.test.tsx
+++ b/ui/components/JsonViewer.test.tsx
@@ -1,0 +1,218 @@
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { JsonViewer } from "./JsonViewer";
+
+const user = userEvent.setup();
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const flatObject = { name: "Alice", age: 30, active: true };
+
+function buildDeepObject(depth: number): Record<string, unknown> {
+  if (depth === 0) return { value: "leaf" };
+  return { nested: buildDeepObject(depth - 1) };
+}
+
+function buildLargeArray(size: number): number[] {
+  return Array.from({ length: size }, (_, i) => i);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("JsonViewer", () => {
+  test("renders a flat JSON object", () => {
+    render(<JsonViewer data={flatObject} />);
+    expect(screen.getByText(/"name"/)).toBeInTheDocument();
+    expect(screen.getByText(/"Alice"/)).toBeInTheDocument();
+    expect(screen.getByText(/"age"/)).toBeInTheDocument();
+    expect(screen.getByText(/30/)).toBeInTheDocument();
+  });
+
+  test("renders a deeply nested object (10+ levels)", () => {
+    const deep = buildDeepObject(12);
+    render(<JsonViewer data={deep} defaultExpandDepth={15} />);
+    // Root renders without crashing — "nested" key appears at least once
+    expect(screen.getAllByText(/"nested"/).length).toBeGreaterThan(0);
+  });
+
+  test("handles a 1000-element array without performance degradation", () => {
+    const largeArray = buildLargeArray(1000);
+    const start = performance.now();
+    render(<JsonViewer data={largeArray} defaultExpandDepth={0} />);
+    const elapsed = performance.now() - start;
+    // Should render in under 3 seconds even without virtualization
+    expect(elapsed).toBeLessThan(3000);
+    // Root array node renders — summary shows item count
+    expect(screen.getByText(/1000/)).toBeInTheDocument();
+  });
+
+  test("displays special characters (Unicode, escaped quotes) correctly", () => {
+    const specialData = {
+      unicode: "こんにちは 🌟",
+      escaped: 'say "hello"',
+      newline: "line1\nline2",
+    };
+    render(<JsonViewer data={specialData} defaultExpandDepth={2} />);
+    expect(screen.getByText(/"unicode"/)).toBeInTheDocument();
+    expect(screen.getByText(/"escaped"/)).toBeInTheDocument();
+  });
+
+  test("collapses and expands tree nodes via click", () => {
+    const nested = { outer: { inner: { value: 42 } } };
+    render(<JsonViewer data={nested} defaultExpandDepth={3} />);
+
+    // "inner" key is visible when expanded
+    expect(screen.getByText(/"inner"/)).toBeInTheDocument();
+
+    // Click the outer node to collapse it
+    const outerRow = screen.getByText(/"outer"/).closest("[style]")!;
+    fireEvent.click(outerRow);
+
+    // After collapse, inner should no longer be visible
+    expect(screen.queryByText(/"inner"/)).not.toBeInTheDocument();
+
+    // Click again to expand
+    fireEvent.click(outerRow);
+    expect(screen.getByText(/"inner"/)).toBeInTheDocument();
+  });
+
+  test("copies JSON value to clipboard via copy button", async () => {
+    const mockWriteText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: mockWriteText },
+      writable: true,
+      configurable: true,
+    });
+    render(<JsonViewer data={flatObject} />);
+    const copyButton = screen.getByText(/Copy/);
+    await user.click(copyButton);
+    expect(mockWriteText).toHaveBeenCalledWith(
+      JSON.stringify(flatObject, null, 2)
+    );
+  });
+
+  test("renders null with distinct visual style", () => {
+    render(<JsonViewer data={{ val: null }} defaultExpandDepth={2} />);
+    expect(screen.getAllByText(/null/).length).toBeGreaterThan(0);
+  });
+
+  test("renders boolean true and false with distinct visual style", () => {
+    render(
+      <JsonViewer data={{ yes: true, no: false }} defaultExpandDepth={2} />
+    );
+    expect(screen.getByText(/true/)).toBeInTheDocument();
+    expect(screen.getByText(/false/)).toBeInTheDocument();
+  });
+
+  test("renders numbers with distinct visual style", () => {
+    render(<JsonViewer data={{ count: 42, pi: 3.14 }} defaultExpandDepth={2} />);
+    expect(screen.getByText(/42/)).toBeInTheDocument();
+    expect(screen.getByText(/3\.14/)).toBeInTheDocument();
+  });
+
+  test("renders strings with distinct visual style", () => {
+    render(<JsonViewer data={{ greeting: "hello" }} defaultExpandDepth={2} />);
+    expect(screen.getByText(/"hello"/)).toBeInTheDocument();
+  });
+
+  test("maxDepth prop limits initial expansion depth", () => {
+    const deep = buildDeepObject(5);
+    render(<JsonViewer data={deep} maxDepth={1} />);
+    // At maxDepth=1, only the first level is expanded
+    // "nested" key at depth 1 is visible (may appear multiple times in tree)
+    expect(screen.getAllByText(/"nested"/).length).toBeGreaterThan(0);
+    // But deeper keys (depth 2+) should be collapsed
+    expect(screen.queryByText(/"value"/)).not.toBeInTheDocument();
+  });
+
+  test("maxDepth=0 collapses everything initially", () => {
+    const obj = { a: { b: { c: 1 } } };
+    render(<JsonViewer data={obj} maxDepth={0} />);
+    // At maxDepth=0, root is shown but children are collapsed
+    // "a" key is visible (it's the root's child shown in collapsed summary)
+    // but "b" (depth 2) should NOT be visible
+    expect(screen.queryByText(/"b"/)).not.toBeInTheDocument();
+    // Root summary shows key count
+    expect(screen.getAllByText(/1 keys/).length).toBeGreaterThan(0);
+  });
+
+  test("expand all button expands all nodes", async () => {
+    const nested = { a: { b: 1 }, c: { d: 2 } };
+    render(<JsonViewer data={nested} maxDepth={0} />);
+
+    const expandBtn = screen.getByText(/Expand All/);
+    await user.click(expandBtn);
+
+    expect(screen.getByText(/"a"/)).toBeInTheDocument();
+    expect(screen.getByText(/"b"/)).toBeInTheDocument();
+  });
+
+  test("collapse all button collapses all nodes", async () => {
+    const nested = { a: { b: 1 } };
+    render(<JsonViewer data={nested} defaultExpandDepth={5} />);
+
+    // Initially expanded
+    expect(screen.getByText(/"b"/)).toBeInTheDocument();
+
+    const collapseBtn = screen.getByText(/Collapse/);
+    await user.click(collapseBtn);
+
+    expect(screen.queryByText(/"b"/)).not.toBeInTheDocument();
+  });
+
+  test("search highlights matching keys and values", async () => {
+    render(<JsonViewer data={flatObject} defaultExpandDepth={2} searchable />);
+    const searchInput = screen.getByPlaceholderText(/Search/);
+    await user.type(searchInput, "Alice");
+    // Match count badge appears (the orange count span)
+    const matchBadge = document.querySelector(
+      'span[style*="color: rgb(249, 115, 22)"]'
+    );
+    expect(matchBadge).toBeTruthy();
+  });
+
+  test("switches between tree and raw mode", async () => {
+    render(<JsonViewer data={flatObject} defaultMode="tree" />);
+    const rawBtn = screen.getByText("raw");
+    await user.click(rawBtn);
+    // In raw mode, a <pre> element with the JSON is rendered
+    const pre = document.querySelector("pre");
+    expect(pre).toBeTruthy();
+  });
+
+  test("renders title and subtitle in titlebar", () => {
+    render(
+      <JsonViewer
+        data={flatObject}
+        title="GET /sep24/info"
+        subtitle="testanchor.stellar.org"
+      />
+    );
+    expect(screen.getByText("GET /sep24/info")).toBeInTheDocument();
+    expect(screen.getByText("testanchor.stellar.org")).toBeInTheDocument();
+  });
+
+  test("renders HTTP status badge for 200", () => {
+    render(<JsonViewer data={flatObject} status={200} />);
+    expect(screen.getByText(/200/)).toBeInTheDocument();
+  });
+
+  test("renders HTTP status badge for 400 error", () => {
+    render(<JsonViewer data={{ error: "bad request" }} status={400} />);
+    expect(screen.getByText(/400/)).toBeInTheDocument();
+  });
+
+  test("renders response time", () => {
+    render(<JsonViewer data={flatObject} responseTime={143} />);
+    expect(screen.getByText(/143ms/)).toBeInTheDocument();
+  });
+
+  test("renders all three themes without crashing", () => {
+    const { rerender } = render(<JsonViewer data={flatObject} theme="ember" />);
+    rerender(<JsonViewer data={flatObject} theme="arctic" />);
+    rerender(<JsonViewer data={flatObject} theme="forest" />);
+    expect(screen.getByText(/"name"/)).toBeInTheDocument();
+  });
+});

--- a/ui/components/JsonViewer.tsx
+++ b/ui/components/JsonViewer.tsx
@@ -18,6 +18,8 @@ export interface JsonViewerProps {
   theme?: ViewerTheme;
   defaultMode?: ViewerMode;
   defaultExpandDepth?: number;
+  /** Alias for defaultExpandDepth — limits the initial expansion depth. */
+  maxDepth?: number;
   searchable?: boolean;
   className?: string;
 }
@@ -562,15 +564,18 @@ export function JsonViewer({
   theme: themeName = "ember",
   defaultMode = "tree",
   defaultExpandDepth = 2,
+  maxDepth,
   searchable = true,
 }: JsonViewerProps) {
+  // maxDepth takes precedence over defaultExpandDepth when provided
+  const expandDepth = maxDepth !== undefined ? maxDepth : defaultExpandDepth;
   const t = THEMES[themeName];
   const [mode, setMode] = useState<ViewerMode>(defaultMode);
   const [search, setSearch] = useState("");
   const [copied, setCopied] = useState(false);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => {
     const acc = new Set<string>();
-    collectPaths(data, "root", 0, defaultExpandDepth, acc);
+    collectPaths(data, "root", 0, expandDepth, acc);
     return acc;
   });
 
@@ -870,7 +875,7 @@ export function JsonViewer({
               depth={0}
               isLast={true}
               theme={t}
-              defaultExpandDepth={defaultExpandDepth}
+              defaultExpandDepth={expandDepth}
               search={search}
               path="root"
               expandedPaths={expandedPaths}


### PR DESCRIPTION
- Create JsonViewer.test.tsx with 21 tests covering: flat objects, deeply nested objects (10+ levels), 1000-element arrays, special characters/Unicode, collapse/expand via click, clipboard copy, null/bool/number/string primitive types, maxDepth prop, expand-all, collapse-all, search highlighting, tree/raw mode switch, title/subtitle, HTTP status badges, response time, and all three themes
- Add maxDepth prop to JsonViewerProps as an alias for defaultExpandDepth that takes precedence when provided, limiting initial expansion depth
- Add storybook/json-viewer.html with stories for flat object, deep nesting, large array, special characters, all primitive types, HTTP error response, and maxDepth=0 collapsed state

Closes #182
closes #183