### PR TITLE
feat: SEP-6 polling, multi-network CLI, no_std audit, AnchorErrorBoundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: cargo check (native)
         run: cargo check
 
+      - name: no_std compliance check (WASM)
+        run: cargo check --target ${{ env.WASM_TARGET }} --no-default-features --features wasm
+
       - name: cargo test
         run: cargo test
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,7 @@ pub use sep6::{
     fetch_transaction_status, initiate_deposit, initiate_withdrawal, DepositResponse,
     RawDepositResponse, RawTransactionResponse, RawWithdrawalResponse, TransactionKind,
     TransactionStatus, TransactionStatusResponse, WithdrawalResponse,
+    poll_transaction_status, PollConfig, PollResult,
 };
 pub use sep24::{
     initiate_interactive_deposit, initiate_interactive_withdrawal, fetch_sep24_transaction_status,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,72 @@
 use clap::{Parser, Subcommand};
 use serde::Serialize;
 
-// ── Key resolution ────────────────────────────────────────────────────────────
+// ── Network profile management ────────────────────────────────────────────────
+
+#[derive(Serialize, serde::Deserialize, Clone, Debug)]
+struct NetworkProfile {
+    name: String,
+    rpc_url: String,
+    network_passphrase: String,
+    horizon_url: Option<String>,
+    #[serde(default)]
+    is_default: bool,
+}
+
+fn networks_path() -> std::path::PathBuf {
+    let dir = dirs_home().join(".anchorkit");
+    std::fs::create_dir_all(&dir).ok();
+    dir.join("networks.json")
+}
+
+fn dirs_home() -> std::path::PathBuf {
+    std::env::var("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+}
+
+fn load_network_profiles() -> Vec<NetworkProfile> {
+    let path = networks_path();
+    if !path.exists() { return Vec::new(); }
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+fn save_network_profiles(profiles: &[NetworkProfile]) {
+    let path = networks_path();
+    let json = serde_json::to_string_pretty(profiles).unwrap_or_default();
+    std::fs::write(path, json).ok();
+}
+
+fn find_profile<'a>(profiles: &'a [NetworkProfile], name: &str) -> Option<&'a NetworkProfile> {
+    profiles.iter().find(|p| p.name == name)
+}
+
+fn rpc_url_for(network: &str) -> String {
+    let profiles = load_network_profiles();
+    if let Some(p) = find_profile(&profiles, network) {
+        return p.rpc_url.clone();
+    }
+    rpc_url(network).to_string()
+}
+
+fn passphrase_for(network: &str) -> String {
+    let profiles = load_network_profiles();
+    if let Some(p) = find_profile(&profiles, network) {
+        return p.network_passphrase.clone();
+    }
+    passphrase(network).to_string()
+}
+
+fn default_network() -> String {
+    let profiles = load_network_profiles();
+    profiles.iter()
+        .find(|p| p.is_default)
+        .map(|p| p.name.clone())
+        .unwrap_or_else(|| "testnet".to_string())
+}
+
+
 
 /// Resolve the signing source from flags or environment.
 /// Priority: --secret-key > ANCHOR_ADMIN_SECRET > --keypair-file
@@ -53,12 +118,14 @@ fn stellar_invoke(
     network: &str,
     fn_args: &[&str],
 ) -> String {
+    let url = rpc_url_for(network);
+    let phrase = passphrase_for(network);
     let output = std::process::Command::new("stellar")
         .args(["contract", "invoke",
                "--id", contract_id,
                "--source", source,
-               "--rpc-url", rpc_url(network),
-               "--network-passphrase", passphrase(network),
+               "--rpc-url", &url,
+               "--network-passphrase", &phrase,
                "--"])
         .args(fn_args)
         .output()
@@ -81,9 +148,9 @@ struct Cli {
     #[arg(long, global = true, env = "ANCHOR_CONTRACT_ID")]
     contract_id: Option<String>,
 
-    /// Stellar network: testnet | mainnet | futurenet (or set STELLAR_NETWORK)
-    #[arg(long, global = true, env = "STELLAR_NETWORK", default_value = "testnet")]
-    network: String,
+    /// Stellar network: testnet | mainnet | futurenet | <custom> (or set STELLAR_NETWORK)
+    #[arg(long, global = true, env = "STELLAR_NETWORK")]
+    network: Option<String>,
 
     #[command(subcommand)]
     command: Commands,
@@ -162,6 +229,32 @@ enum Commands {
         /// Attempt to automatically fix issues
         #[arg(long)]
         fix: bool,
+    },
+    /// Manage custom network profiles
+    Network {
+        #[command(subcommand)]
+        action: NetworkAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum NetworkAction {
+    /// Add a custom network profile
+    Add {
+        #[arg(long)] name: String,
+        #[arg(long)] rpc_url: String,
+        #[arg(long)] passphrase: String,
+        #[arg(long)] horizon_url: Option<String>,
+    },
+    /// List all configured network profiles
+    List,
+    /// Remove a custom network profile
+    Remove {
+        #[arg(long)] name: String,
+    },
+    /// Set the default network
+    SetDefault {
+        #[arg(long)] name: String,
     },
 }
 
@@ -292,11 +385,13 @@ fn deploy(network: &str, source: &str, admin: Option<&str>, dry_run: bool, list:
 
     let wasm = "target/wasm32-unknown-unknown/release/anchorkit.wasm";
     println!("Deploying {wasm} to {network}...");
+    let net_url = rpc_url_for(network);
+    let net_phrase = passphrase_for(network);
     let output = std::process::Command::new("stellar")
         .args(["contract", "deploy", "--wasm", wasm,
                "--source", source,
-               "--rpc-url", rpc_url(network),
-               "--network-passphrase", passphrase(network)])
+               "--rpc-url", &net_url,
+               "--network-passphrase", &net_phrase])
         .output()
         .expect("failed to run stellar contract deploy — is the Stellar CLI installed?");
 
@@ -326,8 +421,8 @@ fn deploy(network: &str, source: &str, admin: Option<&str>, dry_run: bool, list:
         .args(["contract", "invoke",
                "--id", &contract_id,
                "--source", source,
-               "--rpc-url", rpc_url(network),
-               "--network-passphrase", passphrase(network),
+               "--rpc-url", &net_url,
+               "--network-passphrase", &net_phrase,
                "--", "initialize",
                "--admin", admin_addr])
         .output();
@@ -571,18 +666,8 @@ fn check_admin_secret_env() -> CheckResult {
 }
 
 fn check_network_connectivity(network: &str) -> CheckResult {
-    let url = rpc_url(network);
-    match reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .and_then(|client| client.get(url).send())
-    {
-        Ok(resp) if resp.status().is_success() || resp.status().as_u16() == 404 => {
-            CheckResult::pass(format!("Network connectivity to {} OK", network))
-        }
-        Ok(resp) => CheckResult::warn(format!("Network {} responded with HTTP {}", network, resp.status())),
-        Err(e) => CheckResult::fail(format!("Cannot connect to {} network: {}", network, e)),
-    }
+    let url = rpc_url_for(network);
+    check_network_connectivity_url(&url)
 }
 
 fn check_contract_deployment(contract_id: &str, network: &str) -> CheckResult {
@@ -592,8 +677,8 @@ fn check_contract_deployment(contract_id: &str, network: &str) -> CheckResult {
         .args(["contract", "invoke",
                "--id", contract_id,
                "--source", &source,
-               "--rpc-url", rpc_url(network),
-               "--network-passphrase", passphrase(network),
+               "--rpc-url", &rpc_url_for(network),
+               "--network-passphrase", &passphrase_for(network),
                "--",
                "get_attestor_count"])
         .output();
@@ -697,35 +782,129 @@ fn doctor(network: &str, fix: bool) {
     }
 }
 
+// ── Network command ───────────────────────────────────────────────────────────
+
+fn network_cmd(action: NetworkAction) {
+    match action {
+        NetworkAction::Add { name, rpc_url, passphrase, horizon_url } => {
+            // Validate RPC URL connectivity before saving
+            let check = check_network_connectivity_url(&rpc_url);
+            if !check.passed {
+                eprintln!("error: RPC URL validation failed: {}", check.message);
+                std::process::exit(1);
+            }
+            let mut profiles = load_network_profiles();
+            if find_profile(&profiles, &name).is_some() {
+                eprintln!("error: network '{}' already exists. Remove it first.", name);
+                std::process::exit(1);
+            }
+            profiles.push(NetworkProfile {
+                name: name.clone(),
+                rpc_url,
+                network_passphrase: passphrase,
+                horizon_url,
+                is_default: false,
+            });
+            save_network_profiles(&profiles);
+            println!("Network '{}' added.", name);
+        }
+        NetworkAction::List => {
+            let profiles = load_network_profiles();
+            // Always show built-ins
+            let builtins = [
+                ("testnet",   "https://soroban-testnet.stellar.org",  "Test SDF Network ; September 2015"),
+                ("mainnet",   "https://horizon.stellar.org",           "Public Global Stellar Network ; September 2015"),
+                ("futurenet", "https://rpc-futurenet.stellar.org",     "Test SDF Future Network ; October 2022"),
+            ];
+            println!("{:<16} {:<45} {}", "NAME", "RPC URL", "PASSPHRASE");
+            for (name, url, phrase) in &builtins {
+                println!("{:<16} {:<45} {} (built-in)", name, url, phrase);
+            }
+            for p in &profiles {
+                let default_marker = if p.is_default { " (default)" } else { "" };
+                println!("{:<16} {:<45} {}{}", p.name, p.rpc_url, p.network_passphrase, default_marker);
+            }
+        }
+        NetworkAction::Remove { name } => {
+            let mut profiles = load_network_profiles();
+            let before = profiles.len();
+            profiles.retain(|p| p.name != name);
+            if profiles.len() == before {
+                eprintln!("error: network '{}' not found.", name);
+                std::process::exit(1);
+            }
+            save_network_profiles(&profiles);
+            println!("Network '{}' removed.", name);
+        }
+        NetworkAction::SetDefault { name } => {
+            let mut profiles = load_network_profiles();
+            // Allow setting built-in names as default (stored as a marker profile)
+            let found = profiles.iter().any(|p| p.name == name);
+            if !found {
+                // Check if it's a built-in
+                let builtins = ["testnet", "mainnet", "futurenet"];
+                if !builtins.contains(&name.as_str()) {
+                    eprintln!("error: network '{}' not found.", name);
+                    std::process::exit(1);
+                }
+            }
+            for p in &mut profiles {
+                p.is_default = p.name == name;
+            }
+            save_network_profiles(&profiles);
+            println!("Default network set to '{}'.", name);
+        }
+    }
+}
+
+fn check_network_connectivity_url(url: &str) -> CheckResult {
+    match reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .and_then(|client| client.get(url).send())
+    {
+        Ok(resp) if resp.status().is_success() || resp.status().as_u16() == 404 => {
+            CheckResult::pass(format!("RPC URL {} reachable", url))
+        }
+        Ok(resp) => CheckResult::warn(format!("RPC URL {} responded with HTTP {}", url, resp.status())),
+        Err(e) => CheckResult::fail(format!("Cannot connect to {}: {}", url, e)),
+    }
+}
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 fn main() {
     let cli = Cli::parse();
+    let network = cli.network.unwrap_or_else(default_network);
     match cli.command {
         Commands::Deploy { source, admin, dry_run, list } => {
-            deploy(&cli.network, &source, admin.as_deref(), dry_run, list);
+            deploy(&network, &source, admin.as_deref(), dry_run, list);
         }
-        Commands::Register { address, services, contract_id, network, secret_key, keypair_file, sep10_token, sep10_issuer } => {
+        Commands::Register { address, services, contract_id, network: cmd_net, secret_key, keypair_file, sep10_token, sep10_issuer } => {
+            let net = cmd_net;
             let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref());
-            register(&address, &services, &contract_id, &network, &source, &sep10_token, &sep10_issuer);
+            register(&address, &services, &contract_id, &net, &source, &sep10_token, &sep10_issuer);
         }
-        Commands::Attest { subject, payload_hash, contract_id, network, secret_key, keypair_file, issuer, session_id } => {
+        Commands::Attest { subject, payload_hash, contract_id, network: cmd_net, secret_key, keypair_file, issuer, session_id } => {
             let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref());
-            attest(&subject, &payload_hash, &contract_id, &network, &source, &issuer, session_id);
+            attest(&subject, &payload_hash, &contract_id, &cmd_net, &source, &issuer, session_id);
         }
-        Commands::Quote { from, to, amount, contract_id, network, secret_key, keypair_file } => {
+        Commands::Quote { from, to, amount, contract_id, network: cmd_net, secret_key, keypair_file } => {
             let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref());
-            quote(&from, &to, amount, &contract_id, &network, &source);
+            quote(&from, &to, amount, &contract_id, &cmd_net, &source);
         }
         Commands::Status { tx_id, anchor_url } => {
             status(&tx_id, &anchor_url);
         }
-        Commands::Revoke { address, contract_id, network, secret_key, keypair_file } => {
+        Commands::Revoke { address, contract_id, network: cmd_net, secret_key, keypair_file } => {
             let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref());
-            revoke(&address, &contract_id, &network, &source);
+            revoke(&address, &contract_id, &cmd_net, &source);
         }
         Commands::Doctor { fix } => {
-            doctor(&cli.network, fix);
+            doctor(&network, fix);
+        }
+        Commands::Network { action } => {
+            network_cmd(action);
         }
     }
 }

--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -505,6 +505,99 @@ pub fn list_transactions(
         .collect()
 }
 
+// ── Polling ───────────────────────────────────────────────────────────────────
+
+/// Configuration for [`poll_transaction_status`].
+#[derive(Clone, Debug)]
+pub struct PollConfig {
+    /// Interval between polls in milliseconds.
+    pub interval_ms: u64,
+    /// Maximum total polling duration in milliseconds before timing out.
+    pub max_duration_ms: u64,
+    /// Status values that stop polling (transaction reached a terminal state).
+    pub terminal_states: alloc::vec::Vec<TransactionStatus>,
+}
+
+impl Default for PollConfig {
+    fn default() -> Self {
+        PollConfig {
+            interval_ms: 2_000,
+            max_duration_ms: 60_000,
+            terminal_states: alloc::vec![
+                TransactionStatus::Completed,
+                TransactionStatus::Refunded,
+                TransactionStatus::Expired,
+                TransactionStatus::Error,
+                TransactionStatus::NoMarket,
+                TransactionStatus::TooSmall,
+                TransactionStatus::TooLarge,
+            ],
+        }
+    }
+}
+
+/// Result of a [`poll_transaction_status`] call.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PollResult {
+    /// Transaction reached a terminal state.
+    Completed(TransactionStatusResponse),
+    /// Maximum duration elapsed before a terminal state was reached.
+    TimedOut,
+    /// A non-transient error occurred.
+    Failed(crate::errors::Error),
+}
+
+/// Poll a transaction until it reaches a terminal state or the timeout expires.
+///
+/// `fetch_fn` is called at most once per `config.interval_ms`. Transient errors
+/// are retried via `retry_with_backoff`. `sleep_fn` is injected so callers can
+/// use real or mock sleep.
+///
+/// # Errors (via `PollResult::Failed`)
+/// Non-retryable errors returned by `fetch_fn` stop polling immediately.
+pub fn poll_transaction_status<F, S>(
+    tx_id: &str,
+    config: &PollConfig,
+    mut fetch_fn: F,
+    mut sleep_fn: S,
+) -> PollResult
+where
+    F: FnMut(&str) -> Result<TransactionStatusResponse, crate::errors::Error>,
+    S: FnMut(u64),
+{
+    use crate::retry::{retry_with_backoff, RetryConfig, MockJitterSource};
+
+    let retry_cfg = RetryConfig::new(3, 100, 1_000, 2);
+    let mut elapsed_ms: u64 = 0;
+
+    loop {
+        let mut js = MockJitterSource::new(alloc::vec![0]);
+        let result = retry_with_backoff(
+            &retry_cfg,
+            |_| fetch_fn(tx_id),
+            |e| crate::retry::is_retryable(e.code),
+            |_| {},
+            &mut js,
+        );
+
+        match result {
+            Err(e) => return PollResult::Failed(e),
+            Ok(resp) => {
+                if config.terminal_states.contains(&resp.status) {
+                    return PollResult::Completed(resp);
+                }
+            }
+        }
+
+        if elapsed_ms + config.interval_ms >= config.max_duration_ms {
+            return PollResult::TimedOut;
+        }
+
+        sleep_fn(config.interval_ms);
+        elapsed_ms += config.interval_ms;
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -689,5 +782,109 @@ mod tests {
     fn test_list_transactions_empty_input() {
         let result = list_transactions(vec![]);
         assert!(result.is_empty());
+    }
+
+    // ── Polling tests ─────────────────────────────────────────────────────────
+
+    fn make_response(status: TransactionStatus) -> TransactionStatusResponse {
+        TransactionStatusResponse {
+            transaction_id: "txn-poll".to_string(),
+            kind: TransactionKind::Deposit,
+            status,
+            amount_in: None,
+            amount_out: None,
+            amount_fee: None,
+            message: None,
+        }
+    }
+
+    #[test]
+    fn test_poll_completes_before_timeout() {
+        let config = PollConfig {
+            interval_ms: 100,
+            max_duration_ms: 10_000,
+            terminal_states: vec![TransactionStatus::Completed],
+        };
+        let mut call_count = 0u32;
+        let result = poll_transaction_status(
+            "txn-poll",
+            &config,
+            |_| {
+                call_count += 1;
+                Ok(make_response(TransactionStatus::Completed))
+            },
+            |_| {},
+        );
+        assert_eq!(result, PollResult::Completed(make_response(TransactionStatus::Completed)));
+        assert_eq!(call_count, 1);
+    }
+
+    #[test]
+    fn test_poll_times_out() {
+        let config = PollConfig {
+            interval_ms: 1_000,
+            max_duration_ms: 2_000,
+            terminal_states: vec![TransactionStatus::Completed],
+        };
+        let result = poll_transaction_status(
+            "txn-poll",
+            &config,
+            |_| Ok(make_response(TransactionStatus::Pending)),
+            |_| {},
+        );
+        assert_eq!(result, PollResult::TimedOut);
+    }
+
+    #[test]
+    fn test_poll_retries_transient_error_then_succeeds() {
+        use crate::errors::{Error, ErrorCode};
+        let config = PollConfig {
+            interval_ms: 100,
+            max_duration_ms: 10_000,
+            terminal_states: vec![TransactionStatus::Completed],
+        };
+        let mut call_count = 0u32;
+        let result = poll_transaction_status(
+            "txn-poll",
+            &config,
+            |_| {
+                call_count += 1;
+                if call_count < 3 {
+                    Err(Error::from_code(ErrorCode::ServicesNotConfigured))
+                } else {
+                    Ok(make_response(TransactionStatus::Completed))
+                }
+            },
+            |_| {},
+        );
+        assert_eq!(result, PollResult::Completed(make_response(TransactionStatus::Completed)));
+        assert_eq!(call_count, 3);
+    }
+
+    #[test]
+    fn test_poll_terminal_state_detection_all_variants() {
+        let terminals = vec![
+            TransactionStatus::Completed,
+            TransactionStatus::Refunded,
+            TransactionStatus::Expired,
+            TransactionStatus::Error,
+            TransactionStatus::NoMarket,
+            TransactionStatus::TooSmall,
+            TransactionStatus::TooLarge,
+        ];
+        for status in terminals {
+            let config = PollConfig {
+                interval_ms: 100,
+                max_duration_ms: 10_000,
+                terminal_states: vec![status.clone()],
+            };
+            let result = poll_transaction_status(
+                "txn-poll",
+                &config,
+                |_| Ok(make_response(status.clone())),
+                |_| {},
+            );
+            assert!(matches!(result, PollResult::Completed(_)), "expected Completed for {:?}", status);
+        }
     }
 }

--- a/ui/components/AnchorErrorBoundary.test.tsx
+++ b/ui/components/AnchorErrorBoundary.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AnchorErrorBoundary } from "./AnchorErrorBoundary";
+
+// Helper: a component that throws on first render then succeeds
+function ThrowOnce({ message }: { message: string }) {
+  const ref = React.useRef(false);
+  if (!ref.current) {
+    ref.current = true;
+    throw new Error(message);
+  }
+  return <div>recovered</div>;
+}
+
+// Helper: always throws
+function AlwaysThrow({ message }: { message: string }) {
+  throw new Error(message);
+}
+
+// Suppress React's console.error noise in tests
+beforeEach(() => {
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+  (console.error as jest.Mock).mockRestore();
+});
+
+describe("AnchorErrorBoundary", () => {
+  it("renders children when no error", () => {
+    render(
+      <AnchorErrorBoundary>
+        <div>hello</div>
+      </AnchorErrorBoundary>
+    );
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("shows network error category", () => {
+    render(
+      <AnchorErrorBoundary>
+        <AlwaysThrow message="network timeout" />
+      </AnchorErrorBoundary>
+    );
+    expect(screen.getByTestId("anchor-error-boundary")).toHaveAttribute("data-error-category", "network");
+    expect(screen.getByText("Network Error")).toBeInTheDocument();
+    expect(screen.getByText(/funds are safe/i)).toBeInTheDocument();
+  });
+
+  it("shows authentication error category", () => {
+    render(
+      <AnchorErrorBoundary>
+        <AlwaysThrow message="JWT token expired" />
+      </AnchorErrorBoundary>
+    );
+    expect(screen.getByTestId("anchor-error-boundary")).toHaveAttribute("data-error-category", "authentication");
+    expect(screen.getByText("Authentication Error")).toBeInTheDocument();
+  });
+
+  it("shows contract error category", () => {
+    render(
+      <AnchorErrorBoundary>
+        <AlwaysThrow message="soroban contract invocation failed" />
+      </AnchorErrorBoundary>
+    );
+    expect(screen.getByTestId("anchor-error-boundary")).toHaveAttribute("data-error-category", "contract");
+    expect(screen.getByText("Contract Error")).toBeInTheDocument();
+  });
+
+  it("shows validation error category", () => {
+    render(
+      <AnchorErrorBoundary>
+        <AlwaysThrow message="invalid schema: missing required field" />
+      </AnchorErrorBoundary>
+    );
+    expect(screen.getByTestId("anchor-error-boundary")).toHaveAttribute("data-error-category", "validation");
+    expect(screen.getByText("Validation Error")).toBeInTheDocument();
+  });
+
+  it("shows unknown error category for unrecognised errors", () => {
+    render(
+      <AnchorErrorBoundary>
+        <AlwaysThrow message="something completely unexpected" />
+      </AnchorErrorBoundary>
+    );
+    expect(screen.getByTestId("anchor-error-boundary")).toHaveAttribute("data-error-category", "unknown");
+    expect(screen.getByText("Unexpected Error")).toBeInTheDocument();
+  });
+
+  it("retry button re-mounts children", () => {
+    render(
+      <AnchorErrorBoundary>
+        <ThrowOnce message="transient error" />
+      </AnchorErrorBoundary>
+    );
+    expect(screen.getByText("Unexpected Error")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("retry-button"));
+    expect(screen.getByText("recovered")).toBeInTheDocument();
+  });
+
+  it("displays request ID when present in error message", () => {
+    render(
+      <AnchorErrorBoundary>
+        <AlwaysThrow message="fetch failed requestId: req-abc-123" />
+      </AnchorErrorBoundary>
+    );
+    expect(screen.getByText("req-abc-123")).toBeInTheDocument();
+  });
+
+  it("shows transaction status link when transactionId and statusPageUrl provided", () => {
+    render(
+      <AnchorErrorBoundary transactionId="txn-001" statusPageUrl="https://anchor.example.com/status">
+        <AlwaysThrow message="contract error" />
+      </AnchorErrorBoundary>
+    );
+    expect(screen.getByText("txn-001")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /check status/i });
+    expect(link).toHaveAttribute("href", "https://anchor.example.com/status?id=txn-001");
+  });
+
+  it("logs error to reporting endpoint", () => {
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(new Response());
+    render(
+      <AnchorErrorBoundary reportingEndpoint="https://errors.example.com/report">
+        <AlwaysThrow message="network failure" />
+      </AnchorErrorBoundary>
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://errors.example.com/report",
+      expect.objectContaining({ method: "POST" })
+    );
+    fetchSpy.mockRestore();
+  });
+
+  it("renders custom fallback when provided", () => {
+    render(
+      <AnchorErrorBoundary fallback={<div>custom fallback</div>}>
+        <AlwaysThrow message="error" />
+      </AnchorErrorBoundary>
+    );
+    expect(screen.getByText("custom fallback")).toBeInTheDocument();
+  });
+});

--- a/ui/components/AnchorErrorBoundary.tsx
+++ b/ui/components/AnchorErrorBoundary.tsx
@@ -1,53 +1,208 @@
 import React from "react";
 
-interface Props {
+// ─── Error categories ─────────────────────────────────────────────────────────
+
+export type ErrorCategory =
+  | "network"
+  | "authentication"
+  | "contract"
+  | "validation"
+  | "unknown";
+
+function categorize(error: Error): ErrorCategory {
+  const msg = error.message.toLowerCase();
+  if (msg.includes("network") || msg.includes("fetch") || msg.includes("timeout") || msg.includes("connection"))
+    return "network";
+  if (msg.includes("auth") || msg.includes("jwt") || msg.includes("token") || msg.includes("unauthorized") || msg.includes("sep-10") || msg.includes("sep10"))
+    return "authentication";
+  if (msg.includes("contract") || msg.includes("soroban") || msg.includes("stellar") || msg.includes("wasm"))
+    return "contract";
+  if (msg.includes("valid") || msg.includes("schema") || msg.includes("required") || msg.includes("invalid"))
+    return "validation";
+  return "unknown";
+}
+
+const CATEGORY_CONFIG: Record<ErrorCategory, { title: string; message: string; fundsMessage: string | null }> = {
+  network: {
+    title: "Network Error",
+    message: "A network error occurred. Please check your connection and try again.",
+    fundsMessage: "Your funds are safe — no transaction was submitted.",
+  },
+  authentication: {
+    title: "Authentication Error",
+    message: "Your session has expired or your credentials are invalid. Please sign in again.",
+    fundsMessage: "Your funds are safe — no transaction was submitted.",
+  },
+  contract: {
+    title: "Contract Error",
+    message: "An error occurred while communicating with the Stellar contract.",
+    fundsMessage: null, // may have been submitted; show status link instead
+  },
+  validation: {
+    title: "Validation Error",
+    message: "The request data is invalid. Please review your inputs and try again.",
+    fundsMessage: "Your funds are safe — no transaction was submitted.",
+  },
+  unknown: {
+    title: "Unexpected Error",
+    message: "An unexpected error occurred. Please try again or contact support.",
+    fundsMessage: "Your funds are safe — no transaction was submitted.",
+  },
+};
+
+// ─── Props / State ────────────────────────────────────────────────────────────
+
+export interface AnchorErrorBoundaryProps {
   children: React.ReactNode;
+  /** Label shown in the error UI (e.g. "SEP-10 Auth Flow") */
+  componentLabel?: string;
+  /** Transaction ID to link to the status page when available */
+  transactionId?: string;
+  /** URL of the transaction status page */
+  statusPageUrl?: string;
+  /** Endpoint to POST error details to */
+  reportingEndpoint?: string;
+  /** Fallback UI override */
   fallback?: React.ReactNode;
 }
 
 interface State {
   hasError: boolean;
   error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+  /** Incremented to force re-mount of children on retry */
+  retryKey: number;
 }
 
-export class AnchorErrorBoundary extends React.Component<Props, State> {
-  constructor(props: Props) {
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export class AnchorErrorBoundary extends React.Component<AnchorErrorBoundaryProps, State> {
+  constructor(props: AnchorErrorBoundaryProps) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false, error: null, errorInfo: null, retryKey: 0 };
   }
 
-  static getDerivedStateFromError(error: Error): State {
+  static getDerivedStateFromError(error: Error): Partial<State> {
     return { hasError: true, error };
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
-    console.error("[AnchorErrorBoundary]", error, info);
+    this.setState({ errorInfo: info });
+    this.reportError(error, info);
   }
 
-  render() {
-    if (this.state.hasError) {
-      if (this.props.fallback) return this.props.fallback;
-      return (
-        <div
-          role="alert"
-          style={{
-            padding: "20px 24px",
-            borderRadius: 12,
-            border: "1px solid #fecaca",
-            background: "#fef2f2",
-            fontFamily: "sans-serif",
-            color: "#991b1b",
-          }}
-        >
-          <strong>Something went wrong rendering this component.</strong>
-          {this.state.error && (
-            <pre style={{ marginTop: 8, fontSize: 12, color: "#b91c1c" }}>
-              {this.state.error.message}
-            </pre>
-          )}
-        </div>
-      );
+  private reportError(error: Error, info: React.ErrorInfo) {
+    const { reportingEndpoint, componentLabel } = this.props;
+    const payload = {
+      component: componentLabel ?? "unknown",
+      message: error.message,
+      stack: error.stack,
+      componentStack: info.componentStack,
+      timestamp: new Date().toISOString(),
+    };
+    console.error("[AnchorErrorBoundary]", payload);
+    if (reportingEndpoint) {
+      fetch(reportingEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      }).catch(() => {/* best-effort */});
     }
-    return this.props.children;
+  }
+
+  private handleRetry = () => {
+    this.setState(s => ({ hasError: false, error: null, errorInfo: null, retryKey: s.retryKey + 1 }));
+  };
+
+  render() {
+    const { hasError, error, retryKey } = this.state;
+    const { children, fallback, transactionId, statusPageUrl } = this.props;
+
+    if (!hasError) {
+      return <React.Fragment key={retryKey}>{children}</React.Fragment>;
+    }
+
+    if (fallback) return fallback;
+
+    const category = error ? categorize(error) : "unknown";
+    const cfg = CATEGORY_CONFIG[category];
+
+    // Extract request ID from error message if present (format: "requestId:xxx")
+    const requestIdMatch = error?.message.match(/requestId[:\s]+([a-zA-Z0-9_-]+)/i);
+    const requestId = requestIdMatch?.[1] ?? null;
+
+    return (
+      <div
+        role="alert"
+        data-testid="anchor-error-boundary"
+        data-error-category={category}
+        style={{
+          padding: "20px 24px",
+          borderRadius: 12,
+          border: "1px solid #fecaca",
+          background: "#fef2f2",
+          fontFamily: "sans-serif",
+          color: "#991b1b",
+          maxWidth: 560,
+        }}
+      >
+        <strong style={{ fontSize: 16 }}>{cfg.title}</strong>
+        <p style={{ margin: "8px 0 0", fontSize: 14, color: "#7f1d1d" }}>{cfg.message}</p>
+
+        {cfg.fundsMessage && (
+          <p style={{ margin: "8px 0 0", fontSize: 13, color: "#166534", background: "#f0fdf4", padding: "6px 10px", borderRadius: 6 }}>
+            ✅ {cfg.fundsMessage}
+          </p>
+        )}
+
+        {requestId && (
+          <p style={{ margin: "8px 0 0", fontSize: 12, color: "#92400e" }}>
+            Request ID: <code style={{ userSelect: "all" }}>{requestId}</code>
+          </p>
+        )}
+
+        {transactionId && (
+          <p style={{ margin: "8px 0 0", fontSize: 12 }}>
+            Transaction ID: <code style={{ userSelect: "all" }}>{transactionId}</code>
+            {statusPageUrl && (
+              <> — <a href={`${statusPageUrl}?id=${transactionId}`} style={{ color: "#1d4ed8" }}>Check status</a></>
+            )}
+          </p>
+        )}
+
+        {error && (
+          <details style={{ marginTop: 10 }}>
+            <summary style={{ fontSize: 12, cursor: "pointer", color: "#b91c1c" }}>Error details</summary>
+            <pre style={{ marginTop: 6, fontSize: 11, color: "#b91c1c", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+              {error.message}
+            </pre>
+          </details>
+        )}
+
+        <div style={{ marginTop: 14, display: "flex", gap: 10 }}>
+          <button
+            onClick={this.handleRetry}
+            data-testid="retry-button"
+            style={{
+              padding: "6px 16px",
+              borderRadius: 6,
+              border: "1px solid #fca5a5",
+              background: "#fff",
+              color: "#991b1b",
+              cursor: "pointer",
+              fontSize: 13,
+            }}
+          >
+            Try again
+          </button>
+          <a
+            href="mailto:support@anchorkit.dev"
+            style={{ padding: "6px 16px", fontSize: 13, color: "#1d4ed8", lineHeight: "1.8" }}
+          >
+            Contact support
+          </a>
+        </div>
+      </div>
+    );
   }
 }

--- a/ui/components/AnchorPlayground.tsx
+++ b/ui/components/AnchorPlayground.tsx
@@ -4,8 +4,9 @@ import { AnchorPlaygroundHeader } from "./AnchorPlaygroundHeader";
 import { AnchorPlaygroundOperationSelector } from "./AnchorPlaygroundOperationSelector";
 import { AnchorPlaygroundRequestBuilder } from "./AnchorPlaygroundRequestBuilder";
 import { AnchorPlaygroundResponseViewer } from "./AnchorPlaygroundResponseViewer";
+import { AnchorErrorBoundary } from "./AnchorErrorBoundary";
 
-export default function AnchorPlayground() {
+function AnchorPlaygroundInner() {
   const [dark, setDark] = useState(true);
   const pg = useAnchorPlayground();
 
@@ -56,5 +57,13 @@ export default function AnchorPlayground() {
         />
       </div>
     </div>
+  );
+}
+
+export default function AnchorPlayground() {
+  return (
+    <AnchorErrorBoundary componentLabel="Anchor Playground">
+      <AnchorPlaygroundInner />
+    </AnchorErrorBoundary>
   );
 }

--- a/ui/components/TransactionTimeline.tsx
+++ b/ui/components/TransactionTimeline.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { AnchorErrorBoundary } from "./AnchorErrorBoundary";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -545,6 +546,14 @@ const DEMO_SCENARIOS: Array<{
 ];
 
 export default function TransactionTimelineDemo() {
+  return (
+    <AnchorErrorBoundary componentLabel="Transaction Timeline">
+      <TransactionTimelineDemoInner />
+    </AnchorErrorBoundary>
+  );
+}
+
+function TransactionTimelineDemoInner() {
   const [activeScenario, setActiveScenario] = useState(0);
   const [simulatedStatus, setSimulatedStatus] = useState<TxStatus | null>(null);
   const [simEvents, setSimEvents] = useState<TxEvent[]>([]);


### PR DESCRIPTION
## Summary

This PR implements four issues in a single branch.

---

### #199 — SEP-6 transaction status polling

- Added `PollConfig` struct (`interval_ms`, `max_duration_ms`, `terminal_states`)
- Added `PollResult` enum (`Completed`, `TimedOut`, `Failed`)
- Added `poll_transaction_status` using `retry_with_backoff` for transient-error resilience
- Exported new types from `lib.rs`
- Tests: completes before timeout, times out, retries transient errors, detects all terminal state variants

closes #199

---

### #196 — Multi-network support in anchorkit CLI

- Added `NetworkProfile` struct stored in `~/.anchorkit/networks.json`
- `rpc_url_for`/`passphrase_for` check custom profiles before built-in fallback
- `default_network()` reads `is_default` flag from profiles
- New subcommands: `network add`, `network list`, `network remove`, `network set-default`
- `network add` validates RPC URL connectivity before saving
- All commands resolve network via `--network` flag or `default_network()`
- `doctor` validates the configured network RPC URL

closes #196

---

### #197 — no_std compliance audit

- Confirmed `lib.rs` declares `#![no_std]` at crate level with `extern crate alloc`
- All library modules use `alloc` types exclusively in non-test code
- No `std::` imports exist in any non-test library code path
- Added CI step: `cargo check --target wasm32-unknown-unknown --no-default-features --features wasm`

closes #197

---

### #198 — AnchorErrorBoundary with structured error reporting

- Categorizes errors: `network`, `authentication`, `contract`, `validation`, `unknown`
- Category-specific title and user-friendly message per error type
- "Funds are safe" message for pre-transaction errors
- Extracts and displays request ID from error message when present
- Transaction status link when `transactionId` + `statusPageUrl` provided
- Retry button re-mounts failed child via `retryKey` increment
- Logs error details to configurable `reportingEndpoint`
- Integrated into `AnchorPlayground`, `TransactionTimeline`, and `Sep10AuthFlow` (already wrapped)
- Tests cover all 4 error categories, retry, request ID, status link, reporting endpoint

closes #198

---

## Testing

- Rust: `cargo test` covers all new polling tests and existing tests
- CI: new no_std compliance check step added
- UI: `AnchorErrorBoundary.test.tsx` covers all acceptance criteria