### PR TITLE
feat(contract): add endpoint proof-of-possession and anchor health metrics

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     Env, String, Symbol, Vec,
 };
 
+extern crate alloc;
+
 use crate::deterministic_hash::{compute_payload_hash, verify_payload_hash};
 use crate::errors::ErrorCode;
 use crate::rate_limiter::RateLimiter;
@@ -308,6 +310,58 @@ pub struct CachedToml {
 }
 
 const MIN_TEMP_TTL: u32 = 15; // min_temp_entry_ttl - 1
+
+// ---------------------------------------------------------------------------
+// Proof-of-possession types
+// ---------------------------------------------------------------------------
+
+/// A challenge issued to an anchor to prove control of its registered endpoint.
+///
+/// The anchor must sign `nonce` with the Ed25519 key stored via
+/// `set_sep10_jwt_verifying_key` and return the signature via
+/// `verify_pop_response`.  The challenge expires after `expires_at`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EndpointChallenge {
+    pub attestor: Address,
+    /// Random nonce (16 bytes derived from ledger hash) the attestor must sign.
+    pub nonce: Bytes,
+    /// Ledger timestamp after which this challenge is no longer valid.
+    pub expires_at: u64,
+    /// Whether this challenge has already been successfully verified.
+    pub verified: bool,
+}
+
+/// Stored record of a completed proof-of-possession verification.
+#[contracttype]
+#[derive(Clone)]
+pub struct PopVerificationResult {
+    pub attestor: Address,
+    pub nonce: Bytes,
+    pub verified_at: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Anchor health metric types
+// ---------------------------------------------------------------------------
+
+/// Accumulated health metrics for a single anchor endpoint.
+#[contracttype]
+#[derive(Clone)]
+pub struct AnchorHealthMetrics {
+    pub anchor: Address,
+    pub success_count: u64,
+    pub failure_count: u64,
+    /// Consecutive failures since the last success (reset on any success).
+    pub consecutive_failures: u32,
+    /// Ledger timestamp of the most recent response (success or failure).
+    pub last_response_at: u64,
+    /// Ledger timestamp of the most recent successful response (0 if none).
+    pub last_success_at: u64,
+    /// Uptime in basis points (0–10000).  10000 = 100 %.
+    /// Computed as: success_count * 10000 / (success_count + failure_count).
+    pub uptime_bps: u32,
+}
 
 // ---------------------------------------------------------------------------
 // Event structs
@@ -2051,6 +2105,275 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         match Self::get_anchor_asset_info(env, anchor, asset_code) {
             asset => asset.withdrawal_enabled,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Proof-of-possession for anchor endpoints
+    // -----------------------------------------------------------------------
+
+    /// Issue a proof-of-possession challenge for `attestor`'s registered endpoint.
+    ///
+    /// Generates a 16-byte nonce from the current ledger hash and stores it
+    /// with a TTL of `ttl_seconds` (capped at 3600).  The attestor must sign
+    /// the nonce with the Ed25519 key registered via `set_sep10_jwt_verifying_key`
+    /// and call `verify_pop_response` before the challenge expires.
+    ///
+    /// Admin-only — prevents spam issuance.
+    pub fn issue_pop_challenge(env: Env, attestor: Address, ttl_seconds: u64) -> EndpointChallenge {
+        Self::require_admin(&env);
+        Self::check_attestor(&env, &attestor);
+
+        // Cap TTL at 1 hour.
+        let effective_ttl = if ttl_seconds == 0 || ttl_seconds > 3600 { 3600 } else { ttl_seconds };
+
+        // Derive a 16-byte nonce from sha256(timestamp_be || sequence_be || attestor_bytes).
+        let ts = env.ledger().timestamp();
+        let seq = env.ledger().sequence();
+        let mut nonce_input = Bytes::new(&env);
+        for b in ts.to_be_bytes().iter() {
+            nonce_input.push_back(*b);
+        }
+        for b in seq.to_be_bytes().iter() {
+            nonce_input.push_back(*b);
+        }
+        let addr_str = attestor.to_string();
+        let addr_len = addr_str.len() as usize;
+        let mut addr_buf = alloc::vec![0u8; addr_len];
+        addr_str.copy_into_slice(&mut addr_buf);
+        for b in addr_buf.iter() {
+            nonce_input.push_back(*b);
+        }
+        let hash = env.crypto().sha256(&nonce_input).to_bytes();
+        let mut nonce = Bytes::new(&env);
+        for i in 0..16u32 {
+            nonce.push_back(hash.get(i).unwrap());
+        }
+
+        let now = env.ledger().timestamp();
+        let challenge = EndpointChallenge {
+            attestor: attestor.clone(),
+            nonce: nonce.clone(),
+            expires_at: now + effective_ttl,
+            verified: false,
+        };
+
+        let key = (symbol_short!("POPCHAL"), attestor.clone());
+        env.storage().persistent().set(&key, &challenge);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        challenge
+    }
+
+    /// Verify a proof-of-possession response for `attestor`.
+    ///
+    /// `signature` must be a 64-byte Ed25519 signature over the stored nonce,
+    /// produced by the key registered via `set_sep10_jwt_verifying_key`.
+    ///
+    /// On success the challenge is marked verified and a `PopVerificationResult`
+    /// is stored.  Panics with `ProofOfPossessionFailed` on any mismatch.
+    pub fn verify_pop_response(env: Env, attestor: Address, signature: Bytes) -> PopVerificationResult {
+        Self::check_attestor(&env, &attestor);
+
+        // Load the pending challenge.
+        let key = (symbol_short!("POPCHAL"), attestor.clone());
+        let mut challenge: EndpointChallenge = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ChallengeNotFound));
+
+        // Reject expired challenges.
+        let now = env.ledger().timestamp();
+        if now >= challenge.expires_at {
+            panic_with_error!(&env, ErrorCode::ChallengeExpired);
+        }
+
+        // Signature must be exactly 64 bytes (Ed25519).
+        if signature.len() != 64 {
+            panic_with_error!(&env, ErrorCode::ProofOfPossessionFailed);
+        }
+
+        // Load the stored Ed25519 verifying key for this attestor.
+        let pk: Bytes = env
+            .storage()
+            .persistent()
+            .get(&(symbol_short!("SEP10KEY"), attestor.clone()))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ProofOfPossessionFailed));
+
+        if pk.len() != 32 {
+            panic_with_error!(&env, ErrorCode::ProofOfPossessionFailed);
+        }
+
+        // Verify Ed25519 signature: sig over nonce using pk.
+        let mut pk_arr = [0u8; 32];
+        for i in 0..32u32 {
+            pk_arr[i as usize] = pk.get(i).unwrap();
+        }
+        let pk_bytes: BytesN<32> = BytesN::from_array(&env, &pk_arr);
+
+        let mut sig_arr = [0u8; 64];
+        for i in 0..64u32 {
+            sig_arr[i as usize] = signature.get(i).unwrap();
+        }
+        let sig_bytes: BytesN<64> = BytesN::from_array(&env, &sig_arr);
+
+        // Soroban's ed25519_verify panics on failure — catch via the SDK.
+        env.crypto().ed25519_verify(&pk_bytes, &challenge.nonce, &sig_bytes);
+
+        // Mark challenge verified.
+        challenge.verified = true;
+        env.storage().persistent().set(&key, &challenge);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        let result = PopVerificationResult {
+            attestor: attestor.clone(),
+            nonce: challenge.nonce.clone(),
+            verified_at: now,
+        };
+
+        // Persist the verification result.
+        let result_key = (symbol_short!("POPRESULT"), attestor.clone());
+        env.storage().persistent().set(&result_key, &result);
+        env.storage().persistent().extend_ttl(&result_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("pop"), symbol_short!("verified"), attestor),
+            (),
+        );
+
+        result
+    }
+
+    /// Return the current proof-of-possession challenge for `attestor`, if any.
+    pub fn get_pop_challenge(env: Env, attestor: Address) -> EndpointChallenge {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("POPCHAL"), attestor))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ChallengeNotFound))
+    }
+
+    /// Return the most recent successful PoP verification result for `attestor`.
+    pub fn get_pop_status(env: Env, attestor: Address) -> PopVerificationResult {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("POPRESULT"), attestor))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ChallengeNotFound))
+    }
+
+    // -----------------------------------------------------------------------
+    // Anchor health metrics
+    // -----------------------------------------------------------------------
+
+    /// Record a successful endpoint response for `anchor`.
+    ///
+    /// Increments `success_count`, resets `consecutive_failures`, updates
+    /// `last_response_at` and `last_success_at`, and recomputes `uptime_bps`.
+    /// Admin-only so only trusted callers can update metrics.
+    pub fn record_endpoint_success(env: Env, anchor: Address) {
+        Self::require_admin(&env);
+        let now = env.ledger().timestamp();
+        let key = (symbol_short!("HEALTH"), anchor.clone());
+        let mut metrics: AnchorHealthMetrics = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(AnchorHealthMetrics {
+                anchor: anchor.clone(),
+                success_count: 0,
+                failure_count: 0,
+                consecutive_failures: 0,
+                last_response_at: 0,
+                last_success_at: 0,
+                uptime_bps: 0,
+            });
+
+        metrics.success_count += 1;
+        metrics.consecutive_failures = 0;
+        metrics.last_response_at = now;
+        metrics.last_success_at = now;
+        let total = metrics.success_count + metrics.failure_count;
+        metrics.uptime_bps = ((metrics.success_count * 10_000) / total) as u32;
+
+        env.storage().persistent().set(&key, &metrics);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    /// Record a failed endpoint response for `anchor`.
+    ///
+    /// Increments `failure_count` and `consecutive_failures`, updates
+    /// `last_response_at`, and recomputes `uptime_bps`.
+    /// Admin-only.
+    pub fn record_endpoint_failure(env: Env, anchor: Address) {
+        Self::require_admin(&env);
+        let now = env.ledger().timestamp();
+        let key = (symbol_short!("HEALTH"), anchor.clone());
+        let mut metrics: AnchorHealthMetrics = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(AnchorHealthMetrics {
+                anchor: anchor.clone(),
+                success_count: 0,
+                failure_count: 0,
+                consecutive_failures: 0,
+                last_response_at: 0,
+                last_success_at: 0,
+                uptime_bps: 0,
+            });
+
+        metrics.failure_count += 1;
+        metrics.consecutive_failures += 1;
+        metrics.last_response_at = now;
+        let total = metrics.success_count + metrics.failure_count;
+        metrics.uptime_bps = ((metrics.success_count * 10_000) / total) as u32;
+
+        env.storage().persistent().set(&key, &metrics);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    /// Return the health metrics for `anchor`.
+    /// Panics with `HealthMetricsNotFound` if no metrics have been recorded yet.
+    pub fn get_anchor_health(env: Env, anchor: Address) -> AnchorHealthMetrics {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("HEALTH"), anchor))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::HealthMetricsNotFound))
+    }
+
+    /// Reset health metrics for `anchor` back to zero.  Admin-only.
+    pub fn reset_anchor_health(env: Env, anchor: Address) {
+        Self::require_admin(&env);
+        let key = (symbol_short!("HEALTH"), anchor.clone());
+        let reset = AnchorHealthMetrics {
+            anchor: anchor.clone(),
+            success_count: 0,
+            failure_count: 0,
+            consecutive_failures: 0,
+            last_response_at: 0,
+            last_success_at: 0,
+            uptime_bps: 0,
+        };
+        env.storage().persistent().set(&key, &reset);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    /// Return health metrics for all anchors in ANCHLIST that have recorded data.
+    pub fn list_anchor_health(env: Env) -> Vec<AnchorHealthMetrics> {
+        let list_key = soroban_sdk::vec![&env, symbol_short!("ANCHLIST")];
+        let anchors: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<Address>>(&list_key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut results = Vec::new(&env);
+        for anchor in anchors.iter() {
+            let key = (symbol_short!("HEALTH"), anchor.clone());
+            if let Some(metrics) = env.storage().persistent().get::<_, AnchorHealthMetrics>(&key) {
+                results.push_back(metrics);
+            }
+        }
+        results
     }
 
     // -----------------------------------------------------------------------

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env, String,
-    Symbol, Vec,
+    contract, contractimpl, contracttype, panic_with_error, symbol_short, Address, Bytes, BytesN,
+    Env, String, Symbol, Vec,
 };
 
 use crate::deterministic_hash::{compute_payload_hash, verify_payload_hash};
@@ -21,11 +21,8 @@ pub struct Session {
     pub created_at: u64,
     pub nonce: u64,
     pub operation_count: u64,
- feat/session-expiry-check
     pub session_ttl_seconds: u64,
-
     pub closed: bool,
- main
 }
 
 #[contracttype]
@@ -168,7 +165,7 @@ pub struct RoutingOptions {
 // ---------------------------------------------------------------------------
 
 #[contracttype]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u32)]
 pub enum KycStatus {
     Pending = 0,
@@ -192,6 +189,46 @@ pub struct KycRecord {
     pub status: u32,
     pub timestamp: u64,
     pub rejection_reason_hash: Option<Bytes>,
+}
+
+// ---------------------------------------------------------------------------
+// Batch transaction query types
+// ---------------------------------------------------------------------------
+
+/// A page of transaction records returned by a batch query.
+#[contracttype]
+#[derive(Clone)]
+pub struct TransactionBatchResult {
+    /// The records in this page (at most `limit` entries).
+    pub records: Vec<TransactionStateRecord>,
+    /// Total number of records stored in the requested id range.
+    pub total: u32,
+}
+
+/// Aggregated counts per state, used for audit / reconciliation reports.
+#[contracttype]
+#[derive(Clone)]
+pub struct TransactionSummary {
+    pub pending_count: u32,
+    pub in_progress_count: u32,
+    pub completed_count: u32,
+    pub failed_count: u32,
+    pub total_count: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Anchor metadata version history types
+// ---------------------------------------------------------------------------
+
+/// A single immutable snapshot of anchor metadata captured at update time.
+#[contracttype]
+#[derive(Clone)]
+pub struct AnchorMetadataVersion {
+    /// Monotonically increasing version number (1-based).
+    pub version: u32,
+    pub metadata: RoutingAnchorMeta,
+    /// Ledger timestamp when this version was written.
+    pub updated_at: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -344,6 +381,15 @@ struct TxStateChangedEvent {
     timestamp: u64,
 }
 
+#[contracttype]
+#[derive(Clone)]
+struct WebhookEvent {
+    event_type: String,
+    transaction_id: u64,
+    timestamp: u64,
+    payload_hash: Bytes,
+}
+
 // ---------------------------------------------------------------------------
 // TTLs (in ledgers)
 // ---------------------------------------------------------------------------
@@ -365,6 +411,15 @@ fn kyc_record_key(subject: &Address) -> (Symbol, Address) {
 
 fn compliance_check_key(subject: &Address, check_type: &String) -> (Symbol, Address, String) {
     (symbol_short!("COMP"), subject.clone(), check_type.clone())
+}
+
+/// Convert a `soroban_sdk::String` to an `alloc::string::String` for use with
+/// functions that require a `&str` (e.g. domain validation).
+fn soroban_sdk_string_to_alloc(s: &String) -> alloc::string::String {
+    let len = s.len() as usize;
+    let mut buf = alloc::vec![0u8; len];
+    s.copy_into_slice(&mut buf);
+    alloc::string::String::from_utf8(buf).unwrap_or_default()
 }
 
 // ---------------------------------------------------------------------------
@@ -415,7 +470,7 @@ impl AnchorKitContract {
             input.push_back(*b);
         }
 
-        let hash = env.crypto().sha256(&input);
+        let hash = env.crypto().sha256(&input).to_bytes();
         let mut id = Bytes::new(&env);
         for i in 0..16u32 {
             id.push_back(hash.get(i).unwrap());
@@ -564,7 +619,10 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
     pub fn set_endpoint(env: Env, attestor: Address, endpoint: String) {
         attestor.require_auth();
         Self::check_attestor(&env, &attestor);
-        crate::validate_anchor_domain(endpoint.as_str()).map_err(|_| panic_with_error!(&env, ErrorCode::InvalidEndpointFormat))?;
+        let endpoint_str = soroban_sdk_string_to_alloc(&endpoint);
+        if crate::validate_anchor_domain(&endpoint_str).is_err() {
+            panic_with_error!(&env, ErrorCode::InvalidEndpointFormat);
+        }
         let key = (symbol_short!("ENDPOINT"), attestor.clone());
         env.storage().persistent().set(&key, &endpoint);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
@@ -596,12 +654,15 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
     pub fn register_webhook(env: Env, attestor: Address, webhook_url: String) {
         attestor.require_auth();
         Self::check_attestor(&env, &attestor);
-        crate::validate_anchor_domain(webhook_url.as_str()).map_err(|_| panic_with_error!(&env, ErrorCode::InvalidEndpointFormat))?;
+        let webhook_str = soroban_sdk_string_to_alloc(&webhook_url);
+        if crate::validate_anchor_domain(&webhook_str).is_err() {
+            panic_with_error!(&env, ErrorCode::InvalidEndpointFormat);
+        }
         let key = (symbol_short!("WEBHOOK"), attestor.clone());
         env.storage().persistent().set(&key, &webhook_url);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
         env.events().publish(
-            (symbol_short!("webhook"), symbol_short!("registered")),
+            (symbol_short!("webhook"), symbol_short!("reg")),
             EndpointUpdated {
                 attestor,
                 endpoint: webhook_url,
@@ -731,7 +792,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
     // Attestation submission with KYC enforcement
     // -----------------------------------------------------------------------
 
-    pub fn submit_attestation_with_kyc_check(
+    pub fn submit_attest_with_kyc(
         env: Env,
         issuer: Address,
         subject: Address,
@@ -1053,7 +1114,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         env.storage().persistent().set(&key, &record);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
         env.events().publish(
-            (symbol_short!("compliance"), symbol_short!("checked"), subject),
+            (symbol_short!("comply"), symbol_short!("checked"), subject),
             record,
         );
     }
@@ -1073,11 +1134,8 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
             created_at: now,
             nonce: 0,
             operation_count: 0,
- feat/session-expiry-check
             session_ttl_seconds: 3600,
-
             closed: false,
- main
         };
         let sess_key = (symbol_short!("SESS"), session_id);
         env.storage().persistent().set(&sess_key, &session);
@@ -1218,7 +1276,6 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         signature: Bytes,
     ) -> u64 {
         issuer.require_auth();
- feat/session-expiry-check
         let sess_key = (symbol_short!("SESS"), session_id);
         let session: Session = env
             .storage()
@@ -1229,9 +1286,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         if now > session.created_at + session.session_ttl_seconds {
             panic_with_error!(&env, ErrorCode::SessionExpired);
         }
-
         Self::require_session_open(&env, session_id);
- main
         Self::check_attestor(&env, &issuer);
         Self::enforce_rate_limit(&env, &issuer);
         Self::check_timestamp(&env, timestamp);
@@ -1566,6 +1621,33 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
             total_volume,
             is_active: true,
         };
+
+        // ---- version history ----
+        // Increment the per-anchor version counter and store a snapshot.
+        let vcnt_key = (symbol_short!("METAVCNT"), anchor.clone());
+        let next_version: u32 = env
+            .storage()
+            .persistent()
+            .get::<_, u32>(&vcnt_key)
+            .unwrap_or(0)
+            + 1;
+        env.storage().persistent().set(&vcnt_key, &next_version);
+        env.storage()
+            .persistent()
+            .extend_ttl(&vcnt_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        let snapshot = AnchorMetadataVersion {
+            version: next_version,
+            metadata: meta.clone(),
+            updated_at: env.ledger().timestamp(),
+        };
+        let snap_key = (symbol_short!("METAHIST"), anchor.clone(), next_version);
+        env.storage().persistent().set(&snap_key, &snapshot);
+        env.storage()
+            .persistent()
+            .extend_ttl(&snap_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        // ---- end version history ----
+
         let meta_key = (symbol_short!("ANCHMETA"), anchor.clone());
         env.storage().persistent().set(&meta_key, &meta);
         env.storage().persistent().extend_ttl(&meta_key, PERSISTENT_TTL, PERSISTENT_TTL);
@@ -1580,6 +1662,73 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
             env.storage().persistent().set(&list_key, &list);
             env.storage().persistent().extend_ttl(&list_key, PERSISTENT_TTL, PERSISTENT_TTL);
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Anchor metadata version history
+    // -----------------------------------------------------------------------
+
+    /// Return the total number of metadata versions stored for `anchor`.
+    pub fn get_anchor_meta_version_count(env: Env, anchor: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get::<_, u32>(&(symbol_short!("METAVCNT"), anchor))
+            .unwrap_or(0)
+    }
+
+    /// Return up to `limit` historical metadata versions for `anchor`, ordered
+    /// from oldest (version 1) to newest.  `limit` is capped at 50.
+    pub fn get_anchor_metadata_history(
+        env: Env,
+        anchor: Address,
+        limit: u32,
+    ) -> Vec<AnchorMetadataVersion> {
+        const MAX_HISTORY: u32 = 50;
+        let effective_limit = if limit == 0 || limit > MAX_HISTORY { MAX_HISTORY } else { limit };
+
+        let total: u32 = env
+            .storage()
+            .persistent()
+            .get::<_, u32>(&(symbol_short!("METAVCNT"), anchor.clone()))
+            .unwrap_or(0);
+
+        let mut results = Vec::new(&env);
+        if total == 0 {
+            return results;
+        }
+
+        // Return the most recent `effective_limit` versions in ascending order.
+        let start = if total > effective_limit { total - effective_limit + 1 } else { 1 };
+        let mut v = start;
+        while v <= total {
+            let snap_key = (symbol_short!("METAHIST"), anchor.clone(), v);
+            if let Some(snapshot) = env
+                .storage()
+                .persistent()
+                .get::<_, AnchorMetadataVersion>(&snap_key)
+            {
+                results.push_back(snapshot);
+            }
+            v += 1;
+        }
+        results
+    }
+
+    /// Return the metadata snapshot at a specific `version` number for `anchor`.
+    /// Panics with `ValidationError` if the version does not exist.
+    pub fn get_anchor_metadata_at_version(
+        env: Env,
+        anchor: Address,
+        version: u32,
+    ) -> AnchorMetadataVersion {
+        if version == 0 {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        let snap_key = (symbol_short!("METAHIST"), anchor.clone(), version);
+        env.storage()
+            .persistent()
+            .get::<_, AnchorMetadataVersion>(&snap_key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ValidationError))
     }
 
     /// Reactivate a previously deactivated anchor (admin-only). Sets `is_active = true`.
@@ -1845,7 +1994,7 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
                 return asset;
             }
         }
-        panic_with_error!(&env, ErrorCode::ValidationError);
+        panic_with_error!(&env, ErrorCode::ValidationError)
     }
 
     pub fn get_anchor_deposit_limits(
@@ -1926,6 +2075,102 @@ pub fn is_attestor(env: Env, attestor: Address) -> bool {
         env.storage().persistent().set(&key, &record);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
         record
+    }
+
+    // -----------------------------------------------------------------------
+    // Batch transaction queries (audit / reconciliation)
+    // -----------------------------------------------------------------------
+
+    /// Return up to `limit` transaction records whose IDs fall in
+    /// `[from_id, to_id]` (inclusive).  `limit` is capped at 100 to prevent
+    /// unbounded iteration.
+    ///
+    /// Records are returned in ascending ID order.  The `total` field in the
+    /// result reflects how many IDs in the range actually have a stored record.
+    pub fn get_transactions_in_range(
+        env: Env,
+        from_id: u64,
+        to_id: u64,
+        limit: u32,
+    ) -> TransactionBatchResult {
+        // Defensive bounds: require a valid, non-empty range.
+        if from_id > to_id {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        // Cap to prevent unbounded loops.
+        const MAX_BATCH: u32 = 100;
+        let effective_limit = if limit == 0 || limit > MAX_BATCH { MAX_BATCH } else { limit };
+
+        let mut records = Vec::new(&env);
+        let mut total: u32 = 0;
+
+        let mut id = from_id;
+        while id <= to_id {
+            let key = (symbol_short!("TXSTATE"), id);
+            if let Some(record) = env
+                .storage()
+                .persistent()
+                .get::<_, TransactionStateRecord>(&key)
+            {
+                total += 1;
+                if (records.len() as u32) < effective_limit {
+                    records.push_back(record);
+                }
+            }
+            id += 1;
+        }
+
+        TransactionBatchResult { records, total }
+    }
+
+    /// Return aggregated counts for all transaction IDs in `[from_id, to_id]`.
+    /// Scans at most 500 IDs to prevent unbounded loops.
+    pub fn summarize_transactions_by_status(
+        env: Env,
+        from_id: u64,
+        to_id: u64,
+    ) -> TransactionSummary {
+        if from_id > to_id {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        const MAX_SCAN: u64 = 500;
+        let scan_end = if to_id - from_id + 1 > MAX_SCAN {
+            from_id + MAX_SCAN - 1
+        } else {
+            to_id
+        };
+
+        let mut pending: u32 = 0;
+        let mut in_progress: u32 = 0;
+        let mut completed: u32 = 0;
+        let mut failed: u32 = 0;
+
+        let mut id = from_id;
+        while id <= scan_end {
+            let key = (symbol_short!("TXSTATE"), id);
+            if let Some(record) = env
+                .storage()
+                .persistent()
+                .get::<_, TransactionStateRecord>(&key)
+            {
+                match record.state {
+                    TransactionState::Pending => pending += 1,
+                    TransactionState::InProgress => in_progress += 1,
+                    TransactionState::Completed => completed += 1,
+                    TransactionState::Failed => failed += 1,
+                }
+            }
+            id += 1;
+        }
+
+        let total = pending + in_progress + completed + failed;
+        TransactionSummary {
+            pending_count: pending,
+            in_progress_count: in_progress,
+            completed_count: completed,
+            failed_count: failed,
+            total_count: total,
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src/deterministic_hash.rs
+++ b/src/deterministic_hash.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Bytes, BytesN, Env};
+use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env};
 
 /// Compute a canonical SHA-256 hash over attestation payload fields.
 ///
@@ -24,7 +24,7 @@ pub fn compute_payload_hash(
     // 3. data payload
     input.append(data);
 
-    env.crypto().sha256(&input)
+    env.crypto().sha256(&input).to_bytes()
 }
 
 /// Verify that the stored attestation's payload hash matches the expected hash.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -45,31 +45,13 @@ pub enum ErrorCode {
     AttestationNotFound = 17,
     InvalidSep10Token = 18,
     KycNotFound = 19,
- feat/session-expiry-check
-    KycPending = 22,
-    KycRejected = 23,
-    WebhookDeliveryFailed = 24,
-    NotInitialized = 25,
-    IllegalTransition = 26,
-    SessionExpired = 27,
-
+    KycPending = 20,
     KycRejected = 21,
- fix/kyc-pending-error-code-22
- fix/kyc-rejected-error-code-23
-
-    KycRejected = 21,
- fix/kyc-pending-error-code-22
- main
-    KycPending = 22,
-    KycRejected = 23,
-    NotInitialized = 25,
+    WebhookDeliveryFailed = 22,
+    NotInitialized = 23,
     IllegalTransition = 24,
-
-    NotInitialized = 22,
-    IllegalTransition = 23,
     SessionExpired = 25,
     SessionClosed = 26,
- main
     CacheExpired = 48,
     CacheNotFound = 49,
 }
@@ -103,14 +85,9 @@ impl ErrorCode {
             ErrorCode::NotInitialized => "Contract is not initialized",
             ErrorCode::IllegalTransition => "Illegal transaction state transition",
             ErrorCode::SessionExpired => "Session has expired",
+            ErrorCode::SessionClosed => "Session is closed",
             ErrorCode::CacheExpired => "Cache entry has expired",
             ErrorCode::CacheNotFound => "Cache entry not found",
- fix/kyc-pending-error-code-22
-
-            ErrorCode::IllegalTransition => "Illegal transaction state transition",
-            ErrorCode::SessionExpired => "Session has expired",
-            ErrorCode::SessionClosed => "Session is closed",
- main
         }
     }
 }
@@ -264,13 +241,10 @@ impl AnchorKitError {
     pub fn session_expired() -> Self {
         Self::from_code(ErrorCode::SessionExpired)
     }
- feat/session-expiry-check
-
 
     pub fn session_closed() -> Self {
         Self::from_code(ErrorCode::SessionClosed)
     }
- main
 }
 
 // ---------------------------------------------------------------------------
@@ -368,23 +342,15 @@ mod tests {
             ErrorCode::AttestationNotFound,
             ErrorCode::InvalidSep10Token,
             ErrorCode::KycNotFound,
- feat/webhook-delivery-failed-error-code-24
-
-            ErrorCode::KycRejected,
- fix/kyc-pending-error-code-22
             ErrorCode::KycPending,
             ErrorCode::KycRejected,
             ErrorCode::WebhookDeliveryFailed,
             ErrorCode::NotInitialized,
-
- main
-            ErrorCode::IllegalTransition,
-            ErrorCode::SessionExpired,
-            ErrorCode::CacheExpired,
-            ErrorCode::CacheNotFound,
             ErrorCode::IllegalTransition,
             ErrorCode::SessionExpired,
             ErrorCode::SessionClosed,
+            ErrorCode::CacheExpired,
+            ErrorCode::CacheNotFound,
         ];
         for code in codes {
             assert!(!code.default_message().is_empty());

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -54,6 +54,10 @@ pub enum ErrorCode {
     SessionClosed = 26,
     CacheExpired = 48,
     CacheNotFound = 49,
+    ProofOfPossessionFailed = 50,
+    ChallengeNotFound = 51,
+    ChallengeExpired = 52,
+    HealthMetricsNotFound = 53,
 }
 
 impl ErrorCode {
@@ -88,6 +92,10 @@ impl ErrorCode {
             ErrorCode::SessionClosed => "Session is closed",
             ErrorCode::CacheExpired => "Cache entry has expired",
             ErrorCode::CacheNotFound => "Cache entry not found",
+            ErrorCode::ProofOfPossessionFailed => "Proof-of-possession verification failed",
+            ErrorCode::ChallengeNotFound => "Proof-of-possession challenge not found",
+            ErrorCode::ChallengeExpired => "Proof-of-possession challenge has expired",
+            ErrorCode::HealthMetricsNotFound => "Anchor health metrics not found",
         }
     }
 }
@@ -245,6 +253,22 @@ impl AnchorKitError {
     pub fn session_closed() -> Self {
         Self::from_code(ErrorCode::SessionClosed)
     }
+
+    pub fn proof_of_possession_failed() -> Self {
+        Self::from_code(ErrorCode::ProofOfPossessionFailed)
+    }
+
+    pub fn challenge_not_found() -> Self {
+        Self::from_code(ErrorCode::ChallengeNotFound)
+    }
+
+    pub fn challenge_expired() -> Self {
+        Self::from_code(ErrorCode::ChallengeExpired)
+    }
+
+    pub fn health_metrics_not_found() -> Self {
+        Self::from_code(ErrorCode::HealthMetricsNotFound)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -351,6 +375,10 @@ mod tests {
             ErrorCode::SessionClosed,
             ErrorCode::CacheExpired,
             ErrorCode::CacheNotFound,
+            ErrorCode::ProofOfPossessionFailed,
+            ErrorCode::ChallengeNotFound,
+            ErrorCode::ChallengeExpired,
+            ErrorCode::HealthMetricsNotFound,
         ];
         for code in codes {
             assert!(!code.default_message().is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,3 +89,9 @@ mod batch_transaction_tests;
 
 #[cfg(test)]
 mod metadata_version_history_tests;
+
+#[cfg(test)]
+mod proof_of_possession_tests;
+
+#[cfg(test)]
+mod anchor_health_tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use sep24::{
     InteractiveDepositResponse, InteractiveWithdrawalResponse, Sep24TransactionStatusResponse,
     RawInteractiveDepositResponse, RawInteractiveWithdrawalResponse, RawSep24TransactionResponse,
 };
-pub use contract::{AnchorKitContract, EndpointUpdated, get_endpoint, set_endpoint};
+pub use contract::{AnchorKitContract, EndpointUpdated};
 pub use transaction_state_tracker::{TransactionState, TransactionStateRecord};
 
 #[cfg(test)]
@@ -78,7 +78,14 @@ mod deterministic_hash_snapshot_tests {
     // This module exists to satisfy the test_snapshots/deterministic_hash_tests path.
 }
 
+#[cfg(test)]
 mod capability_detection_tests;
 
 #[cfg(test)]
 mod attestor_endpoint_tests;
+
+#[cfg(test)]
+mod batch_transaction_tests;
+
+#[cfg(test)]
+mod metadata_version_history_tests;

--- a/src/sep10_jwt.rs
+++ b/src/sep10_jwt.rs
@@ -8,7 +8,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use soroban_sdk::{Bytes, Env, String};
+use soroban_sdk::{Bytes, BytesN, Env, String};
 
 /// Default maximum JWT character length. Can be overridden via contract storage key "JWTMAXLEN".
 pub const MAX_JWT_LEN: u32 = 2048;
@@ -220,14 +220,20 @@ pub fn verify_sep10_jwt(
     }
 
     let signing_input = Bytes::from_slice(env, &buf[..d1]);
-    let sig_bytes = Bytes::from_slice(env, sig_dec.as_slice());
+    let sig_bytes_raw = Bytes::from_slice(env, sig_dec.as_slice());
 
-    if !env
-        .crypto()
-        .ed25519_verify(anchor_public_key, &signing_input, &sig_bytes)
-    {
-        return Err(());
-    }
+    // Convert to fixed-size types required by ed25519_verify
+    let pk_fixed: BytesN<32> = anchor_public_key
+        .clone()
+        .try_into()
+        .map_err(|_| ())?;
+    let sig_fixed: BytesN<64> = sig_bytes_raw
+        .try_into()
+        .map_err(|_| ())?;
+
+    // ed25519_verify panics on bad signature (SDK contract).
+    // In the test environment the Env wraps panics so we can catch them.
+    env.crypto().ed25519_verify(&pk_fixed, &signing_input, &sig_fixed);
 
     let payload_dec = base64url_decode(payload_b64).map_err(|_| ())?;
     let exp = parse_json_exp(&payload_dec)?;
@@ -381,7 +387,11 @@ mod tests {
         let jwt = build_jwt(&signing_key, sub_str.as_str(), 2_000);
         let token = String::from_str(&env, jwt.as_str());
 
-        assert!(verify_sep10_jwt(&env, &token, &pk, Some(&sub)).is_err());
+        // ed25519_verify panics on bad sig; catch_unwind converts that to an Err-like result
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            verify_sep10_jwt(&env, &token, &pk, Some(&sub))
+        }));
+        assert!(result.is_err() || result.unwrap().is_err());
     }
 
     // Issue #61: nbf support

--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -197,10 +197,10 @@ pub struct RawTransactionResponse {
 
 /// Normalize a raw anchor deposit response into a canonical [`DepositResponse`].
 ///
-/// Returns `Err(Error::InvalidTransactionIntent)` if required fields are missing.
+/// Returns `Err(Error::invalid_transaction_intent())` if required fields are missing.
 pub fn initiate_deposit(raw: RawDepositResponse) -> Result<DepositResponse, Error> {
     if raw.transaction_id.is_empty() || raw.how.is_empty() {
-        return Err(Error::InvalidTransactionIntent);
+        return Err(Error::invalid_transaction_intent());
     }
 
     Ok(DepositResponse {
@@ -223,10 +223,10 @@ pub fn initiate_deposit(raw: RawDepositResponse) -> Result<DepositResponse, Erro
 
 /// Normalize a raw anchor withdrawal response into a canonical [`WithdrawalResponse`].
 ///
-/// Returns `Err(Error::InvalidTransactionIntent)` if required fields are missing.
+/// Returns `Err(Error::invalid_transaction_intent())` if required fields are missing.
 pub fn initiate_withdrawal(raw: RawWithdrawalResponse) -> Result<WithdrawalResponse, Error> {
     if raw.transaction_id.is_empty() || raw.account_id.is_empty() {
-        return Err(Error::InvalidTransactionIntent);
+        return Err(Error::invalid_transaction_intent());
     }
 
     Ok(WithdrawalResponse {
@@ -248,12 +248,12 @@ pub fn initiate_withdrawal(raw: RawWithdrawalResponse) -> Result<WithdrawalRespo
 /// Normalize a raw anchor transaction-status response into a canonical
 /// [`TransactionStatusResponse`].
 ///
-/// Returns `Err(Error::InvalidTransactionIntent)` if the transaction ID is missing.
+/// Returns `Err(Error::invalid_transaction_intent())` if the transaction ID is missing.
 pub fn fetch_transaction_status(
     raw: RawTransactionResponse,
 ) -> Result<TransactionStatusResponse, Error> {
     if raw.transaction_id.is_empty() {
-        return Err(Error::InvalidTransactionIntent);
+        return Err(Error::invalid_transaction_intent());
     }
 
     Ok(TransactionStatusResponse {
@@ -355,7 +355,7 @@ mod tests {
     fn test_initiate_deposit_missing_fields_returns_error() {
         let mut raw = raw_deposit();
         raw.transaction_id = "".to_string();
-        assert_eq!(initiate_deposit(raw), Err(Error::InvalidTransactionIntent));
+        assert_eq!(initiate_deposit(raw), Err(Error::invalid_transaction_intent()));
     }
 
     #[test]
@@ -380,7 +380,7 @@ mod tests {
         raw.account_id = "".to_string();
         assert_eq!(
             initiate_withdrawal(raw),
-            Err(Error::InvalidTransactionIntent)
+            Err(Error::invalid_transaction_intent())
         );
     }
 
@@ -398,7 +398,7 @@ mod tests {
         raw.transaction_id = "".to_string();
         assert_eq!(
             fetch_transaction_status(raw),
-            Err(Error::InvalidTransactionIntent)
+            Err(Error::invalid_transaction_intent())
         );
     }
 

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -264,6 +264,108 @@ impl TransactionStateTracker {
         }
     }
 
+    /// Return up to `limit` records whose IDs fall in `[from_id, to_id]` (inclusive).
+    /// `limit` is capped at 100 to prevent unbounded iteration.
+    /// In dev mode, scans the in-memory cache; in production, scans persistent storage.
+    pub fn get_transactions_in_range(
+        &self,
+        from_id: u64,
+        to_id: u64,
+        limit: usize,
+        env: &Env,
+    ) -> Result<alloc::vec::Vec<TransactionStateRecord>, String> {
+        if from_id > to_id {
+            return Err(String::from_str(env, "from_id must be <= to_id"));
+        }
+        const MAX_BATCH: usize = 100;
+        let effective_limit = if limit == 0 || limit > MAX_BATCH { MAX_BATCH } else { limit };
+
+        let mut results = alloc::vec::Vec::new();
+
+        if self.is_dev_mode {
+            for record in self.cache.iter() {
+                if record.transaction_id >= from_id && record.transaction_id <= to_id {
+                    if results.len() < effective_limit {
+                        results.push(record.clone());
+                    }
+                }
+            }
+            // Sort by transaction_id ascending for deterministic output.
+            results.sort_by_key(|r| r.transaction_id);
+        } else {
+            let mut id = from_id;
+            while id <= to_id && results.len() < effective_limit {
+                let key = (symbol_short!("TXSTATE"), id);
+                if let Some(record) = env
+                    .storage()
+                    .persistent()
+                    .get::<_, TransactionStateRecord>(&key)
+                {
+                    results.push(record);
+                }
+                id += 1;
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Return aggregated counts for all records in `[from_id, to_id]`.
+    /// Scans at most 500 IDs to prevent unbounded loops.
+    pub fn summarize_by_status(
+        &self,
+        from_id: u64,
+        to_id: u64,
+        env: &Env,
+    ) -> Result<(u32, u32, u32, u32), String> {
+        if from_id > to_id {
+            return Err(String::from_str(env, "from_id must be <= to_id"));
+        }
+        let mut pending: u32 = 0;
+        let mut in_progress: u32 = 0;
+        let mut completed: u32 = 0;
+        let mut failed: u32 = 0;
+
+        if self.is_dev_mode {
+            for record in self.cache.iter() {
+                if record.transaction_id >= from_id && record.transaction_id <= to_id {
+                    match record.state {
+                        TransactionState::Pending => pending += 1,
+                        TransactionState::InProgress => in_progress += 1,
+                        TransactionState::Completed => completed += 1,
+                        TransactionState::Failed => failed += 1,
+                    }
+                }
+            }
+        } else {
+            const MAX_SCAN: u64 = 500;
+            let scan_end = if to_id - from_id + 1 > MAX_SCAN {
+                from_id + MAX_SCAN - 1
+            } else {
+                to_id
+            };
+            let mut id = from_id;
+            while id <= scan_end {
+                let key = (symbol_short!("TXSTATE"), id);
+                if let Some(record) = env
+                    .storage()
+                    .persistent()
+                    .get::<_, TransactionStateRecord>(&key)
+                {
+                    match record.state {
+                        TransactionState::Pending => pending += 1,
+                        TransactionState::InProgress => in_progress += 1,
+                        TransactionState::Completed => completed += 1,
+                        TransactionState::Failed => failed += 1,
+                    }
+                }
+                id += 1;
+            }
+        }
+
+        Ok((pending, in_progress, completed, failed))
+    }
+
     /// Clear all cached transactions (dev mode only)
     pub fn clear_cache(&mut self) -> Result<(), String> {
         if self.is_dev_mode {

--- a/tests/anchor_health_tests.rs
+++ b/tests/anchor_health_tests.rs
@@ -1,0 +1,270 @@
+#![cfg(test)]
+
+mod anchor_health_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Bytes, Env, String,
+    };
+
+    use crate::contract::{AnchorKitContract, AnchorKitContractClient};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, timestamp: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    /// Set up a contract with an admin and a registered anchor (via set_anchor_metadata).
+    fn setup(env: &Env) -> (Address, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+
+        let admin = Address::generate(env);
+        let anchor = Address::generate(env);
+
+        client.initialize(&admin);
+
+        // Register the anchor so it appears in ANCHLIST.
+        client.set_anchor_metadata(&anchor, &80u32, &500u64, &70u32, &95u32, &1_000_000u64);
+
+        (contract_id, anchor)
+    }
+
+    // -----------------------------------------------------------------------
+    // record_endpoint_success
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_record_success_increments_count() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, anchor) = setup(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        client.record_endpoint_success(&anchor);
+        let metrics = client.get_anchor_health(&anchor);
+
+        assert_eq!(metrics.success_count, 1);
+        assert_eq!(metrics.failure_count, 0);
+        assert_eq!(metrics.consecutive_failures, 0);
+        assert_eq!(metrics.last_response_at, 1_000_000);
+        assert_eq!(metrics.last_success_at, 1_000_000);
+        assert_eq!(metrics.uptime_bps, 10_000); // 100 %
+    }
+
+    #[test]
+    fn test_multiple_successes_accumulate() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, anchor) = setup(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        client.record_endpoint_success(&anchor);
+        client.record_endpoint_success(&anchor);
+        client.record_endpoint_success(&anchor);
+
+        let metrics = client.get_anchor_health(&anchor);
+        assert_eq!(metrics.success_count, 3);
+        assert_eq!(metrics.uptime_bps, 10_000);
+    }
+
+    // -----------------------------------------------------------------------
+    // record_endpoint_failure
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_record_failure_increments_count() {
+        let env = make_env();
+        set_ledger(&env, 2_000_000);
+        let (contract_id, anchor) = setup(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        client.record_endpoint_failure(&anchor);
+        let metrics = client.get_anchor_health(&anchor);
+
+        assert_eq!(metrics.failure_count, 1);
+        assert_eq!(metrics.success_count, 0);
+        assert_eq!(metrics.consecutive_failures, 1);
+        assert_eq!(metrics.last_response_at, 2_000_000);
+        assert_eq!(metrics.last_success_at, 0);
+        assert_eq!(metrics.uptime_bps, 0); // 0 %
+    }
+
+    #[test]
+    fn test_consecutive_failures_reset_on_success() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, anchor) = setup(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        client.record_endpoint_failure(&anchor);
+        client.record_endpoint_failure(&anchor);
+        client.record_endpoint_failure(&anchor);
+
+        let before = client.get_anchor_health(&anchor);
+        assert_eq!(before.consecutive_failures, 3);
+
+        client.record_endpoint_success(&anchor);
+        let after = client.get_anchor_health(&anchor);
+        assert_eq!(after.consecutive_failures, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // uptime_bps calculation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_uptime_bps_mixed_results() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, anchor) = setup(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        // 3 successes, 1 failure → 75 % → 7500 bps
+        client.record_endpoint_success(&anchor);
+        client.record_endpoint_success(&anchor);
+        client.record_endpoint_success(&anchor);
+        client.record_endpoint_failure(&anchor);
+
+        let metrics = client.get_anchor_health(&anchor);
+        assert_eq!(metrics.success_count, 3);
+        assert_eq!(metrics.failure_count, 1);
+        assert_eq!(metrics.uptime_bps, 7500);
+    }
+
+    #[test]
+    fn test_uptime_bps_all_failures() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, anchor) = setup(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        client.record_endpoint_failure(&anchor);
+        client.record_endpoint_failure(&anchor);
+
+        let metrics = client.get_anchor_health(&anchor);
+        assert_eq!(metrics.uptime_bps, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_anchor_health — not found
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn test_get_anchor_health_no_data_panics() {
+        let env = make_env();
+        let (contract_id, anchor) = setup(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        // No success/failure recorded yet.
+        client.get_anchor_health(&anchor);
+    }
+
+    // -----------------------------------------------------------------------
+    // reset_anchor_health
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_reset_anchor_health_clears_metrics() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, anchor) = setup(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        client.record_endpoint_success(&anchor);
+        client.record_endpoint_success(&anchor);
+        client.record_endpoint_failure(&anchor);
+
+        client.reset_anchor_health(&anchor);
+        let metrics = client.get_anchor_health(&anchor);
+
+        assert_eq!(metrics.success_count, 0);
+        assert_eq!(metrics.failure_count, 0);
+        assert_eq!(metrics.consecutive_failures, 0);
+        assert_eq!(metrics.uptime_bps, 0);
+        assert_eq!(metrics.last_response_at, 0);
+        assert_eq!(metrics.last_success_at, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // list_anchor_health
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_list_anchor_health_returns_only_anchors_with_data() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let anchor_a = Address::generate(&env);
+        let anchor_b = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.set_anchor_metadata(&anchor_a, &80u32, &500u64, &70u32, &95u32, &1_000_000u64);
+        client.set_anchor_metadata(&anchor_b, &60u32, &800u64, &50u32, &90u32, &500_000u64);
+
+        // Only record health for anchor_a.
+        client.record_endpoint_success(&anchor_a);
+
+        let list = client.list_anchor_health();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list.get(0).unwrap().anchor, anchor_a);
+    }
+
+    #[test]
+    fn test_list_anchor_health_multiple_anchors() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let anchor_a = Address::generate(&env);
+        let anchor_b = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.set_anchor_metadata(&anchor_a, &80u32, &500u64, &70u32, &95u32, &1_000_000u64);
+        client.set_anchor_metadata(&anchor_b, &60u32, &800u64, &50u32, &90u32, &500_000u64);
+
+        client.record_endpoint_success(&anchor_a);
+        client.record_endpoint_failure(&anchor_b);
+
+        let list = client.list_anchor_health();
+        assert_eq!(list.len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // last_response_at tracks most recent call
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_last_response_at_updates_on_each_call() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, anchor) = setup(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        client.record_endpoint_success(&anchor);
+        assert_eq!(client.get_anchor_health(&anchor).last_response_at, 1_000_000);
+
+        set_ledger(&env, 2_000_000);
+        client.record_endpoint_failure(&anchor);
+        assert_eq!(client.get_anchor_health(&anchor).last_response_at, 2_000_000);
+    }
+}

--- a/tests/batch_transaction_tests.rs
+++ b/tests/batch_transaction_tests.rs
@@ -1,0 +1,287 @@
+#![cfg(test)]
+
+mod batch_transaction_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env,
+    };
+
+    use crate::contract::{AnchorKitContract, AnchorKitContractClient};
+    use crate::transaction_state_tracker::{TransactionState, TransactionStateTracker};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, timestamp: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin)
+    }
+
+    // -----------------------------------------------------------------------
+    // Contract-level batch query tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_transactions_in_range_basic() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let initiator = Address::generate(&env);
+
+        // Create 5 transaction records with IDs 1..=5
+        for id in 1u64..=5 {
+            client.create_transaction_record(&id, &initiator);
+        }
+
+        let result = client.get_transactions_in_range(&1u64, &5u64, &5u32);
+        assert_eq!(result.total, 5);
+        assert_eq!(result.records.len(), 5);
+    }
+
+    #[test]
+    fn test_get_transactions_in_range_partial_window() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let initiator = Address::generate(&env);
+
+        for id in 1u64..=10 {
+            client.create_transaction_record(&id, &initiator);
+        }
+
+        // Request IDs 3..=7 with limit 3 — should return 3 records, total=5
+        let result = client.get_transactions_in_range(&3u64, &7u64, &3u32);
+        assert_eq!(result.total, 5);
+        assert_eq!(result.records.len(), 3);
+        // First record in the page must be ID 3
+        assert_eq!(result.records.get(0).unwrap().transaction_id, 3);
+    }
+
+    #[test]
+    fn test_get_transactions_in_range_sparse_ids() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let initiator = Address::generate(&env);
+
+        // Only create records for IDs 2 and 4 — IDs 1, 3, 5 are absent
+        client.create_transaction_record(&2u64, &initiator);
+        client.create_transaction_record(&4u64, &initiator);
+
+        let result = client.get_transactions_in_range(&1u64, &5u64, &10u32);
+        assert_eq!(result.total, 2);
+        assert_eq!(result.records.len(), 2);
+    }
+
+    #[test]
+    fn test_get_transactions_in_range_limit_capped_at_100() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let initiator = Address::generate(&env);
+
+        for id in 1u64..=10 {
+            client.create_transaction_record(&id, &initiator);
+        }
+
+        // Passing limit=0 should default to the internal cap (100), returning all 10
+        let result = client.get_transactions_in_range(&1u64, &10u64, &0u32);
+        assert_eq!(result.total, 10);
+        assert_eq!(result.records.len(), 10);
+    }
+
+    #[test]
+    fn test_get_transactions_in_range_empty_range() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+
+        // No records created — range should return empty
+        let result = client.get_transactions_in_range(&100u64, &200u64, &50u32);
+        assert_eq!(result.total, 0);
+        assert_eq!(result.records.len(), 0);
+    }
+
+    #[test]
+    fn test_summarize_transactions_by_status_mixed_states() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let initiator = Address::generate(&env);
+
+        // IDs 1-4: create all as Pending
+        for id in 1u64..=4 {
+            client.create_transaction_record(&id, &initiator);
+        }
+
+        // The contract's create_transaction_record only creates Pending records.
+        // Use the tracker directly to advance states for the summary test.
+        // We verify the summary via the tracker's summarize_by_status method.
+        let mut tracker = TransactionStateTracker::new(true);
+        let env2 = Env::default();
+        let init2 = Address::generate(&env2);
+
+        tracker.create_transaction(1, init2.clone(), &env2).unwrap();
+        tracker.create_transaction(2, init2.clone(), &env2).unwrap();
+        tracker.create_transaction(3, init2.clone(), &env2).unwrap();
+        tracker.create_transaction(4, init2.clone(), &env2).unwrap();
+
+        tracker.start_transaction(1, &env2).unwrap();
+        tracker.start_transaction(2, &env2).unwrap();
+        tracker.complete_transaction(2, &env2).unwrap();
+        tracker.start_transaction(3, &env2).unwrap();
+        tracker
+            .fail_transaction(3, soroban_sdk::String::from_str(&env2, "err"), &env2)
+            .unwrap();
+
+        // State: 1=InProgress, 2=Completed, 3=Failed, 4=Pending
+        let (pending, in_progress, completed, failed) =
+            tracker.summarize_by_status(1, 4, &env2).unwrap();
+        assert_eq!(pending, 1);
+        assert_eq!(in_progress, 1);
+        assert_eq!(completed, 1);
+        assert_eq!(failed, 1);
+    }
+
+    #[test]
+    fn test_summarize_transactions_by_status_all_pending() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let initiator = Address::generate(&env);
+
+        for id in 1u64..=5 {
+            client.create_transaction_record(&id, &initiator);
+        }
+
+        let summary = client.summarize_transactions_by_status(&1u64, &5u64);
+        assert_eq!(summary.pending_count, 5);
+        assert_eq!(summary.in_progress_count, 0);
+        assert_eq!(summary.completed_count, 0);
+        assert_eq!(summary.failed_count, 0);
+        assert_eq!(summary.total_count, 5);
+    }
+
+    #[test]
+    fn test_summarize_transactions_by_status_empty() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+
+        let summary = client.summarize_transactions_by_status(&50u64, &100u64);
+        assert_eq!(summary.total_count, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // TransactionStateTracker unit-level batch tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_tracker_get_transactions_in_range_dev_mode() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        for id in 1u64..=6 {
+            tracker.create_transaction(id, initiator.clone(), &env).unwrap();
+        }
+
+        let results = tracker.get_transactions_in_range(2, 5, 10, &env).unwrap();
+        assert_eq!(results.len(), 4);
+        // Verify ascending order
+        assert_eq!(results[0].transaction_id, 2);
+        assert_eq!(results[3].transaction_id, 5);
+    }
+
+    #[test]
+    fn test_tracker_get_transactions_in_range_respects_limit() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        for id in 1u64..=10 {
+            tracker.create_transaction(id, initiator.clone(), &env).unwrap();
+        }
+
+        let results = tracker.get_transactions_in_range(1, 10, 3, &env).unwrap();
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn test_tracker_get_transactions_in_range_invalid_range() {
+        let env = Env::default();
+        let tracker = TransactionStateTracker::new(true);
+
+        let result = tracker.get_transactions_in_range(10, 5, 10, &env);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tracker_summarize_by_status_dev_mode() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        for id in 1u64..=5 {
+            tracker.create_transaction(id, initiator.clone(), &env).unwrap();
+        }
+        tracker.start_transaction(1, &env).unwrap();
+        tracker.complete_transaction(1, &env).unwrap();
+        tracker.start_transaction(2, &env).unwrap();
+        tracker
+            .fail_transaction(2, soroban_sdk::String::from_str(&env, "fail"), &env)
+            .unwrap();
+
+        // IDs 1-5: 1=Completed, 2=Failed, 3-5=Pending
+        let (pending, in_progress, completed, failed) =
+            tracker.summarize_by_status(1, 5, &env).unwrap();
+        assert_eq!(pending, 3);
+        assert_eq!(in_progress, 0);
+        assert_eq!(completed, 1);
+        assert_eq!(failed, 1);
+    }
+
+    #[test]
+    fn test_tracker_summarize_by_status_invalid_range() {
+        let env = Env::default();
+        let tracker = TransactionStateTracker::new(true);
+
+        let result = tracker.summarize_by_status(10, 5, &env);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tracker_summarize_excludes_out_of_range_ids() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        // IDs 1, 5, 10
+        tracker.create_transaction(1, initiator.clone(), &env).unwrap();
+        tracker.create_transaction(5, initiator.clone(), &env).unwrap();
+        tracker.create_transaction(10, initiator.clone(), &env).unwrap();
+
+        // Summarize only IDs 1..=5 — should count 2, not 3
+        let (pending, _, _, _) = tracker.summarize_by_status(1, 5, &env).unwrap();
+        assert_eq!(pending, 2);
+    }
+}

--- a/tests/metadata_version_history_tests.rs
+++ b/tests/metadata_version_history_tests.rs
@@ -1,0 +1,290 @@
+#![cfg(test)]
+
+mod metadata_version_history_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env,
+    };
+
+    use crate::contract::{AnchorKitContract, AnchorKitContractClient};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, timestamp: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin)
+    }
+
+    // -----------------------------------------------------------------------
+    // Version counter tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_first_set_creates_version_1() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor, &8000u32, &300u64, &7500u32, &9900u32, &1_000_000u64);
+
+        let count = client.get_anchor_meta_version_count(&anchor);
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_multiple_updates_increment_version() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor, &8000u32, &300u64, &7500u32, &9900u32, &1_000_000u64);
+        client.set_anchor_metadata(&anchor, &8500u32, &250u64, &8000u32, &9950u32, &2_000_000u64);
+        client.set_anchor_metadata(&anchor, &9000u32, &200u64, &8500u32, &9980u32, &3_000_000u64);
+
+        let count = client.get_anchor_meta_version_count(&anchor);
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_version_count_zero_for_unknown_anchor() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        let count = client.get_anchor_meta_version_count(&anchor);
+        assert_eq!(count, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // History retrieval tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_history_returns_ordered_versions() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor, &1000u32, &600u64, &1000u32, &9000u32, &100_000u64);
+        set_ledger(&env, 2_000);
+        client.set_anchor_metadata(&anchor, &2000u32, &500u64, &2000u32, &9100u32, &200_000u64);
+        set_ledger(&env, 3_000);
+        client.set_anchor_metadata(&anchor, &3000u32, &400u64, &3000u32, &9200u32, &300_000u64);
+
+        let history = client.get_anchor_metadata_history(&anchor, &10u32);
+        assert_eq!(history.len(), 3);
+
+        // Versions must be in ascending order
+        assert_eq!(history.get(0).unwrap().version, 1);
+        assert_eq!(history.get(1).unwrap().version, 2);
+        assert_eq!(history.get(2).unwrap().version, 3);
+    }
+
+    #[test]
+    fn test_history_preserves_field_values_per_version() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor, &1000u32, &600u64, &1000u32, &9000u32, &100_000u64);
+        set_ledger(&env, 2_000);
+        client.set_anchor_metadata(&anchor, &9999u32, &100u64, &9999u32, &9999u32, &999_999u64);
+
+        let history = client.get_anchor_metadata_history(&anchor, &10u32);
+        assert_eq!(history.len(), 2);
+
+        let v1 = history.get(0).unwrap();
+        assert_eq!(v1.metadata.reputation_score, 1000);
+        assert_eq!(v1.metadata.average_settlement_time, 600);
+        assert_eq!(v1.updated_at, 1_000);
+
+        let v2 = history.get(1).unwrap();
+        assert_eq!(v2.metadata.reputation_score, 9999);
+        assert_eq!(v2.metadata.average_settlement_time, 100);
+        assert_eq!(v2.updated_at, 2_000);
+    }
+
+    #[test]
+    fn test_history_limit_respected() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        for i in 0u64..10 {
+            set_ledger(&env, 1_000 + i * 100);
+            client.set_anchor_metadata(
+                &anchor,
+                &(i as u32 * 1000),
+                &(600 - i * 50),
+                &7000u32,
+                &9000u32,
+                &(i * 100_000),
+            );
+        }
+
+        // Request only the last 3 versions
+        let history = client.get_anchor_metadata_history(&anchor, &3u32);
+        assert_eq!(history.len(), 3);
+        // The last 3 versions should be 8, 9, 10
+        assert_eq!(history.get(0).unwrap().version, 8);
+        assert_eq!(history.get(2).unwrap().version, 10);
+    }
+
+    #[test]
+    fn test_history_empty_for_unknown_anchor() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        let history = client.get_anchor_metadata_history(&anchor, &10u32);
+        assert_eq!(history.len(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Point-in-time version lookup tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_metadata_at_version_returns_correct_snapshot() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor, &1111u32, &111u64, &1111u32, &9000u32, &111_111u64);
+        set_ledger(&env, 2_000);
+        client.set_anchor_metadata(&anchor, &2222u32, &222u64, &2222u32, &9200u32, &222_222u64);
+
+        let v1 = client.get_anchor_metadata_at_version(&anchor, &1u32);
+        assert_eq!(v1.version, 1);
+        assert_eq!(v1.metadata.reputation_score, 1111);
+        assert_eq!(v1.updated_at, 1_000);
+
+        let v2 = client.get_anchor_metadata_at_version(&anchor, &2u32);
+        assert_eq!(v2.version, 2);
+        assert_eq!(v2.metadata.reputation_score, 2222);
+        assert_eq!(v2.updated_at, 2_000);
+    }
+
+    #[test]
+    fn test_get_metadata_at_version_nonexistent_panics() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        // No metadata set — version 1 should not exist
+        let result = client.try_get_anchor_metadata_at_version(&anchor, &1u32);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_metadata_at_version_zero_panics() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor, &8000u32, &300u64, &7500u32, &9900u32, &1_000_000u64);
+
+        // Version 0 is invalid
+        let result = client.try_get_anchor_metadata_at_version(&anchor, &0u32);
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Rollback semantics test
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_rollback_semantics_via_history() {
+        // Demonstrates that a caller can "roll back" by reading a prior version
+        // and re-applying it as the current metadata.
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        // v1: good state
+        client.set_anchor_metadata(&anchor, &8000u32, &300u64, &7500u32, &9900u32, &1_000_000u64);
+        // v2: bad update (e.g., wrong reputation)
+        set_ledger(&env, 2_000);
+        client.set_anchor_metadata(&anchor, &1u32, &9999u64, &1u32, &1u32, &1u64);
+
+        // Current metadata reflects v2
+        let current = client.get_anchor_metadata(&anchor);
+        assert_eq!(current.reputation_score, 1);
+
+        // Retrieve v1 snapshot and re-apply it (simulating rollback)
+        let v1 = client.get_anchor_metadata_at_version(&anchor, &1u32);
+        set_ledger(&env, 3_000);
+        client.set_anchor_metadata(
+            &anchor,
+            &v1.metadata.reputation_score,
+            &v1.metadata.average_settlement_time,
+            &v1.metadata.liquidity_score,
+            &v1.metadata.uptime_percentage,
+            &v1.metadata.total_volume,
+        );
+
+        // Now current metadata matches the rolled-back v1 values
+        let restored = client.get_anchor_metadata(&anchor);
+        assert_eq!(restored.reputation_score, 8000);
+        assert_eq!(restored.average_settlement_time, 300);
+
+        // Version count is now 3 (v1, v2, v3=rollback)
+        let count = client.get_anchor_meta_version_count(&anchor);
+        assert_eq!(count, 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // Independent anchors don't share history
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_history_is_per_anchor() {
+        let env = make_env();
+        set_ledger(&env, 1_000);
+        let (client, _) = setup(&env);
+        let anchor_a = Address::generate(&env);
+        let anchor_b = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor_a, &1000u32, &100u64, &1000u32, &9000u32, &100_000u64);
+        client.set_anchor_metadata(&anchor_a, &2000u32, &200u64, &2000u32, &9100u32, &200_000u64);
+        client.set_anchor_metadata(&anchor_b, &5000u32, &500u64, &5000u32, &9500u32, &500_000u64);
+
+        assert_eq!(client.get_anchor_meta_version_count(&anchor_a), 2);
+        assert_eq!(client.get_anchor_meta_version_count(&anchor_b), 1);
+
+        let hist_b = client.get_anchor_metadata_history(&anchor_b, &10u32);
+        assert_eq!(hist_b.len(), 1);
+        assert_eq!(hist_b.get(0).unwrap().metadata.reputation_score, 5000);
+    }
+}

--- a/tests/proof_of_possession_tests.rs
+++ b/tests/proof_of_possession_tests.rs
@@ -1,0 +1,205 @@
+#![cfg(test)]
+
+mod proof_of_possession_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Bytes, Env, String,
+    };
+
+    use crate::contract::{AnchorKitContract, AnchorKitContractClient};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, timestamp: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp,
+            protocol_version: 21,
+            sequence_number: 100,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    /// Register an admin + attestor and store a 32-byte dummy verifying key.
+    fn setup_attestor(env: &Env) -> (Address, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+
+        let admin = Address::generate(env);
+        let attestor = Address::generate(env);
+
+        client.initialize(&admin);
+
+        // Register a dummy SEP-10 verifying key (32 zero bytes).
+        let pk = Bytes::from_array(env, &[0u8; 32]);
+        client.set_sep10_jwt_verifying_key(&attestor, &pk);
+
+        // Register the attestor (mock auth bypasses JWT check).
+        client.register_attestor(
+            &attestor,
+            &String::from_str(env, "mock_token"),
+            &Address::generate(env),
+        );
+
+        (contract_id, attestor)
+    }
+
+    // -----------------------------------------------------------------------
+    // issue_pop_challenge
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_issue_pop_challenge_returns_nonce() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, attestor) = setup_attestor(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let challenge = client.issue_pop_challenge(&attestor, &300u64);
+
+        assert_eq!(challenge.attestor, attestor);
+        assert_eq!(challenge.nonce.len(), 16);
+        assert!(!challenge.verified);
+        // expires_at = now + ttl
+        assert_eq!(challenge.expires_at, 1_000_000 + 300);
+    }
+
+    #[test]
+    fn test_issue_pop_challenge_ttl_capped_at_3600() {
+        let env = make_env();
+        set_ledger(&env, 2_000_000);
+        let (contract_id, attestor) = setup_attestor(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        // Request a TTL larger than the 3600-second cap.
+        let challenge = client.issue_pop_challenge(&attestor, &99999u64);
+        assert_eq!(challenge.expires_at, 2_000_000 + 3600);
+    }
+
+    #[test]
+    fn test_issue_pop_challenge_zero_ttl_uses_default() {
+        let env = make_env();
+        set_ledger(&env, 500_000);
+        let (contract_id, attestor) = setup_attestor(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        let challenge = client.issue_pop_challenge(&attestor, &0u64);
+        assert_eq!(challenge.expires_at, 500_000 + 3600);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_issue_pop_challenge_unregistered_attestor_panics() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        // Attestor was never registered.
+        let stranger = Address::generate(&env);
+        client.issue_pop_challenge(&stranger, &300u64);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_pop_challenge
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_pop_challenge_returns_stored_challenge() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, attestor) = setup_attestor(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        client.issue_pop_challenge(&attestor, &600u64);
+        let fetched = client.get_pop_challenge(&attestor);
+
+        assert_eq!(fetched.attestor, attestor);
+        assert_eq!(fetched.nonce.len(), 16);
+        assert!(!fetched.verified);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_pop_challenge_no_challenge_panics() {
+        let env = make_env();
+        let (contract_id, attestor) = setup_attestor(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        // No challenge issued yet.
+        client.get_pop_challenge(&attestor);
+    }
+
+    // -----------------------------------------------------------------------
+    // verify_pop_response — failure paths (success path requires real Ed25519)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn test_verify_pop_response_wrong_sig_length_panics() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, attestor) = setup_attestor(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        client.issue_pop_challenge(&attestor, &300u64);
+
+        // Signature is only 32 bytes — must be 64.
+        let bad_sig = Bytes::from_array(&env, &[0u8; 32]);
+        client.verify_pop_response(&attestor, &bad_sig);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_verify_pop_response_expired_challenge_panics() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, attestor) = setup_attestor(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        // Issue a 60-second challenge.
+        client.issue_pop_challenge(&attestor, &60u64);
+
+        // Advance ledger past expiry.
+        set_ledger(&env, 1_000_000 + 61);
+
+        let sig = Bytes::from_array(&env, &[0u8; 64]);
+        client.verify_pop_response(&attestor, &sig);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_verify_pop_response_no_challenge_panics() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (contract_id, attestor) = setup_attestor(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        // No challenge issued.
+        let sig = Bytes::from_array(&env, &[0u8; 64]);
+        client.verify_pop_response(&attestor, &sig);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_pop_status — no result yet
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn test_get_pop_status_before_verification_panics() {
+        let env = make_env();
+        let (contract_id, attestor) = setup_attestor(&env);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+
+        client.get_pop_status(&attestor);
+    }
+}


### PR DESCRIPTION


Anchor endpoints are now verifiable beyond syntactic validation. Admins
can issue a nonce challenge to any registered attestor; the attestor signs
it with their stored Ed25519 key and submits the response on-chain. A
verified PopVerificationResult is persisted so callers can confirm
endpoint ownership at any time.

Health metrics give production operators visibility into anchor reliability.
Each success or failure call accumulates counts, tracks consecutive failures,
records last-response timestamps, and recomputes uptime in basis points
(0-10000). Metrics are queryable per-anchor or across all active anchors.

New contract methods:
- issue_pop_challenge, verify_pop_response, get_pop_challenge, get_pop_status
- record_endpoint_success, record_endpoint_failure
- get_anchor_health, reset_anchor_health, list_anchor_health

New error codes: ProofOfPossessionFailed, ChallengeNotFound,
ChallengeExpired, HealthMetricsNotFound

Closes #285
Closes #286
