### PR TITLE
fix(#231,#233,#234,#235): harden SEP-10 JWT, rate limiter, webhook DLQ, SEP-24 URL validation

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -694,6 +694,43 @@ impl AnchorKitContract {
             .extend_ttl(&storage_key, PERSISTENT_TTL, PERSISTENT_TTL);
     }
 
+    /// Rotate the SEP-10 issuer key for `issuer` to `new_public_key`.
+    ///
+    /// Requires admin authorization. The old key is replaced atomically; any
+    /// subsequent `verify_sep10_token` call will use the new key. The previous
+    /// key is stored under `"SEP10OLD"` for one TTL period to allow in-flight
+    /// tokens signed with the old key to drain gracefully.
+    pub fn rotate_sep10_key(env: Env, issuer: Address, new_public_key: Bytes) {
+        Self::require_admin(&env);
+        if new_public_key.len() != 32 {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        let storage_key = (symbol_short!("SEP10KEY"), issuer.clone());
+        // Preserve old key for graceful drain
+        if let Some(old_key) = env.storage().persistent().get::<_, Bytes>(&storage_key) {
+            let old_key_storage = (symbol_short!("SEP10OLD"), issuer.clone());
+            env.storage().persistent().set(&old_key_storage, &old_key);
+            env.storage()
+                .persistent()
+                .extend_ttl(&old_key_storage, PERSISTENT_TTL, PERSISTENT_TTL);
+        }
+        env.storage().persistent().set(&storage_key, &new_public_key);
+        env.storage()
+            .persistent()
+            .extend_ttl(&storage_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        env.events().publish(
+            (symbol_short!("sep10key"), symbol_short!("rotated"), issuer),
+            (),
+        );
+    }
+
+    /// Return the current SEP-10 verifying key for `issuer`, or `None` if not set.
+    pub fn get_sep10_key(env: Env, issuer: Address) -> Option<Bytes> {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("SEP10KEY"), issuer))
+    }
+
     /// Configure the maximum JWT length accepted by `verify_sep10_jwt` (issue #64).
     /// Must be between 2048 and 16384. Admin-only.
     pub fn set_jwt_max_len(env: Env, max_len: u32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub use response_validator::{
 };
 pub use retry::{retry_with_backoff, is_retryable, RetryConfig, JitterSource, LedgerJitterSource, MockJitterSource};
 pub use deterministic_hash::{compute_payload_hash, verify_payload_hash};
-pub use webhook::{deliver_webhook, get_dead_letter_webhooks, WebhookDeliveryConfig};
+pub use webhook::{deliver_webhook, get_dead_letter_webhooks, query_dlq, WebhookDeliveryConfig, DlqEntry};
 
 pub use sep6::{
     fetch_transaction_status, initiate_deposit, initiate_withdrawal, DepositResponse,

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -169,6 +169,7 @@ impl RateLimiter {
     ///
     /// Loads the stored admin from instance storage (key `"ADMIN"`) and calls
     /// `admin.require_auth()`. Returns `Err(NotInitialized)` if no admin is stored.
+    /// Returns `Err(ValidationError)` if `config` contains zero or nonsensical values.
     pub fn update_config(
         env: &Env,
         admin: &Address,
@@ -183,8 +184,22 @@ impl RateLimiter {
             return Err(AnchorKitError::unauthorized_attestor());
         }
         admin.require_auth();
+        Self::validate_config(config)?;
         let config_key = Self::get_config_key(env);
         env.storage().persistent().set(&config_key, config);
+        Ok(())
+    }
+
+    /// Validate that a [`RateLimitConfig`] has sensible non-zero values.
+    ///
+    /// Returns `Err(ValidationError)` if `max_submissions` or `window_length` is zero.
+    pub fn validate_config(config: &RateLimitConfig) -> Result<(), AnchorKitError> {
+        if config.max_submissions == 0 {
+            return Err(AnchorKitError::validation_error("max_submissions must be > 0"));
+        }
+        if config.window_length == 0 {
+            return Err(AnchorKitError::validation_error("window_length must be > 0"));
+        }
         Ok(())
     }
     
@@ -452,5 +467,114 @@ mod tests {
         });
         assert_eq!(config.max_submissions, 10);
         assert_eq!(config.window_length, 100);
+    }
+
+    #[test]
+    fn test_validate_config_rejects_zero_max_submissions() {
+        let config = RateLimitConfig { max_submissions: 0, window_length: 100 };
+        assert!(RateLimiter::validate_config(&config).is_err());
+        assert_eq!(
+            RateLimiter::validate_config(&config).unwrap_err().code,
+            ErrorCode::ValidationError
+        );
+    }
+
+    #[test]
+    fn test_validate_config_rejects_zero_window_length() {
+        let config = RateLimitConfig { max_submissions: 5, window_length: 0 };
+        assert!(RateLimiter::validate_config(&config).is_err());
+        assert_eq!(
+            RateLimiter::validate_config(&config).unwrap_err().code,
+            ErrorCode::ValidationError
+        );
+    }
+
+    #[test]
+    fn test_validate_config_accepts_valid() {
+        let config = RateLimitConfig { max_submissions: 1, window_length: 1 };
+        assert!(RateLimiter::validate_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_update_config_rejects_zero_values() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let bad_config = RateLimitConfig { max_submissions: 0, window_length: 100 };
+
+        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_id = env.register_contract(&contract_address, crate::contract::AnchorKitContract);
+
+        env.as_contract(&contract_id, &|| {
+            env.storage()
+                .instance()
+                .set(&soroban_sdk::vec![&env, soroban_sdk::symbol_short!("ADMIN")], &admin);
+        });
+
+        let result = env.as_contract(&contract_id, &|| {
+            RateLimiter::update_config(&env, &admin, &bad_config)
+        });
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, ErrorCode::ValidationError);
+    }
+
+    #[test]
+    fn test_window_rollover_at_exact_boundary() {
+        let env = Env::default();
+        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let config = RateLimitConfig { max_submissions: 1, window_length: 10 };
+
+        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_id = env.register_contract(&contract_address, crate::contract::AnchorKitContract);
+
+        // Fill the window
+        assert!(env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        }).is_ok());
+        // Same window — should fail
+        assert!(env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        }).is_err());
+
+        // Advance ledger by exactly window_length (10)
+        env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+            sequence_number: 10,
+            timestamp: 1000,
+            protocol_version: 21,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+
+        // Window should have rolled over — first submission in new window succeeds
+        assert!(env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        }).is_ok());
+    }
+
+    #[test]
+    fn test_max_submission_error_is_consistent() {
+        let env = Env::default();
+        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let config = RateLimitConfig { max_submissions: 2, window_length: 100 };
+
+        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_id = env.register_contract(&contract_address, crate::contract::AnchorKitContract);
+
+        env.as_contract(&contract_id, &|| { RateLimiter::check_and_increment(&env, &attestor, &config).unwrap(); });
+        env.as_contract(&contract_id, &|| { RateLimiter::check_and_increment(&env, &attestor, &config).unwrap(); });
+
+        // Every subsequent call must return RateLimitExceeded without corrupting state
+        for _ in 0..3 {
+            let err = env.as_contract(&contract_id, &|| {
+                RateLimiter::check_and_increment(&env, &attestor, &config)
+            }).unwrap_err();
+            assert_eq!(err.code, ErrorCode::RateLimitExceeded);
+        }
+        // State must still show exactly max_submissions
+        let state = env.as_contract(&contract_id, &|| RateLimiter::get_state(&env, &attestor));
+        assert_eq!(state.submission_count, 2);
     }
 }

--- a/src/sep10_jwt.rs
+++ b/src/sep10_jwt.rs
@@ -170,6 +170,28 @@ fn parse_json_jti(payload: &[u8]) -> Option<Vec<u8>> {
     None
 }
 
+/// Parse first `"iss":"..."` string value. Returns `None` if absent.
+fn parse_json_iss(payload: &[u8]) -> Option<Vec<u8>> {
+    let key = b"\"iss\":";
+    let pos = find_bytes(payload, key)?;
+    let mut i = pos + key.len();
+    while i < payload.len() && payload[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if i >= payload.len() || payload[i] != b'"' {
+        return None;
+    }
+    i += 1;
+    let start = i;
+    while i < payload.len() {
+        if payload[i] == b'"' {
+            return Some(payload[start..i].to_vec());
+        }
+        i += 1;
+    }
+    None
+}
+
 /// Parse first `"sub":"..."` string value (no escape sequences inside value).
 fn parse_json_sub(env: &Env, payload: &[u8]) -> Result<String, ()> {
     let key = b"\"sub\":";
@@ -297,6 +319,13 @@ pub fn verify_sep10_jwt(
     if !contains_subslice(&header_dec, b"EdDSA") {
         return Err(());
     }
+    // Reject tokens that claim a non-EdDSA algorithm alongside EdDSA (e.g. "alg":"RS256")
+    // by requiring the header to NOT contain any of the common non-EdDSA algorithm names.
+    for forbidden in &[b"RS256" as &[u8], b"RS384", b"RS512", b"HS256", b"HS384", b"HS512", b"ES256", b"ES384", b"ES512", b"none"] {
+        if contains_subslice(&header_dec, forbidden) {
+            return Err(());
+        }
+    }
 
     let sig_dec = base64url_decode(sig_b64).map_err(|_| ())?;
     if sig_dec.len() != 64 {
@@ -362,6 +391,12 @@ pub fn verify_sep10_jwt(
         }
     }
 
+    // iss claim must be present and non-empty (SEP-10 requirement)
+    match parse_json_iss(&payload_dec) {
+        Some(iss) if !iss.is_empty() => {}
+        _ => return Err(()),
+    }
+
     Ok(())
 }
 
@@ -397,7 +432,7 @@ mod tests {
     fn build_jwt(signing_key: &SigningKey, sub: &str, exp: u64) -> std::string::String {
         use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
         let header = r#"{"alg":"EdDSA","typ":"JWT"}"#;
-        let payload = format!(r#"{{"sub":"{}","exp":{}}}"#, sub, exp);
+        let payload = format!(r#"{{"sub":"{}","exp":{},"iss":"https://anchor.example.com"}}"#, sub, exp);
         let header_b64 = URL_SAFE_NO_PAD.encode(header);
         let payload_b64 = URL_SAFE_NO_PAD.encode(payload);
         let signing_input = format!("{}.{}", header_b64, payload_b64);
@@ -415,7 +450,7 @@ mod tests {
     ) -> std::string::String {
         use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
         let header = r#"{"alg":"EdDSA","typ":"JWT"}"#;
-        let mut payload = format!(r#"{{"sub":"{}","exp":{}"#, sub, exp);
+        let mut payload = format!(r#"{{"sub":"{}","exp":{},"iss":"https://anchor.example.com""#, sub, exp);
         if let Some(n) = nbf {
             payload.push_str(&format!(r#","nbf":{}"#, n));
         }
@@ -423,6 +458,30 @@ mod tests {
             payload.push_str(&format!(r#","jti":"{}""#, j));
         }
         payload.push('}');
+        let header_b64 = URL_SAFE_NO_PAD.encode(header);
+        let payload_b64 = URL_SAFE_NO_PAD.encode(payload);
+        let signing_input = format!("{}.{}", header_b64, payload_b64);
+        let sig = signing_key.sign(signing_input.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        format!("{}.{}", signing_input, sig_b64)
+    }
+
+    fn build_jwt_with_alg(signing_key: &SigningKey, alg: &str, sub: &str, exp: u64) -> std::string::String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let header = format!(r#"{{"alg":"{}","typ":"JWT"}}"#, alg);
+        let payload = format!(r#"{{"sub":"{}","exp":{},"iss":"https://anchor.example.com"}}"#, sub, exp);
+        let header_b64 = URL_SAFE_NO_PAD.encode(header);
+        let payload_b64 = URL_SAFE_NO_PAD.encode(payload);
+        let signing_input = format!("{}.{}", header_b64, payload_b64);
+        let sig = signing_key.sign(signing_input.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        format!("{}.{}", signing_input, sig_b64)
+    }
+
+    fn build_jwt_no_iss(signing_key: &SigningKey, sub: &str, exp: u64) -> std::string::String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let header = r#"{"alg":"EdDSA","typ":"JWT"}"#;
+        let payload = format!(r#"{{"sub":"{}","exp":{}}}"#, sub, exp);
         let header_b64 = URL_SAFE_NO_PAD.encode(header);
         let payload_b64 = URL_SAFE_NO_PAD.encode(payload);
         let signing_input = format!("{}.{}", header_b64, payload_b64);
@@ -583,6 +642,75 @@ mod tests {
                 .instance()
                 .set(&soroban_sdk::symbol_short!("JWTMAXLEN"), &8192u32);
             assert!(verify_sep10_jwt(&env, &token2, &pk, None).is_ok());
+        });
+    }
+
+    #[test]
+    fn verify_rejects_missing_iss_claim() {
+        let env = Env::default();
+        ledger(&env, 1_000);
+        let contract_id = make_contract_id(&env);
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, signing_key.verifying_key().as_bytes());
+
+        let attestor = Address::generate(&env);
+        let sub_str: std::string::String = attestor.to_string().to_string();
+        let jwt = build_jwt_no_iss(&signing_key, sub_str.as_str(), 5_000);
+        let token = String::from_str(&env, jwt.as_str());
+        env.as_contract(&contract_id, || {
+            assert!(verify_sep10_jwt(&env, &token, &pk, None).is_err());
+        });
+    }
+
+    #[test]
+    fn verify_rejects_rs256_algorithm() {
+        let env = Env::default();
+        ledger(&env, 1_000);
+        let contract_id = make_contract_id(&env);
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, signing_key.verifying_key().as_bytes());
+
+        let attestor = Address::generate(&env);
+        let sub_str: std::string::String = attestor.to_string().to_string();
+        // RS256 header — should be rejected even if EdDSA is absent
+        let jwt = build_jwt_with_alg(&signing_key, "RS256", sub_str.as_str(), 5_000);
+        let token = String::from_str(&env, jwt.as_str());
+        env.as_contract(&contract_id, || {
+            assert!(verify_sep10_jwt(&env, &token, &pk, None).is_err());
+        });
+    }
+
+    #[test]
+    fn verify_rejects_hs256_algorithm() {
+        let env = Env::default();
+        ledger(&env, 1_000);
+        let contract_id = make_contract_id(&env);
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, signing_key.verifying_key().as_bytes());
+
+        let attestor = Address::generate(&env);
+        let sub_str: std::string::String = attestor.to_string().to_string();
+        let jwt = build_jwt_with_alg(&signing_key, "HS256", sub_str.as_str(), 5_000);
+        let token = String::from_str(&env, jwt.as_str());
+        env.as_contract(&contract_id, || {
+            assert!(verify_sep10_jwt(&env, &token, &pk, None).is_err());
+        });
+    }
+
+    #[test]
+    fn verify_rejects_none_algorithm() {
+        let env = Env::default();
+        ledger(&env, 1_000);
+        let contract_id = make_contract_id(&env);
+        let signing_key = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, signing_key.verifying_key().as_bytes());
+
+        let attestor = Address::generate(&env);
+        let sub_str: std::string::String = attestor.to_string().to_string();
+        let jwt = build_jwt_with_alg(&signing_key, "none", sub_str.as_str(), 5_000);
+        let token = String::from_str(&env, jwt.as_str());
+        env.as_contract(&contract_id, || {
+            assert!(verify_sep10_jwt(&env, &token, &pk, None).is_err());
         });
     }
 }

--- a/src/sep24.rs
+++ b/src/sep24.rs
@@ -69,8 +69,47 @@ pub struct Sep24TransactionStatusResponse {
 // ---------------------------------------------------------------------------
 
 /// Validates that a SEP-24 interactive flow URL is a well-formed HTTPS URL.
-/// Delegates to `validate_anchor_domain` to avoid duplicating logic.
+///
+/// In addition to the base `validate_anchor_domain` checks, this function also:
+/// - Rejects URLs with embedded userinfo (`https://user:pass@host/...`)
+/// - Rejects IP literals in brackets (`https://[::1]/...`)
+/// - Rejects excessively long individual URL components (host > 253 chars, path > 2048 chars)
 pub fn validate_interactive_url(url: &str) -> Result<(), AnchorKitError> {
+    if url.is_empty() {
+        return Err(AnchorKitError::invalid_endpoint_format());
+    }
+
+    // Must start with https://
+    if !url.starts_with("https://") {
+        return Err(AnchorKitError::invalid_endpoint_format());
+    }
+
+    let after_scheme = &url[8..]; // skip "https://"
+
+    // Reject IP literals: https://[...]
+    if after_scheme.starts_with('[') {
+        return Err(AnchorKitError::invalid_endpoint_format());
+    }
+
+    // Reject userinfo: presence of '@' before the first '/' indicates user:pass@host
+    let authority_end = after_scheme.find('/').unwrap_or(after_scheme.len());
+    let authority = &after_scheme[..authority_end];
+    if authority.contains('@') {
+        return Err(AnchorKitError::invalid_endpoint_format());
+    }
+
+    // Reject excessively long host component (RFC 1035: max 253 chars)
+    let host = authority.split(':').next().unwrap_or(authority);
+    if host.len() > 253 {
+        return Err(AnchorKitError::invalid_endpoint_format());
+    }
+
+    // Reject excessively long path component
+    let path = &after_scheme[authority_end..];
+    if path.len() > 2048 {
+        return Err(AnchorKitError::invalid_endpoint_format());
+    }
+
     validate_anchor_domain(url).map_err(|_| AnchorKitError::invalid_endpoint_format())
 }
 
@@ -272,6 +311,36 @@ mod tests {
     #[test]
     fn test_validate_interactive_url_rejects_empty() {
         assert!(validate_interactive_url("").is_err());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_rejects_userinfo() {
+        assert!(validate_interactive_url("https://user:pass@anchor.example.com/deposit").is_err());
+        assert!(validate_interactive_url("https://user@anchor.example.com/deposit").is_err());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_rejects_ip_literal() {
+        assert!(validate_interactive_url("https://[::1]/deposit").is_err());
+        assert!(validate_interactive_url("https://[2001:db8::1]/deposit").is_err());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_rejects_long_host() {
+        // 254-char host (exceeds RFC 1035 limit of 253)
+        let long_host = alloc::format!("https://{}.com/path", "a".repeat(250));
+        assert!(validate_interactive_url(&long_host).is_err());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_rejects_long_path() {
+        let long_path = alloc::format!("https://anchor.example.com/{}", "a".repeat(2049));
+        assert!(validate_interactive_url(&long_path).is_err());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_accepts_valid_with_path_and_query() {
+        assert!(validate_interactive_url("https://anchor.example.com/sep24/deposit?asset=USDC").is_ok());
     }
 
     // -----------------------------------------------------------------------

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,9 +1,9 @@
 //! Webhook delivery with exponential backoff and a Dead Letter Queue (DLQ).
 //!
 //! `deliver_webhook` wraps the HTTP POST in `retry_with_backoff`.  On total
-//! exhaustion the serialised payload is written into the caller-supplied DLQ
-//! map under `dead_letter_storage_key`.  `get_dead_letter_webhooks` lets
-//! admins inspect those failed entries.
+//! exhaustion a structured [`DlqEntry`] is written into the caller-supplied DLQ
+//! map under `dead_letter_storage_key`.  `get_dead_letter_webhooks` and
+//! `query_dlq` let admins inspect those failed entries.
 
 #[cfg(feature = "std")]
 extern crate std;
@@ -35,10 +35,33 @@ pub struct WebhookDeliveryConfig {
     pub endpoint_url: String,
     /// Maximum delivery attempts (passed straight to `RetryConfig::max_attempts`).
     pub max_retries: u32,
+    /// Base delay between retries in milliseconds.
+    pub retry_delay_ms: u64,
+    /// Per-attempt timeout in milliseconds (informational; enforced by `http_post`).
+    pub timeout_ms: u64,
     /// Backoff parameters (base delay, multiplier, cap).
     pub retry_config: RetryConfig,
-    /// Key under which a failed payload is stored in the DLQ map.
+    /// Key under which failed entries are stored in the DLQ map.
     pub dead_letter_storage_key: String,
+}
+
+// ---------------------------------------------------------------------------
+// DLQ entry
+// ---------------------------------------------------------------------------
+
+/// Structured record stored in the DLQ when all delivery attempts are exhausted.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DlqEntry {
+    /// The payload that failed to deliver.
+    pub payload: String,
+    /// Unix timestamp (seconds) when the entry was written to the DLQ.
+    pub failed_at_timestamp: u64,
+    /// Last HTTP status code received, or 0 if the transport failed entirely.
+    pub last_status_code: u16,
+    /// Number of delivery attempts made before giving up.
+    pub attempts_made: u32,
+    /// Human-readable description of the last error.
+    pub last_error: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -49,49 +72,53 @@ pub struct WebhookDeliveryConfig {
 ///
 /// `http_post` is an injectable transport function `(url, body) -> Result<u16, String>`
 /// that returns the HTTP status code on success or an error string on failure.
-/// This keeps the core logic testable without a live network.
 ///
 /// `sleep_fn` is called with the computed delay (ms) between retries.
 ///
-/// On total failure the payload is written to `dlq` under
+/// `now_fn` returns the current Unix timestamp in seconds (used to timestamp DLQ entries).
+///
+/// On total failure a [`DlqEntry`] is appended to `dlq` under
 /// `config.dead_letter_storage_key` and an `AnchorKitError` is returned.
-pub fn deliver_webhook<H, S>(
+pub fn deliver_webhook<H, S, T>(
     config: &WebhookDeliveryConfig,
     payload: &str,
-    dlq: &mut BTreeMap<String, Vec<String>>,
+    dlq: &mut BTreeMap<String, Vec<DlqEntry>>,
     http_post: H,
     mut sleep_fn: S,
+    now_fn: T,
 ) -> Result<(), AnchorKitError>
 where
     H: Fn(&str, &str) -> Result<u16, String>,
     S: FnMut(u64),
+    T: Fn() -> u64,
 {
     let mut retry_cfg = config.retry_config.clone();
     retry_cfg.max_attempts = config.max_retries;
 
-    // RefCell lets the closure capture last_error_msg mutably while the
-    // closure itself is only FnMut (not FnOnce).
     let last_error_msg: RefCell<String> = RefCell::new(String::new());
+    let last_status: RefCell<u16> = RefCell::new(0);
 
     let mut jitter_source = crate::retry::MockJitterSource::new(vec![0]);
     let result = retry_with_backoff(
         &retry_cfg,
         |attempt| {
-            let msg = match http_post(&config.endpoint_url, payload) {
+            let (status, msg) = match http_post(&config.endpoint_url, payload) {
                 Ok(s) if s < 400 => return Ok(()),
-                Ok(s) => format!("HTTP {s}"),
-                Err(e) => e,
+                Ok(s) => (s, format!("HTTP {s}")),
+                Err(e) => (0, e),
             };
             #[cfg(feature = "std")]
             std::eprintln!(
-                "[webhook] attempt={} error=\"{}\"",
+                "[webhook] attempt={} status={} error=\"{}\"",
                 attempt + 1,
+                status,
                 msg
             );
             *last_error_msg.borrow_mut() = msg.clone();
+            *last_status.borrow_mut() = status;
             Err(msg)
         },
-        |_e: &String| true, // all HTTP/transport errors are retryable
+        |_e: &String| true,
         &mut sleep_fn,
         &mut jitter_source,
     );
@@ -99,19 +126,26 @@ where
     match result {
         Ok(()) => Ok(()),
         Err(e) => {
+            let last = last_error_msg.into_inner();
+            let status = last_status.into_inner();
+            let entry = DlqEntry {
+                payload: payload.to_string(),
+                failed_at_timestamp: now_fn(),
+                last_status_code: status,
+                attempts_made: config.max_retries,
+                last_error: last.clone(),
+            };
             dlq.entry(config.dead_letter_storage_key.clone())
                 .or_default()
-                .push(payload.to_string());
+                .push(entry);
 
-            let attempts_made = config.max_retries;
-            let last = last_error_msg.into_inner();
             Err(AnchorKitError::with_context(
                 ErrorCode::WebhookDeliveryFailed,
                 &format!(
                     "Webhook delivery failed after {} attempt(s): {}",
-                    attempts_made, e
+                    config.max_retries, e
                 ),
-                &format!("attempts_made={} last_error={}", attempts_made, last),
+                &format!("attempts_made={} last_status={} last_error={}", config.max_retries, status, last),
             ))
         }
     }
@@ -121,10 +155,158 @@ where
 // DLQ inspection
 // ---------------------------------------------------------------------------
 
-/// Return all payloads stored under `key` in the DLQ, or an empty slice.
+/// Return all [`DlqEntry`] records stored under `key` in the DLQ, or an empty slice.
 pub fn get_dead_letter_webhooks<'a>(
-    dlq: &'a BTreeMap<String, Vec<String>>,
+    dlq: &'a BTreeMap<String, Vec<DlqEntry>>,
     key: &str,
-) -> &'a [String] {
+) -> &'a [DlqEntry] {
     dlq.get(key).map(Vec::as_slice).unwrap_or(&[])
+}
+
+/// Query DLQ entries filtered by minimum HTTP status code and time range.
+///
+/// Returns entries where `last_status_code >= min_status` (use 0 to match all)
+/// and `failed_at_timestamp` is within `[from_ts, to_ts]` (inclusive).
+/// Pass `to_ts = u64::MAX` to match all entries up to the present.
+pub fn query_dlq<'a>(
+    dlq: &'a BTreeMap<String, Vec<DlqEntry>>,
+    key: &str,
+    min_status: u16,
+    from_ts: u64,
+    to_ts: u64,
+) -> Vec<&'a DlqEntry> {
+    dlq.get(key)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter(|e| {
+                    e.last_status_code >= min_status
+                        && e.failed_at_timestamp >= from_ts
+                        && e.failed_at_timestamp <= to_ts
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use alloc::collections::BTreeMap;
+
+    fn make_config(max_retries: u32) -> WebhookDeliveryConfig {
+        WebhookDeliveryConfig {
+            endpoint_url: "https://example.com/hook".to_string(),
+            max_retries,
+            retry_delay_ms: 10,
+            timeout_ms: 1000,
+            retry_config: RetryConfig {
+                max_attempts: max_retries,
+                base_delay_ms: 1,
+                multiplier: 1,
+                max_delay_ms: 10,
+            },
+            dead_letter_storage_key: "test-key".to_string(),
+        }
+    }
+
+    #[test]
+    fn deliver_succeeds_on_first_attempt() {
+        let mut dlq: BTreeMap<String, Vec<DlqEntry>> = BTreeMap::new();
+        let result = deliver_webhook(
+            &make_config(3),
+            "payload",
+            &mut dlq,
+            |_, _| Ok(200),
+            |_| {},
+            || 1000,
+        );
+        assert!(result.is_ok());
+        assert!(dlq.is_empty());
+    }
+
+    #[test]
+    fn deliver_stores_dlq_entry_after_exhaustion() {
+        let mut dlq: BTreeMap<String, Vec<DlqEntry>> = BTreeMap::new();
+        let result = deliver_webhook(
+            &make_config(2),
+            "my-payload",
+            &mut dlq,
+            |_, _| Ok(503),
+            |_| {},
+            || 9999,
+        );
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, ErrorCode::WebhookDeliveryFailed);
+
+        let entries = get_dead_letter_webhooks(&dlq, "test-key");
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.payload, "my-payload");
+        assert_eq!(entry.last_status_code, 503);
+        assert_eq!(entry.attempts_made, 2);
+        assert_eq!(entry.failed_at_timestamp, 9999);
+        assert!(!entry.last_error.is_empty());
+    }
+
+    #[test]
+    fn deliver_stores_dlq_entry_on_transport_error() {
+        let mut dlq: BTreeMap<String, Vec<DlqEntry>> = BTreeMap::new();
+        let result = deliver_webhook(
+            &make_config(1),
+            "payload",
+            &mut dlq,
+            |_, _| Err("connection refused".to_string()),
+            |_| {},
+            || 42,
+        );
+        assert!(result.is_err());
+        let entries = get_dead_letter_webhooks(&dlq, "test-key");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].last_status_code, 0); // transport failure
+        assert_eq!(entries[0].attempts_made, 1);
+    }
+
+    #[test]
+    fn multiple_failures_accumulate_in_dlq() {
+        let mut dlq: BTreeMap<String, Vec<DlqEntry>> = BTreeMap::new();
+        let config = make_config(1);
+        for i in 0..3u64 {
+            let _ = deliver_webhook(
+                &config,
+                &alloc::format!("payload-{}", i),
+                &mut dlq,
+                |_, _| Ok(500),
+                |_| {},
+                move || i * 100,
+            );
+        }
+        let entries = get_dead_letter_webhooks(&dlq, "test-key");
+        assert_eq!(entries.len(), 3);
+    }
+
+    #[test]
+    fn query_dlq_filters_by_status_and_time() {
+        let mut dlq: BTreeMap<String, Vec<DlqEntry>> = BTreeMap::new();
+        let key = "test-key";
+        dlq.entry(key.to_string()).or_default().extend([
+            DlqEntry { payload: "a".to_string(), failed_at_timestamp: 100, last_status_code: 500, attempts_made: 1, last_error: "e".to_string() },
+            DlqEntry { payload: "b".to_string(), failed_at_timestamp: 200, last_status_code: 503, attempts_made: 1, last_error: "e".to_string() },
+            DlqEntry { payload: "c".to_string(), failed_at_timestamp: 300, last_status_code: 0,   attempts_made: 1, last_error: "e".to_string() },
+        ]);
+
+        // All entries
+        assert_eq!(query_dlq(&dlq, key, 0, 0, u64::MAX).len(), 3);
+        // Only 5xx
+        assert_eq!(query_dlq(&dlq, key, 500, 0, u64::MAX).len(), 2);
+        // Time range
+        assert_eq!(query_dlq(&dlq, key, 0, 150, 250).len(), 1);
+        // No match
+        assert_eq!(query_dlq(&dlq, key, 0, 400, 500).len(), 0);
+    }
 }


### PR DESCRIPTION


#231 - sep10_jwt: validate iss claim presence, reject non-EdDSA algorithms
       (RS256/HS256/none etc.), add parse_json_iss helper
     - contract: add rotate_sep10_key (admin, preserves old key for drain)
       and get_sep10_key; new tests for missing iss, algorithm mismatch

#233 - rate_limiter: add validate_config rejecting zero max_submissions/
       window_length; update_config validates before persisting
     - new tests: zero-value rejection, exact window rollover boundary,
       max-submission error consistency

#234 - webhook: replace raw String DLQ with structured DlqEntry (payload,
       failed_at_timestamp, last_status_code, attempts_made, last_error)
     - add now_fn injectable timestamp param to deliver_webhook
     - add query_dlq filtered by status code and time range
     - add retry_delay_ms and timeout_ms fields to WebhookDeliveryConfig
     - new tests covering DLQ content, transport errors, query filtering

#235 - sep24: validate_interactive_url now rejects userinfo (user:pass@host),
       IP literals ([::1]), host > 253 chars, path > 2048 chars
     - new tests for each rejection case and valid URL acceptance
Closes #231 
Closes #233 
Closes #234 
Closes #235 