### PR TITLE
feat: add CLI validation, contract-id fallback, and env command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ ed25519-dalek = "2"
 rand = "0.8"
 criterion = { version = "0.5", features = ["html_reports"] }
 jsonschema = "0.17"
+assert_cmd = "2.0"
+predicates = "3.0"
 
 [profile.release]
 opt-level = "z"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,31 @@
 use clap::{Parser, Subcommand};
 use serde::Serialize;
 
+// ── SecretKey wrapper ──────────────────────────────────────────────────────────
+
+/// Opaque wrapper around a Stellar secret key string.
+/// Does not implement Debug or Display to prevent accidental logging.
+struct SecretKey(String);
+
+impl SecretKey {
+    fn new(s: impl Into<String>) -> Self {
+        SecretKey(s.into())
+    }
+}
+
+impl std::ops::Deref for SecretKey {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<std::ffi::OsStr> for SecretKey {
+    fn as_ref(&self) -> &std::ffi::OsStr {
+        self.0.as_ref()
+    }
+}
+
 // ── Network profile management ────────────────────────────────────────────────
 
 #[derive(Serialize, serde::Deserialize, Clone, Debug)]
@@ -66,11 +91,20 @@ fn default_network() -> String {
         .unwrap_or_else(|| "testnet".to_string())
 }
 
-
+/// Return the contract ID to use, checking the per-command arg first, then
+/// the global flag / ANCHOR_CONTRACT_ID env var.  Exits with a clear error
+/// if neither is set.
+fn require_contract_id(global: Option<String>, local: Option<String>, command: &str) -> String {
+    local.or(global).unwrap_or_else(|| {
+        eprintln!("error: --contract-id (or ANCHOR_CONTRACT_ID) is required for `{command}`");
+        eprintln!("hint:  pass --contract-id <ID>  or  export ANCHOR_CONTRACT_ID=<ID>");
+        std::process::exit(1);
+    })
+}
 
 /// Resolve the signing source from flags or environment.
 /// Priority: --secret-key > ANCHOR_ADMIN_SECRET > --keypair-file > --credential-name
-fn resolve_source(secret_key: Option<&str>, keypair_file: Option<&str>, credential_name: Option<&str>) -> String {
+fn resolve_source(secret_key: Option<&str>, keypair_file: Option<&str>, credential_name: Option<&str>) -> SecretKey {
     if let Some(sk) = secret_key {
         return SecretKey::new(sk);
     }
@@ -99,7 +133,11 @@ fn resolve_source(secret_key: Option<&str>, keypair_file: Option<&str>, credenti
             .unwrap_or_else(|e| { eprintln!("error: failed to read password: {e}"); std::process::exit(1); });
         return keystore_get_decrypted(name, &password);
     }
-    eprintln!("error: signing key required — provide --secret-key, set ANCHOR_ADMIN_SECRET, use --keypair-file, or use --credential-name");
+    eprintln!("error: signing key required — provide one of:");
+    eprintln!("  --secret-key <KEY>");
+    eprintln!("  export ANCHOR_ADMIN_SECRET=<KEY>");
+    eprintln!("  --keypair-file <PATH>");
+    eprintln!("  --credential-name <NAME>  (use: anchorkit credentials add --name <NAME>)");
     std::process::exit(1);
 }
 
@@ -134,6 +172,7 @@ fn stellar_invoke(
 ) -> String {
     let url = rpc_url_for(network);
     let phrase = passphrase_for(network);
+    let source: &str = source; // coerce &SecretKey → &str for uniform array element type
     let output = std::process::Command::new("stellar")
         .args(["contract", "invoke",
                "--id", contract_id,
@@ -203,7 +242,7 @@ enum Commands {
     Register {
         #[arg(long)] address: String,
         #[arg(long, value_delimiter = ',')] services: Vec<String>,
-        #[arg(long)] contract_id: String,
+        #[arg(long)] contract_id: Option<String>,
         #[arg(long, default_value = "testnet")] network: String,
         #[arg(long)] secret_key: Option<String>,
         #[arg(long)] keypair_file: Option<String>,
@@ -216,7 +255,7 @@ enum Commands {
     Attest {
         #[arg(long)] subject: String,
         #[arg(long)] payload_hash: String,
-        #[arg(long)] contract_id: String,
+        #[arg(long)] contract_id: Option<String>,
         #[arg(long, default_value = "testnet")] network: String,
         #[arg(long)] secret_key: Option<String>,
         #[arg(long)] keypair_file: Option<String>,
@@ -233,7 +272,7 @@ enum Commands {
         #[arg(long)] to: String,
         /// Amount in base asset units
         #[arg(long)] amount: u64,
-        #[arg(long)] contract_id: String,
+        #[arg(long)] contract_id: Option<String>,
         #[arg(long, default_value = "testnet")] network: String,
         #[arg(long)] secret_key: Option<String>,
         #[arg(long)] keypair_file: Option<String>,
@@ -250,7 +289,7 @@ enum Commands {
     /// Revoke an attestor
     Revoke {
         #[arg(long)] address: String,
-        #[arg(long)] contract_id: String,
+        #[arg(long)] contract_id: Option<String>,
         #[arg(long, default_value = "testnet")] network: String,
         #[arg(long)] secret_key: Option<String>,
         #[arg(long)] keypair_file: Option<String>,
@@ -268,6 +307,8 @@ enum Commands {
         #[arg(long)]
         fix: bool,
     },
+    /// Show active environment: contract ID, network, profiles, and recent deployments
+    Env,
     /// Manage custom network profiles
     Network {
         #[command(subcommand)]
@@ -415,7 +456,7 @@ fn pre_deploy_validate(network: &str) -> bool {
 ///   2. Upload the WASM to the network and obtain its hash.
 ///   3. Call `upgrade(new_wasm_hash)` on the contract.
 ///   4. Call `migrate()` to apply any state-schema changes.
-fn upgrade_contract(contract_id: &str, network: &str, source: &str) {
+fn upgrade_contract(contract_id: &str, network: &str, source: &SecretKey) {
     println!("\n🔍 Pre-upgrade validation ({network})...");
     if !pre_deploy_validate(network) {
         eprintln!("\n❌ Pre-upgrade validation failed. Aborting.");
@@ -444,11 +485,12 @@ fn upgrade_contract(contract_id: &str, network: &str, source: &str) {
 
     // Upload WASM and capture the resulting hash.
     println!("Uploading WASM to {network}...");
+    let source_str: &str = source; // coerce &SecretKey → &str for uniform array element type
     let upload_output = std::process::Command::new("stellar")
         .args([
             "contract", "upload",
             "--wasm", wasm,
-            "--source", source,
+            "--source", source_str,
             "--rpc-url", &net_url,
             "--network-passphrase", &net_phrase,
         ])
@@ -834,10 +876,11 @@ fn check_contract_deployment(contract_id: &str, network: &str) -> CheckResult {
         .map(SecretKey::new)
         .unwrap_or_else(|| SecretKey::new("default"));
 
+    let source_str: &str = &*source; // coerce SecretKey → &str for uniform array element type
     let output = std::process::Command::new("stellar")
         .args(["contract", "invoke",
                "--id", contract_id,
-               "--source", &source,
+               "--source", source_str,
                "--rpc-url", &rpc_url_for(network),
                "--network-passphrase", &passphrase_for(network),
                "--",
@@ -940,6 +983,51 @@ fn doctor(network: &str, fix: bool) {
             println!("Tip: Run with --fix to automatically resolve fixable issues.\n");
         }
         std::process::exit(1);
+    }
+}
+
+// ── Env command ───────────────────────────────────────────────────────────────
+
+fn env_info() {
+    println!("Active environment");
+    match std::env::var("ANCHOR_CONTRACT_ID").ok().filter(|s| !s.is_empty()) {
+        Some(id) => println!("  Contract ID : {} (from ANCHOR_CONTRACT_ID)", id),
+        None     => println!("  Contract ID : (not set — use --contract-id or export ANCHOR_CONTRACT_ID=<ID>)"),
+    }
+    let network_via_env = std::env::var("STELLAR_NETWORK").ok().filter(|s| !s.is_empty());
+    let active_network = network_via_env.as_deref()
+        .map(|s| s.to_string())
+        .unwrap_or_else(default_network);
+    let network_src = if network_via_env.is_some() { "(from STELLAR_NETWORK)" } else { "(default)" };
+    println!("  Network     : {} {}", active_network, network_src);
+
+    println!("\nNetwork profiles");
+    println!("  {:<16} {:<45} {}", "NAME", "RPC URL", "PASSPHRASE");
+    let builtins = [
+        ("testnet",   "https://soroban-testnet.stellar.org",  "Test SDF Network ; September 2015"),
+        ("mainnet",   "https://horizon.stellar.org",           "Public Global Stellar Network ; September 2015"),
+        ("futurenet", "https://rpc-futurenet.stellar.org",     "Test SDF Future Network ; October 2022"),
+    ];
+    for (name, url, phrase) in &builtins {
+        println!("  {:<16} {:<45} {} (built-in)", name, url, phrase);
+    }
+    for p in &load_network_profiles() {
+        let marker = if p.is_default { " (default)" } else { "" };
+        println!("  {:<16} {:<45} {}{}", p.name, p.rpc_url, p.network_passphrase, marker);
+    }
+
+    println!("\nRecent deployments (.anchorkit/deployments.json)");
+    let deployments = load_deployments();
+    if deployments.is_empty() {
+        println!("  (none)");
+    } else {
+        println!("  {:<52} {:<12} {:<14} {}", "CONTRACT ID", "NETWORK", "TIMESTAMP", "INIT");
+        for d in deployments.iter().rev().take(5) {
+            let display_id = &d.contract_id[..d.contract_id.len().min(52)];
+            println!("  {:<52} {:<12} {:<14} {}",
+                display_id, d.network, d.timestamp,
+                if d.initialized { "yes" } else { "no" });
+        }
     }
 }
 
@@ -1173,15 +1261,19 @@ fn credentials_remove(name: &str) {
 
 fn main() {
     let cli = Cli::parse();
-    let network = cli.network.unwrap_or_else(default_network);
+    let global_contract_id = cli.contract_id.clone();
+    let network = cli.network.unwrap_or_else(|| {
+        let n = default_network();
+        if std::env::var("STELLAR_NETWORK").is_err() && !load_network_profiles().iter().any(|p| p.is_default) {
+            eprintln!("note: STELLAR_NETWORK not set — using '{n}' (set STELLAR_NETWORK or: anchorkit network set-default --name <NAME>)");
+        }
+        n
+    });
     match cli.command {
         Commands::Deploy { network: cmd_net, source, admin, dry_run, list, upgrade, secret_key, keypair_file } => {
             let net = cmd_net;
             if upgrade {
-                let contract_id = cli.contract_id.unwrap_or_else(|| {
-                    eprintln!("error: --contract-id (or ANCHOR_CONTRACT_ID) is required for --upgrade");
-                    std::process::exit(1);
-                });
+                let contract_id = require_contract_id(global_contract_id, None, "deploy --upgrade");
                 let signing_source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), None);
                 upgrade_contract(&contract_id, &net, &signing_source);
             } else {
@@ -1189,27 +1281,34 @@ fn main() {
             }
         }
         Commands::Register { address, services, contract_id, network: cmd_net, secret_key, keypair_file, credential_name, sep10_token, sep10_issuer } => {
+            let cid = require_contract_id(global_contract_id, contract_id, "register");
             let net = cmd_net;
             let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), credential_name.as_deref());
-            register(&address, &services, &contract_id, &net, &source, &sep10_token, &sep10_issuer);
+            register(&address, &services, &cid, &net, &source, &sep10_token, &sep10_issuer);
         }
         Commands::Attest { subject, payload_hash, contract_id, network: cmd_net, secret_key, keypair_file, credential_name, issuer, session_id } => {
+            let cid = require_contract_id(global_contract_id, contract_id, "attest");
             let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), credential_name.as_deref());
-            attest(&subject, &payload_hash, &contract_id, &cmd_net, &source, &issuer, session_id);
+            attest(&subject, &payload_hash, &cid, &cmd_net, &source, &issuer, session_id);
         }
         Commands::Quote { from, to, amount, contract_id, network: cmd_net, secret_key, keypair_file, credential_name } => {
+            let cid = require_contract_id(global_contract_id, contract_id, "quote");
             let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), credential_name.as_deref());
-            quote(&from, &to, amount, &contract_id, &cmd_net, &source);
+            quote(&from, &to, amount, &cid, &cmd_net, &source);
         }
         Commands::Status { tx_id, anchor_url } => {
             status(&tx_id, &anchor_url);
         }
         Commands::Revoke { address, contract_id, network: cmd_net, secret_key, keypair_file, credential_name } => {
+            let cid = require_contract_id(global_contract_id, contract_id, "revoke");
             let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), credential_name.as_deref());
-            revoke(&address, &contract_id, &cmd_net, &source);
+            revoke(&address, &cid, &cmd_net, &source);
         }
         Commands::Doctor { fix } => {
             doctor(&network, fix);
+        }
+        Commands::Env => {
+            env_info();
         }
         Commands::Network { action } => {
             network_cmd(action);

--- a/tests/cli_validation_tests.rs
+++ b/tests/cli_validation_tests.rs
@@ -1,0 +1,251 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+fn cmd() -> Command {
+    Command::cargo_bin("anchorkit").expect("anchorkit binary not found")
+}
+
+// ── Group A: missing contract_id validation ───────────────────────────────────
+
+#[test]
+fn test_register_missing_contract_id() {
+    cmd()
+        .args(["register", "--address", "GABC",
+               "--services", "kyc",
+               "--sep10-token", "T", "--sep10-issuer", "I",
+               "--secret-key", "SABC"])
+        .env_remove("ANCHOR_CONTRACT_ID")
+        .assert()
+        .failure()
+        .stderr(contains("--contract-id"))
+        .stderr(contains("ANCHOR_CONTRACT_ID"));
+}
+
+#[test]
+fn test_attest_missing_contract_id() {
+    cmd()
+        .args(["attest", "--subject", "S", "--payload-hash", "H",
+               "--issuer", "I", "--secret-key", "SABC"])
+        .env_remove("ANCHOR_CONTRACT_ID")
+        .assert()
+        .failure()
+        .stderr(contains("--contract-id"))
+        .stderr(contains("ANCHOR_CONTRACT_ID"));
+}
+
+#[test]
+fn test_quote_missing_contract_id() {
+    cmd()
+        .args(["quote", "--from", "USDC", "--to", "XLM",
+               "--amount", "100", "--secret-key", "SABC"])
+        .env_remove("ANCHOR_CONTRACT_ID")
+        .assert()
+        .failure()
+        .stderr(contains("--contract-id"))
+        .stderr(contains("ANCHOR_CONTRACT_ID"));
+}
+
+#[test]
+fn test_revoke_missing_contract_id() {
+    cmd()
+        .args(["revoke", "--address", "GABC", "--secret-key", "SABC"])
+        .env_remove("ANCHOR_CONTRACT_ID")
+        .assert()
+        .failure()
+        .stderr(contains("--contract-id"))
+        .stderr(contains("ANCHOR_CONTRACT_ID"));
+}
+
+#[test]
+fn test_deploy_upgrade_missing_contract_id() {
+    cmd()
+        .args(["deploy", "--upgrade", "--secret-key", "SABC"])
+        .env_remove("ANCHOR_CONTRACT_ID")
+        .assert()
+        .failure()
+        .stderr(contains("--contract-id"))
+        .stderr(contains("ANCHOR_CONTRACT_ID"));
+}
+
+// ── Group B: contract_id resolved from env var ────────────────────────────────
+
+/// When ANCHOR_CONTRACT_ID is set the contract-id validation passes; the
+/// command then fails for another reason (missing signing key), NOT because
+/// of a missing contract ID.
+#[test]
+fn test_register_contract_id_from_env_passes_validation() {
+    cmd()
+        .args(["register", "--address", "GABC",
+               "--services", "kyc",
+               "--sep10-token", "T", "--sep10-issuer", "I"])
+        .env("ANCHOR_CONTRACT_ID", "CTEST123")
+        .env_remove("ANCHOR_ADMIN_SECRET")
+        .assert()
+        .failure()
+        // Error must be about the signing key, not the contract ID
+        .stderr(contains("signing key required"))
+        .stderr(predicates::str::contains("--contract-id").not());
+}
+
+#[test]
+fn test_revoke_contract_id_from_env_passes_validation() {
+    cmd()
+        .args(["revoke", "--address", "GABC"])
+        .env("ANCHOR_CONTRACT_ID", "CTEST123")
+        .env_remove("ANCHOR_ADMIN_SECRET")
+        .assert()
+        .failure()
+        .stderr(contains("signing key required"))
+        .stderr(predicates::str::contains("--contract-id").not());
+}
+
+// ── Group C: network fallback note ────────────────────────────────────────────
+
+#[test]
+fn test_network_note_when_stellar_network_unset() {
+    // `network list` is a harmless read-only command with no STELLAR_NETWORK dependency.
+    // When neither STELLAR_NETWORK nor a default profile is set, a note is printed.
+    cmd()
+        .args(["network", "list"])
+        .env_remove("STELLAR_NETWORK")
+        .env("HOME", std::env::temp_dir().to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(contains("note:"))
+        .stderr(contains("testnet"));
+}
+
+#[test]
+fn test_no_network_note_when_stellar_network_is_set() {
+    cmd()
+        .args(["network", "list"])
+        .env("STELLAR_NETWORK", "testnet")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("note:").not());
+}
+
+// ── Group D: `env` subcommand ─────────────────────────────────────────────────
+
+#[test]
+fn test_env_command_exits_zero() {
+    cmd()
+        .args(["env"])
+        .env_remove("ANCHOR_CONTRACT_ID")
+        .env_remove("STELLAR_NETWORK")
+        .env("HOME", std::env::temp_dir().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(contains("Contract ID"))
+        .stdout(contains("Network"));
+}
+
+#[test]
+fn test_env_command_shows_contract_id_from_env() {
+    cmd()
+        .args(["env"])
+        .env("ANCHOR_CONTRACT_ID", "CTEST123ENVTEST")
+        .env("HOME", std::env::temp_dir().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(contains("CTEST123ENVTEST"))
+        .stdout(contains("ANCHOR_CONTRACT_ID"));
+}
+
+#[test]
+fn test_env_command_shows_network_from_env() {
+    cmd()
+        .args(["env"])
+        .env("STELLAR_NETWORK", "mainnet")
+        .env("HOME", std::env::temp_dir().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(contains("mainnet"))
+        .stdout(contains("STELLAR_NETWORK"));
+}
+
+#[test]
+fn test_env_command_shows_builtin_profiles() {
+    cmd()
+        .args(["env"])
+        .env("HOME", std::env::temp_dir().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(contains("testnet"))
+        .stdout(contains("mainnet"))
+        .stdout(contains("futurenet"));
+}
+
+// ── Group E: commands that do NOT need contract_id ───────────────────────────
+
+#[test]
+fn test_doctor_does_not_require_contract_id() {
+    // doctor may exit 0 or 1 depending on the environment, but must NOT
+    // emit the contract-id validation error.
+    let output = cmd()
+        .args(["doctor"])
+        .env_remove("ANCHOR_CONTRACT_ID")
+        .output()
+        .expect("failed to run anchorkit doctor");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("--contract-id (or ANCHOR_CONTRACT_ID) is required"),
+        "doctor should not require --contract-id, but got: {stderr}"
+    );
+}
+
+#[test]
+fn test_credentials_list_does_not_require_contract_id() {
+    cmd()
+        .args(["credentials", "list"])
+        .env_remove("ANCHOR_CONTRACT_ID")
+        .env("HOME", std::env::temp_dir().to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("--contract-id").not());
+}
+
+#[test]
+fn test_network_list_does_not_require_contract_id() {
+    cmd()
+        .args(["network", "list"])
+        .env_remove("ANCHOR_CONTRACT_ID")
+        .env("HOME", std::env::temp_dir().to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("--contract-id (or ANCHOR_CONTRACT_ID) is required").not());
+}
+
+// ── Group F: invalid invocations (clap-level) ────────────────────────────────
+
+#[test]
+fn test_missing_subcommand_exits_with_usage() {
+    cmd()
+        .assert()
+        .failure()
+        .stderr(contains("Usage"));
+}
+
+#[test]
+fn test_unknown_subcommand() {
+    cmd()
+        .args(["foobar"])
+        .assert()
+        .failure()
+        .stderr(contains("unrecognized subcommand"));
+}
+
+#[test]
+fn test_register_missing_required_address_arg() {
+    // --contract-id and signing key provided, but --address is missing → clap error
+    cmd()
+        .args(["register",
+               "--contract-id", "CTEST",
+               "--services", "kyc",
+               "--sep10-token", "T", "--sep10-issuer", "I",
+               "--secret-key", "SABC"])
+        .assert()
+        .failure()
+        .stderr(contains("--address"));
+}


### PR DESCRIPTION
 Closes #262 

  Implements all acceptance criteria from the issue:

  - require_contract_id(): validates --contract-id / ANCHOR_CONTRACT_ID for register, attest, quote, revoke, and deploy
  --upgrade — exits with a clear error and hint if neither is set
  - Global --contract-id now falls back to per-command args, wiring ANCHOR_CONTRACT_ID env var through all contract
  commands
  - resolve_source() error message expanded to list all 4 signing key options
  - Network fallback note printed to stderr when STELLAR_NETWORK is unset and no default profile is configured
  - anchorkit env subcommand: shows active contract ID, network, all configured profiles, and last 5 deployment records
  - SecretKey newtype defined with Deref<Target=str> and AsRef<OsStr> — prevents accidental logging
  - 17 integration tests in tests/cli_validation_tests.rs covering: missing contract-id, env-var fallback, network note,
   env command output, commands that don't need contract-id, and invalid clap invocations