### PR TITLE
feat: add health check APIs and CLI diagnostics

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -326,6 +326,49 @@ pub struct KycRecord {
 }
 
 // ---------------------------------------------------------------------------
+// Health check types (#268)
+// ---------------------------------------------------------------------------
+
+/// Overall contract health state returned by [`AnchorKitContract::get_health_status`].
+#[contracttype]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum HealthStatus {
+    /// Contract is initialized and all subsystems are operational.
+    Healthy = 0,
+    /// Contract is initialized but one or more subsystems are using fallback defaults.
+    Degraded = 1,
+    /// Contract has not been initialized.
+    Unavailable = 2,
+}
+
+/// Metadata freshness report returned by [`AnchorKitContract::get_metadata_freshness`].
+#[contracttype]
+#[derive(Clone)]
+pub struct MetadataFreshnessReport {
+    pub anchor: Address,
+    pub state: MetadataCacheState,
+    /// Age of the cached entry in seconds (0 when missing).
+    pub age_seconds: u64,
+    /// Whether a background refresh is recommended.
+    pub needs_refresh: bool,
+}
+
+/// Rate limiter health report returned by [`AnchorKitContract::get_rate_limiter_health`].
+#[contracttype]
+#[derive(Clone)]
+pub struct RateLimiterHealth {
+    pub attestor: Address,
+    /// Effective submission count in the current window (0 if window expired).
+    pub submission_count: u32,
+    pub max_submissions: u32,
+    pub window_length: u32,
+    pub window_start_ledger: u32,
+    /// `true` when the attestor has reached the submission limit.
+    pub is_throttled: bool,
+}
+
+// ---------------------------------------------------------------------------
 // Metadata cache types
 // ---------------------------------------------------------------------------
 
@@ -3350,6 +3393,82 @@ impl AnchorKitContract {
         env.storage()
             .temporary()
             .extend_ttl(&key, SPAN_TTL, SPAN_TTL);
+    }
+
+    // -----------------------------------------------------------------------
+    // Health check APIs (#268)
+    // -----------------------------------------------------------------------
+
+    /// Overall service health status.
+    ///
+    /// Returns `Healthy` when the contract is initialized and the rate limiter
+    /// config is present. Returns `Degraded` when initialized but the rate
+    /// limiter config is missing (default fallback in use). Returns
+    /// `Unavailable` when the contract has not been initialized.
+    pub fn get_health_status(env: Env) -> HealthStatus {
+        if !env.storage().persistent().has(&initialized_key(&env)) {
+            return HealthStatus::Unavailable;
+        }
+        let rl_key = make_storage_key(&env, &[b"RL_CONFIG"]);
+        if env.storage().persistent().has(&rl_key) {
+            HealthStatus::Healthy
+        } else {
+            HealthStatus::Degraded
+        }
+    }
+
+    /// Metadata freshness report for a given anchor.
+    ///
+    /// Returns the cache state together with the age of the entry in seconds
+    /// (zero when missing). Callers can use this to detect stale or expired
+    /// metadata without triggering a panic.
+    pub fn get_metadata_freshness(env: Env, anchor: Address) -> MetadataFreshnessReport {
+        let key = (symbol_short!("METACACHE"), anchor.clone());
+        match env.storage().temporary().get::<_, MetadataCache>(&key) {
+            None => MetadataFreshnessReport {
+                anchor,
+                state: MetadataCacheState::Missing,
+                age_seconds: 0,
+                needs_refresh: false,
+            },
+            Some(entry) => {
+                let now = env.ledger().timestamp();
+                let age = now.saturating_sub(entry.cached_at);
+                let state = if age <= entry.ttl_seconds {
+                    MetadataCacheState::Fresh
+                } else if age <= entry.ttl_seconds.saturating_add(entry.stale_ttl_seconds) {
+                    MetadataCacheState::Stale
+                } else {
+                    MetadataCacheState::Expired
+                };
+                MetadataFreshnessReport {
+                    anchor,
+                    state,
+                    age_seconds: age,
+                    needs_refresh: entry.needs_refresh || state != MetadataCacheState::Fresh,
+                }
+            }
+        }
+    }
+
+    /// Rate limiter health for a given attestor.
+    ///
+    /// Returns the current submission count, window start ledger, configured
+    /// limits, and whether the attestor is currently throttled.
+    pub fn get_rate_limiter_health(env: Env, attestor: Address) -> RateLimiterHealth {
+        let config = RateLimiter::get_config(&env);
+        let state = RateLimiter::get_state(&env, &attestor);
+        let current_ledger = env.ledger().sequence();
+        let window_expired = state.window_start_ledger.saturating_add(config.window_length) <= current_ledger;
+        let effective_count = if window_expired { 0 } else { state.submission_count };
+        RateLimiterHealth {
+            attestor,
+            submission_count: effective_count,
+            max_submissions: config.max_submissions,
+            window_length: config.window_length,
+            window_start_ledger: state.window_start_ledger,
+            is_throttled: !window_expired && effective_count >= config.max_submissions,
+        }
     }
 
     /// Append `operation_name` to the `RequestContext` stored under `root_id_bytes`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ pub use sep24::{
     RawInteractiveDepositResponse, RawInteractiveWithdrawalResponse, RawSep24TransactionResponse,
 };
 pub use contract::{AnchorKitContract, EndpointUpdated, CacheConfig};
+pub use contract::{HealthStatus, MetadataFreshnessReport, RateLimiterHealth};
 pub use transaction_state_tracker::{TransactionState, TransactionStateRecord, RecoveryMetadata};
 pub use transaction_state_tracker::{StorageBudgetMonitor, TransactionStateTracker};
 pub mod streaming_monitor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,6 +268,24 @@ enum Commands {
         #[arg(long)]
         fix: bool,
     },
+    /// Query contract health, metadata freshness, and rate limiter status
+    Health {
+        /// Contract ID to query (or set ANCHOR_CONTRACT_ID)
+        #[arg(long)]
+        contract_id: String,
+        #[arg(long, default_value = "testnet")]
+        network: String,
+        #[arg(long)]
+        secret_key: Option<String>,
+        #[arg(long)]
+        keypair_file: Option<String>,
+        /// Anchor address to check metadata freshness for (optional)
+        #[arg(long)]
+        anchor: Option<String>,
+        /// Attestor address to check rate limiter health for (optional)
+        #[arg(long)]
+        attestor: Option<String>,
+    },
     /// Manage custom network profiles
     Network {
         #[command(subcommand)]
@@ -943,6 +961,62 @@ fn doctor(network: &str, fix: bool) {
     }
 }
 
+// ── Health check command (#268) ───────────────────────────────────────────────
+
+fn health_check(contract_id: &str, network: &str, source: &SecretKey, anchor: Option<&str>, attestor: Option<&str>) {
+    println!("\n🏥 AnchorKit Health Check\n");
+
+    // 1. Overall service health
+    let status_raw = stellar_invoke(contract_id, source, network, &["get_health_status"]);
+    let status_label = match status_raw.trim().trim_matches('"') {
+        "0" | "Healthy"     => "\x1b[32m✓ Healthy\x1b[0m",
+        "1" | "Degraded"    => "\x1b[33m⚠ Degraded\x1b[0m",
+        _                   => "\x1b[31m✗ Unavailable\x1b[0m",
+    };
+    println!("  Service Status : {status_label}");
+
+    // 2. Metadata freshness (optional — only when --anchor is supplied)
+    if let Some(anchor_addr) = anchor {
+        let freshness_raw = stellar_invoke(contract_id, source, network, &[
+            "get_metadata_freshness",
+            "--anchor", anchor_addr,
+        ]);
+        // Parse the returned struct fields from JSON-like output
+        let state_label = if freshness_raw.contains("\"Fresh\"") || freshness_raw.contains("\"state\":0") {
+            "\x1b[32mFresh\x1b[0m"
+        } else if freshness_raw.contains("\"Stale\"") || freshness_raw.contains("\"state\":2") {
+            "\x1b[33mStale — refresh recommended\x1b[0m"
+        } else if freshness_raw.contains("\"Expired\"") || freshness_raw.contains("\"state\":3") {
+            "\x1b[31mExpired — must refresh\x1b[0m"
+        } else {
+            "\x1b[31mMissing — no cache entry\x1b[0m"
+        };
+        println!("  Metadata Cache : {state_label}");
+        println!("  Anchor         : {anchor_addr}");
+    }
+
+    // 3. Rate limiter health (optional — only when --attestor is supplied)
+    if let Some(attestor_addr) = attestor {
+        let rl_raw = stellar_invoke(contract_id, source, network, &[
+            "get_rate_limiter_health",
+            "--attestor", attestor_addr,
+        ]);
+        let throttled = rl_raw.contains("\"is_throttled\":true") || rl_raw.contains("is_throttled: true");
+        let rl_label = if throttled {
+            "\x1b[31m✗ Throttled\x1b[0m"
+        } else {
+            "\x1b[32m✓ OK\x1b[0m"
+        };
+        println!("  Rate Limiter   : {rl_label}");
+        println!("  Attestor       : {attestor_addr}");
+        if throttled {
+            eprintln!("\n  ⚠  Attestor has reached the submission limit for the current window.");
+        }
+    }
+
+    println!();
+}
+
 // ── Network command ───────────────────────────────────────────────────────────
 
 fn network_cmd(action: NetworkAction) {
@@ -1210,6 +1284,10 @@ fn main() {
         }
         Commands::Doctor { fix } => {
             doctor(&network, fix);
+        }
+        Commands::Health { contract_id, network: cmd_net, secret_key, keypair_file, anchor, attestor } => {
+            let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), None);
+            health_check(&contract_id, &cmd_net, &source, anchor.as_deref(), attestor.as_deref());
         }
         Commands::Network { action } => {
             network_cmd(action);

--- a/tests/health_check_tests.rs
+++ b/tests/health_check_tests.rs
@@ -1,0 +1,196 @@
+//! Tests for health check APIs (#268):
+//! - get_health_status
+//! - get_metadata_freshness
+//! - get_rate_limiter_health
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env,
+};
+use anchorkit::contract::{
+    AnchorKitContract, AnchorKitContractClient, AnchorMetadata, HealthStatus,
+    MetadataCacheState, RateLimitConfig,
+};
+use anchorkit::RateLimiter;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup_env() -> (Env, AnchorKitContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, AnchorKitContract);
+    let client = AnchorKitContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+fn init_contract(env: &Env, client: &AnchorKitContractClient) -> Address {
+    let admin = Address::generate(env);
+    let public_key = soroban_sdk::BytesN::from_array(env, &[0u8; 32]);
+    client.initialize(&admin, &public_key);
+    admin
+}
+
+fn make_metadata(env: &Env, anchor: &Address) -> AnchorMetadata {
+    AnchorMetadata {
+        anchor: anchor.clone(),
+        reputation_score: 90,
+        liquidity_score: 80,
+        uptime_percentage: 99,
+        total_volume: 1_000_000,
+        average_settlement_time: 60,
+        is_active: true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// get_health_status
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_health_status_unavailable_before_init() {
+    let (_env, client) = setup_env();
+    assert_eq!(client.get_health_status(), HealthStatus::Unavailable);
+}
+
+#[test]
+fn test_health_status_degraded_after_init_no_rl_config() {
+    let (env, client) = setup_env();
+    init_contract(&env, &client);
+    // No explicit rate-limit config stored → Degraded (using fallback defaults)
+    assert_eq!(client.get_health_status(), HealthStatus::Degraded);
+}
+
+#[test]
+fn test_health_status_healthy_after_init_with_rl_config() {
+    let (env, client) = setup_env();
+    init_contract(&env, &client);
+    // set_rate_limit_config(max_submissions, window_length)
+    client.set_rate_limit_config(&10u32, &100u32);
+    assert_eq!(client.get_health_status(), HealthStatus::Healthy);
+}
+
+// ---------------------------------------------------------------------------
+// get_metadata_freshness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_metadata_freshness_missing() {
+    let (env, client) = setup_env();
+    init_contract(&env, &client);
+    let anchor = Address::generate(&env);
+    let report = client.get_metadata_freshness(&anchor);
+    assert_eq!(report.state, MetadataCacheState::Missing);
+    assert_eq!(report.age_seconds, 0);
+    assert!(!report.needs_refresh);
+}
+
+#[test]
+fn test_metadata_freshness_fresh() {
+    let (env, client) = setup_env();
+    init_contract(&env, &client);
+    let anchor = Address::generate(&env);
+    let metadata = make_metadata(&env, &anchor);
+    // Cache with a 3600-second TTL
+    client.cache_metadata(&anchor, &metadata, &3600u64);
+    let report = client.get_metadata_freshness(&anchor);
+    assert_eq!(report.state, MetadataCacheState::Fresh);
+    assert!(!report.needs_refresh);
+}
+
+#[test]
+fn test_metadata_freshness_stale() {
+    let (env, client) = setup_env();
+    init_contract(&env, &client);
+    let anchor = Address::generate(&env);
+    let metadata = make_metadata(&env, &anchor);
+    // Cache with 10s TTL and 20s stale window
+    client.cache_metadata_swr(&anchor, &metadata, &10u64, &20u64);
+
+    // Advance time past the primary TTL but within the stale window
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + 15,
+        ..env.ledger().get()
+    });
+
+    let report = client.get_metadata_freshness(&anchor);
+    assert_eq!(report.state, MetadataCacheState::Stale);
+    assert!(report.needs_refresh);
+}
+
+#[test]
+fn test_metadata_freshness_expired() {
+    let (env, client) = setup_env();
+    init_contract(&env, &client);
+    let anchor = Address::generate(&env);
+    let metadata = make_metadata(&env, &anchor);
+    client.cache_metadata_swr(&anchor, &metadata, &10u64, &5u64);
+
+    // Advance time past both TTL and stale window
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + 20,
+        ..env.ledger().get()
+    });
+
+    let report = client.get_metadata_freshness(&anchor);
+    assert_eq!(report.state, MetadataCacheState::Expired);
+    assert!(report.needs_refresh);
+}
+
+// ---------------------------------------------------------------------------
+// get_rate_limiter_health
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_rate_limiter_health_not_throttled() {
+    let (env, client) = setup_env();
+    init_contract(&env, &client);
+    client.set_rate_limit_config(&5u32, &100u32);
+
+    let attestor = Address::generate(&env);
+    let report = client.get_rate_limiter_health(&attestor);
+    assert_eq!(report.submission_count, 0);
+    assert_eq!(report.max_submissions, 5);
+    assert!(!report.is_throttled);
+}
+
+#[test]
+fn test_rate_limiter_health_throttled() {
+    let (env, client) = setup_env();
+    init_contract(&env, &client);
+    client.set_rate_limit_config(&2u32, &100u32);
+
+    let config = RateLimitConfig { max_submissions: 2, window_length: 100 };
+    let attestor = Address::generate(&env);
+    // Exhaust the limit
+    RateLimiter::check_and_increment(&env, &attestor, &config).unwrap();
+    RateLimiter::check_and_increment(&env, &attestor, &config).unwrap();
+
+    let report = client.get_rate_limiter_health(&attestor);
+    assert_eq!(report.submission_count, 2);
+    assert!(report.is_throttled);
+}
+
+#[test]
+fn test_rate_limiter_health_resets_after_window() {
+    let (env, client) = setup_env();
+    init_contract(&env, &client);
+    client.set_rate_limit_config(&2u32, &10u32);
+
+    let config = RateLimitConfig { max_submissions: 2, window_length: 10 };
+    let attestor = Address::generate(&env);
+    RateLimiter::check_and_increment(&env, &attestor, &config).unwrap();
+    RateLimiter::check_and_increment(&env, &attestor, &config).unwrap();
+
+    // Advance ledger past the window
+    env.ledger().set(LedgerInfo {
+        sequence_number: env.ledger().sequence() + 11,
+        ..env.ledger().get()
+    });
+
+    let report = client.get_rate_limiter_health(&attestor);
+    // Window expired → effective count is 0, not throttled
+    assert_eq!(report.submission_count, 0);
+    assert!(!report.is_throttled);
+}


### PR DESCRIPTION
- Add HealthStatus, MetadataFreshnessReport, RateLimiterHealth types to contract.rs
- Add get_health_status, get_metadata_freshness, get_rate_limiter_health contract methods
- Add Health subcommand to CLI (anchorkit health --contract-id ... [--anchor ...] [--attestor ...])
- Export new types from lib.rs
- Add tests/health_check_tests.rs covering healthy, degraded, stale, expired, and throttled states

Closes #268
Closes #270 
Closes #269 
Closes #271 