### PR TITLE
feat: batch tx queries, status summary, and anchor metadata version history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ argon2 = { version = "0.5.3", optional = true }
 rand = { version = "0.8", features = ["std"] }
 base64 = { version = "0.22" }
 rpassword = { version = "7.3", optional = true }
+sha2 = { version = "0.10", default-features = false }
 
 [build-dependencies]
 serde_json = "1"

--- a/src/anchor_health.rs
+++ b/src/anchor_health.rs
@@ -1,0 +1,294 @@
+//! Off-chain helpers for anchor health monitoring and proof-of-possession.
+//!
+//! # Proof-of-possession protocol
+//!
+//! The proof-of-possession (PoP) flow lets an anchor prove it controls the
+//! endpoint it advertises without requiring a live HTTP round-trip from the
+//! contract itself (Soroban contracts cannot make outbound HTTP calls).
+//!
+//! ## Flow
+//!
+//! ```text
+//! 1. Anchor publishes a challenge nonce in its stellar.toml:
+//!       ANCHOR_PROOF_CHALLENGE = "<hex-encoded 32-byte nonce>"
+//!
+//! 2. Off-chain monitor fetches the challenge and computes:
+//!       proof_hash = SHA-256(challenge_bytes || endpoint_bytes)
+//!
+//! 3. Anchor calls AnchorKitContract::register_endpoint_proof(
+//!       anchor, endpoint, proof_hash)
+//!    on-chain, binding its Stellar identity to the endpoint.
+//!
+//! 4. Any verifier calls AnchorKitContract::verify_endpoint_proof(
+//!       anchor, proof_hash)
+//!    to confirm the hash matches and mark the record as verified.
+//! ```
+//!
+//! The helpers in this module implement step 2 and provide utilities for
+//! health-event recording that wrap the contract calls.
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+// ---------------------------------------------------------------------------
+// Proof-of-possession helpers
+// ---------------------------------------------------------------------------
+
+/// Compute the proof-of-possession hash that an anchor must submit to
+/// [`AnchorKitContract::register_endpoint_proof`].
+///
+/// `proof_hash = SHA-256(challenge_bytes || endpoint_bytes)`
+///
+/// # Arguments
+///
+/// * `challenge` - Raw bytes of the nonce published by the anchor
+///   (e.g. hex-decoded `ANCHOR_PROOF_CHALLENGE` from `stellar.toml`).
+/// * `endpoint`  - The endpoint URL string the anchor is proving ownership of.
+///
+/// # Returns
+///
+/// A 32-byte array containing the SHA-256 digest.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::anchor_health::compute_pop_hash;
+///
+/// let challenge = b"deadbeefdeadbeefdeadbeefdeadbeef";
+/// let endpoint  = "https://anchor.example.com";
+/// let hash = compute_pop_hash(challenge, endpoint);
+/// assert_eq!(hash.len(), 32);
+/// ```
+pub fn compute_pop_hash(challenge: &[u8], endpoint: &str) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(challenge);
+    hasher.update(endpoint.as_bytes());
+    hasher.finalize().into()
+}
+
+/// Verify that a stored proof hash matches the expected value recomputed from
+/// `challenge` and `endpoint`.
+///
+/// Returns `true` when the hashes match — the anchor controls the endpoint.
+///
+/// # Arguments
+///
+/// * `stored_hash` - The 32-byte hash retrieved from the contract via
+///   `AnchorKitContract::get_endpoint_proof`.
+/// * `challenge`   - The raw challenge bytes fetched from the anchor's
+///   `stellar.toml`.
+/// * `endpoint`    - The endpoint URL to verify.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::anchor_health::{compute_pop_hash, verify_pop_challenge};
+///
+/// let challenge = b"deadbeefdeadbeefdeadbeefdeadbeef";
+/// let endpoint  = "https://anchor.example.com";
+/// let hash = compute_pop_hash(challenge, endpoint);
+///
+/// assert!(verify_pop_challenge(&hash, challenge, endpoint));
+/// assert!(!verify_pop_challenge(&hash, b"wrongchallenge00wrongchallenge00", endpoint));
+/// assert!(!verify_pop_challenge(&hash, challenge, "https://other.example.com"));
+/// ```
+pub fn verify_pop_challenge(
+    stored_hash: &[u8; 32],
+    challenge: &[u8],
+    endpoint: &str,
+) -> bool {
+    let expected = compute_pop_hash(challenge, endpoint);
+    // Constant-time comparison to prevent timing attacks.
+    constant_time_eq(stored_hash, &expected)
+}
+
+/// Constant-time byte-slice equality check.
+fn constant_time_eq(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+// ---------------------------------------------------------------------------
+// Health event helpers
+// ---------------------------------------------------------------------------
+
+/// Outcome of a single anchor endpoint interaction, used as input to
+/// [`classify_health_event`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum EndpointOutcome {
+    /// The call succeeded and returned a valid response.
+    Success,
+    /// The call failed (network error, timeout, invalid response, etc.).
+    Failure(String),
+}
+
+impl EndpointOutcome {
+    /// Returns `true` for [`EndpointOutcome::Success`].
+    pub fn is_success(&self) -> bool {
+        matches!(self, EndpointOutcome::Success)
+    }
+
+    /// Returns the failure reason, or an empty string for success.
+    pub fn failure_reason(&self) -> &str {
+        match self {
+            EndpointOutcome::Success => "",
+            EndpointOutcome::Failure(r) => r.as_str(),
+        }
+    }
+}
+
+/// Classify a raw HTTP status code into an [`EndpointOutcome`].
+///
+/// Status codes 200–299 are treated as success; everything else is a failure.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::anchor_health::{classify_http_status, EndpointOutcome};
+///
+/// assert_eq!(classify_http_status(200), EndpointOutcome::Success);
+/// assert_eq!(classify_http_status(204), EndpointOutcome::Success);
+/// assert!(matches!(classify_http_status(404), EndpointOutcome::Failure(_)));
+/// assert!(matches!(classify_http_status(500), EndpointOutcome::Failure(_)));
+/// ```
+pub fn classify_http_status(status: u16) -> EndpointOutcome {
+    if (200..300).contains(&status) {
+        EndpointOutcome::Success
+    } else {
+        EndpointOutcome::Failure(alloc::format!("HTTP {status}"))
+    }
+}
+
+/// Compute an uptime percentage (0.0–100.0) from raw success/failure counts.
+///
+/// Returns `0.0` when `total == 0`.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::anchor_health::uptime_percent;
+///
+/// assert_eq!(uptime_percent(9, 1), 90.0_f64);
+/// assert_eq!(uptime_percent(0, 0), 0.0_f64);
+/// assert_eq!(uptime_percent(1, 0), 100.0_f64);
+/// ```
+pub fn uptime_percent(success: u64, failure: u64) -> f64 {
+    let total = success + failure;
+    if total == 0 {
+        return 0.0;
+    }
+    (success as f64 / total as f64) * 100.0
+}
+
+/// Convert basis-point uptime (0–10 000) returned by the contract to a
+/// human-readable percentage string with two decimal places.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::anchor_health::bps_to_percent_str;
+///
+/// assert_eq!(bps_to_percent_str(10_000), "100.00%");
+/// assert_eq!(bps_to_percent_str(9_950),  "99.50%");
+/// assert_eq!(bps_to_percent_str(0),      "0.00%");
+/// ```
+pub fn bps_to_percent_str(bps: u32) -> String {
+    let whole = bps / 100;
+    let frac = bps % 100;
+    alloc::format!("{whole}.{frac:02}%")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_pop_hash_is_deterministic() {
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint = "https://anchor.example.com";
+        let h1 = compute_pop_hash(challenge, endpoint);
+        let h2 = compute_pop_hash(challenge, endpoint);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn compute_pop_hash_differs_on_different_inputs() {
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let h1 = compute_pop_hash(challenge, "https://anchor.example.com");
+        let h2 = compute_pop_hash(challenge, "https://other.example.com");
+        assert_ne!(h1, h2);
+
+        let h3 = compute_pop_hash(b"different_challenge_bytes_______", "https://anchor.example.com");
+        assert_ne!(h1, h3);
+    }
+
+    #[test]
+    fn verify_pop_challenge_success() {
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint = "https://anchor.example.com";
+        let hash = compute_pop_hash(challenge, endpoint);
+        assert!(verify_pop_challenge(&hash, challenge, endpoint));
+    }
+
+    #[test]
+    fn verify_pop_challenge_wrong_challenge_fails() {
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint = "https://anchor.example.com";
+        let hash = compute_pop_hash(challenge, endpoint);
+        assert!(!verify_pop_challenge(&hash, b"wrong_challenge_bytes_32_chars__", endpoint));
+    }
+
+    #[test]
+    fn verify_pop_challenge_wrong_endpoint_fails() {
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint = "https://anchor.example.com";
+        let hash = compute_pop_hash(challenge, endpoint);
+        assert!(!verify_pop_challenge(&hash, challenge, "https://evil.example.com"));
+    }
+
+    #[test]
+    fn classify_http_status_success_range() {
+        for code in [200u16, 201, 204, 299] {
+            assert_eq!(classify_http_status(code), EndpointOutcome::Success, "code={code}");
+        }
+    }
+
+    #[test]
+    fn classify_http_status_failure_range() {
+        for code in [400u16, 404, 500, 503] {
+            assert!(matches!(classify_http_status(code), EndpointOutcome::Failure(_)), "code={code}");
+        }
+    }
+
+    #[test]
+    fn uptime_percent_calculations() {
+        assert_eq!(uptime_percent(0, 0), 0.0);
+        assert_eq!(uptime_percent(1, 0), 100.0);
+        assert_eq!(uptime_percent(0, 1), 0.0);
+        assert!((uptime_percent(9, 1) - 90.0).abs() < 1e-9);
+        assert!((uptime_percent(1, 1) - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn bps_to_percent_str_formatting() {
+        assert_eq!(bps_to_percent_str(10_000), "100.00%");
+        assert_eq!(bps_to_percent_str(9_950), "99.50%");
+        assert_eq!(bps_to_percent_str(5_000), "50.00%");
+        assert_eq!(bps_to_percent_str(0), "0.00%");
+        assert_eq!(bps_to_percent_str(1), "0.01%");
+    }
+
+    #[test]
+    fn endpoint_outcome_helpers() {
+        assert!(EndpointOutcome::Success.is_success());
+        assert!(!EndpointOutcome::Failure("err".into()).is_success());
+        assert_eq!(EndpointOutcome::Success.failure_reason(), "");
+        assert_eq!(EndpointOutcome::Failure("timeout".into()).failure_reason(), "timeout");
+    }
+}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -683,6 +683,38 @@ pub struct ContractDiagnostics {
 /// stored data to detect version skew.
 pub const SCHEMA_V1: u32 = 1;
 
+/// Aggregated transaction counts returned by
+/// [`AnchorKitContract::summarize_transactions_by_status`].
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransactionStatusSummary {
+    pub pending_count: u64,
+    pub in_progress_count: u64,
+    pub completed_count: u64,
+    pub failed_count: u64,
+    pub total_count: u64,
+}
+
+/// A single versioned snapshot of anchor metadata, stored in the history log.
+///
+/// Written by [`AnchorKitContract::set_anchor_metadata`] each time the metadata
+/// changes. The `version` field is a monotonically increasing counter scoped to
+/// the anchor; `updated_at` is the ledger timestamp of the write.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AnchorMetadataVersion {
+    /// Monotonically increasing version number (1-based).
+    pub version: u32,
+    /// Ledger timestamp when this version was written.
+    pub updated_at: u64,
+    pub reputation_score: u32,
+    pub average_settlement_time: u64,
+    pub liquidity_score: u32,
+    pub uptime_percentage: u32,
+    pub total_volume: u64,
+    pub is_active: bool,
+}
+
 // ---------------------------------------------------------------------------
 // Event structs
 // ---------------------------------------------------------------------------
@@ -3595,6 +3627,34 @@ impl AnchorKitContract {
         env.storage().persistent().set(&meta_key, &meta);
         env.storage().persistent().extend_ttl(&meta_key, PERSISTENT_TTL, PERSISTENT_TTL);
 
+        // ── Version history ──────────────────────────────────────────────────
+        // Increment the per-anchor version counter and append a history entry.
+        let xdr = anchor.clone().to_xdr(&env);
+        let raw = xdr_to_vec(&xdr);
+        let vcnt_key = make_storage_key(&env, &[b"METAVCNT", &raw]);
+        let version: u32 = env
+            .storage()
+            .persistent()
+            .get::<_, u32>(&vcnt_key)
+            .unwrap_or(0)
+            + 1;
+        env.storage().persistent().set(&vcnt_key, &version);
+        env.storage().persistent().extend_ttl(&vcnt_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        let history_entry = AnchorMetadataVersion {
+            version,
+            updated_at: env.ledger().timestamp(),
+            reputation_score,
+            average_settlement_time,
+            liquidity_score,
+            uptime_percentage,
+            total_volume,
+            is_active: true,
+        };
+        let hkey = make_storage_key(&env, &[b"METAHIST", &raw, &version.to_be_bytes()]);
+        env.storage().persistent().set(&hkey, &history_entry);
+        env.storage().persistent().extend_ttl(&hkey, PERSISTENT_TTL, PERSISTENT_TTL);
+
         // Maintain ANCHLIST — stored under a deterministic key (#229)
         let list_key = make_storage_key(&env, &[b"ANCHLIST"]);
         let mut list: Vec<Address> = env.storage().persistent()
@@ -3605,6 +3665,85 @@ impl AnchorKitContract {
             env.storage().persistent().set(&list_key, &list);
             env.storage().persistent().extend_ttl(&list_key, PERSISTENT_TTL, PERSISTENT_TTL);
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Anchor metadata version history
+    // -----------------------------------------------------------------------
+
+    /// Return the current version number for an anchor's metadata history.
+    ///
+    /// Returns `0` when no metadata has ever been set for the anchor.
+    pub fn get_anchor_metadata_version_count(env: Env, anchor: Address) -> u32 {
+        let xdr = anchor.clone().to_xdr(&env);
+        let raw = xdr_to_vec(&xdr);
+        let vcnt_key = make_storage_key(&env, &[b"METAVCNT", &raw]);
+        env.storage()
+            .persistent()
+            .get::<_, u32>(&vcnt_key)
+            .unwrap_or(0)
+    }
+
+    /// Retrieve a specific historical version of an anchor's metadata.
+    ///
+    /// Versions are 1-based and increase monotonically with each call to
+    /// [`set_anchor_metadata`](Self::set_anchor_metadata).
+    ///
+    /// # Errors
+    ///
+    /// Panics with [`ErrorCode::AttestorNotRegistered`] when the requested
+    /// version does not exist (never written or TTL expired).
+    pub fn get_anchor_metadata_at_version(
+        env: Env,
+        anchor: Address,
+        version: u32,
+    ) -> AnchorMetadataVersion {
+        let xdr = anchor.clone().to_xdr(&env);
+        let raw = xdr_to_vec(&xdr);
+        let hkey = make_storage_key(&env, &[b"METAHIST", &raw, &version.to_be_bytes()]);
+        env.storage()
+            .persistent()
+            .get::<_, AnchorMetadataVersion>(&hkey)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestorNotRegistered))
+    }
+
+    /// Return the full ordered metadata history for an anchor, from version 1
+    /// to the current version, capped at 50 entries to prevent unbounded reads.
+    ///
+    /// Entries are returned in ascending version order (oldest first).
+    /// Versions whose storage entries have expired are silently omitted.
+    ///
+    /// # Returns
+    ///
+    /// A [`Vec`] of [`AnchorMetadataVersion`] records, oldest first.
+    pub fn get_anchor_metadata_history(
+        env: Env,
+        anchor: Address,
+    ) -> Vec<AnchorMetadataVersion> {
+        const MAX_HISTORY: u32 = 50;
+        let xdr = anchor.clone().to_xdr(&env);
+        let raw = xdr_to_vec(&xdr);
+        let vcnt_key = make_storage_key(&env, &[b"METAVCNT", &raw]);
+        let total: u32 = env
+            .storage()
+            .persistent()
+            .get::<_, u32>(&vcnt_key)
+            .unwrap_or(0);
+
+        let mut history = Vec::new(&env);
+        // Start from the oldest version that fits within the cap.
+        let start = if total > MAX_HISTORY { total - MAX_HISTORY + 1 } else { 1 };
+        for v in start..=total {
+            let hkey = make_storage_key(&env, &[b"METAHIST", &raw, &v.to_be_bytes()]);
+            if let Some(entry) = env
+                .storage()
+                .persistent()
+                .get::<_, AnchorMetadataVersion>(&hkey)
+            {
+                history.push_back(entry);
+            }
+        }
+        history
     }
 
     /// Reactivate a previously deactivated anchor (admin-only). Sets `is_active = true`.
@@ -4068,7 +4207,7 @@ impl AnchorKitContract {
             initiator,
             timestamp: now,
             last_updated: now,
-            last_updated_ledger: env.ledger().sequence(),
+            last_updated_ledger: current_ledger,
             error_message: None,
             state_history: history,
             recovery_metadata: OptRecovery::None,
@@ -4076,6 +4215,78 @@ impl AnchorKitContract {
         let key = (symbol_short!("TXSTATE"), transaction_id);
         env.storage().persistent().set(&key, &record);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        // Track in TXIDS list for summarize_transactions_by_status
+        let ids_key = symbol_short!("TXIDS");
+        let mut ids: soroban_sdk::Vec<u64> = env
+            .storage().persistent().get(&ids_key)
+            .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
+        ids.push_back(transaction_id);
+        env.storage().persistent().set(&ids_key, &ids);
+        env.storage().persistent().extend_ttl(&ids_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        record
+    }
+
+    /// Advance a transaction from Pending to InProgress.
+    pub fn start_transaction_record(env: Env, transaction_id: u64) -> TransactionStateRecord {
+        Self::advance_transaction_state_internal(&env, transaction_id, TransactionState::InProgress, None)
+    }
+
+    /// Advance a transaction from InProgress to Completed.
+    pub fn complete_transaction_record(env: Env, transaction_id: u64) -> TransactionStateRecord {
+        Self::advance_transaction_state_internal(&env, transaction_id, TransactionState::Completed, None)
+    }
+
+    /// Advance a transaction to Failed with an error message.
+    pub fn fail_transaction_record(env: Env, transaction_id: u64, error_message: String) -> TransactionStateRecord {
+        Self::advance_transaction_state_internal(&env, transaction_id, TransactionState::Failed, Some(error_message))
+    }
+
+    fn advance_transaction_state_internal(
+        env: &Env,
+        transaction_id: u64,
+        new_state: TransactionState,
+        error_message: Option<String>,
+    ) -> TransactionStateRecord {
+        let key = (symbol_short!("TXSTATE"), transaction_id);
+        let mut record: TransactionStateRecord = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::AttestationNotFound));
+
+        let from_state = record.state;
+        if !from_state.is_valid_transition(new_state) {
+            panic_with_error!(env, ErrorCode::IllegalTransition);
+        }
+
+        let now = env.ledger().timestamp();
+        let current_ledger = env.ledger().sequence();
+        record.state = new_state;
+        record.last_updated = now;
+        record.last_updated_ledger = current_ledger;
+        record.error_message = error_message.clone();
+        record.state_history.push_back((new_state, now));
+
+        if new_state == TransactionState::Failed {
+            let reason = error_message
+                .unwrap_or_else(|| String::from_str(env, "unspecified failure"));
+            record.recovery_metadata = OptRecovery::Some(
+                crate::transaction_state_tracker::RecoveryMetadata {
+                    failure_reason: reason,
+                    last_updated_ledger: current_ledger,
+                    failed_from_state: from_state,
+                    retry_count: 0,
+                },
+            );
+        }
+
+        let ttl = if new_state.is_terminal() {
+            518_400u32 // ~30 days terminal TTL (matches TXSTATE_TTL_TERMINAL)
+        } else {
+            PERSISTENT_TTL
+        };
+        env.storage().persistent().set(&key, &record);
+        env.storage().persistent().extend_ttl(&key, ttl, ttl);
         record
     }
 
@@ -4501,6 +4712,108 @@ impl AnchorKitContract {
                 .unwrap_or(false)
         } else {
             false
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Batch transaction queries and summaries
+    // -----------------------------------------------------------------------
+
+    /// Return up to `limit` transaction records whose IDs fall in the inclusive
+    /// range `[from_id, to_id]`, ordered by ID ascending.
+    ///
+    /// The batch size is capped at 100 to prevent unbounded on-chain iteration.
+    /// This method reads directly from persistent storage and skips IDs that
+    /// have expired (TTL elapsed).
+    ///
+    /// # Arguments
+    ///
+    /// * `from_id` - Inclusive lower bound of the transaction ID range.
+    /// * `to_id`   - Inclusive upper bound of the transaction ID range.
+    /// * `limit`   - Maximum records to return (capped at 100).
+    ///
+    /// # Returns
+    ///
+    /// A [`Vec`] of [`TransactionStateRecord`]s sorted by ID ascending.
+    pub fn get_transactions_in_range(
+        env: Env,
+        from_id: u64,
+        to_id: u64,
+        limit: u32,
+    ) -> Vec<TransactionStateRecord> {
+        const MAX_BATCH: u32 = 100;
+        let effective_limit = limit.min(MAX_BATCH);
+        let mut results = Vec::new(&env);
+
+        if from_id > to_id {
+            return results;
+        }
+
+        let mut id = from_id;
+        let mut count = 0u32;
+        while id <= to_id && count < effective_limit {
+            let key = (symbol_short!("TXSTATE"), id);
+            if let Some(record) = env
+                .storage()
+                .persistent()
+                .get::<_, TransactionStateRecord>(&key)
+            {
+                results.push_back(record);
+                count += 1;
+            }
+            id += 1;
+        }
+        results
+    }
+
+    /// Return aggregated transaction counts grouped by current state.
+    ///
+    /// Reads the known-IDs list from persistent storage and counts each live
+    /// record by its current [`TransactionState`]. Records whose TTL has
+    /// elapsed are silently excluded from the totals.
+    ///
+    /// # Returns
+    ///
+    /// A [`TransactionStatusSummary`] with per-state counts and a `total_count`.
+    pub fn summarize_transactions_by_status(env: Env) -> TransactionStatusSummary {
+        use crate::transaction_state_tracker::TransactionState as TxState;
+
+        let ids_key = symbol_short!("TXIDS");
+        let ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&ids_key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut pending_count: u64 = 0;
+        let mut in_progress_count: u64 = 0;
+        let mut completed_count: u64 = 0;
+        let mut failed_count: u64 = 0;
+        let mut total_count: u64 = 0;
+
+        for id in ids.iter() {
+            let key = (symbol_short!("TXSTATE"), id);
+            if let Some(record) = env
+                .storage()
+                .persistent()
+                .get::<_, TransactionStateRecord>(&key)
+            {
+                match record.state {
+                    TxState::Pending    => pending_count += 1,
+                    TxState::InProgress => in_progress_count += 1,
+                    TxState::Completed  => completed_count += 1,
+                    TxState::Failed     => failed_count += 1,
+                }
+                total_count += 1;
+            }
+        }
+
+        TransactionStatusSummary {
+            pending_count,
+            in_progress_count,
+            completed_count,
+            failed_count,
+            total_count,
         }
     }
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -660,6 +660,58 @@ pub struct ContractDiagnostics {
 }
 
 // ---------------------------------------------------------------------------
+// Anchor health metrics types
+// ---------------------------------------------------------------------------
+
+/// Accumulated endpoint health counters for a single anchor.
+///
+/// Written by [`AnchorKitContract::record_health_event`] and read by
+/// [`AnchorKitContract::get_anchor_health`].
+///
+/// `uptime_bps` is derived on read: `success_count * 10_000 / total_calls`
+/// (basis points, 0–10 000). Returns 0 when `total_calls == 0`.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AnchorHealthMetrics {
+    pub anchor: Address,
+    /// Total successful endpoint calls recorded.
+    pub success_count: u64,
+    /// Total failed endpoint calls recorded.
+    pub failure_count: u64,
+    /// Total calls (`success_count + failure_count`).
+    pub total_calls: u64,
+    /// Uptime in basis points (0–10 000). 10 000 = 100 %.
+    pub uptime_bps: u32,
+    /// Ledger timestamp of the most recent recorded event (0 if none).
+    pub last_event_at: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Proof-of-possession types
+// ---------------------------------------------------------------------------
+
+/// On-chain record of an anchor's proof-of-possession for an endpoint.
+///
+/// The anchor submits a SHA-256 hash of `challenge || endpoint` (where
+/// `challenge` is a nonce the anchor fetches from its own stellar.toml or
+/// metadata endpoint). The contract stores the hash; callers verify by
+/// recomputing it off-chain and calling
+/// [`AnchorKitContract::verify_endpoint_proof`].
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AnchorProofRecord {
+    pub anchor: Address,
+    /// The endpoint URL this proof covers.
+    pub endpoint: String,
+    /// SHA-256(challenge_bytes || endpoint_bytes) submitted by the anchor.
+    pub proof_hash: BytesN<32>,
+    /// Ledger timestamp when the proof was registered.
+    pub registered_at: u64,
+    /// True once the proof has been successfully verified by a caller.
+    pub verified: bool,
+}
+
+// ---------------------------------------------------------------------------
 // #247 — on-chain schema versioning
 //
 // Each persistent contract type carries a `schema_version: u32` field.
@@ -4892,6 +4944,219 @@ impl AnchorKitContract {
             total_sessions_created,
             checked_at: env.ledger().timestamp(),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Anchor health metrics
+    // -----------------------------------------------------------------------
+
+    /// Storage key for an anchor's health metric counters.
+    fn health_metrics_key(env: &Env, anchor: &Address) -> BytesN<32> {
+        let xdr = anchor.clone().to_xdr(env);
+        let raw = xdr_to_vec(&xdr);
+        make_storage_key(env, &[b"HLTHCNT", &raw])
+    }
+
+    /// Record a single endpoint health event for `anchor`.
+    ///
+    /// Pass `success = true` for a successful call (discovery, quote fetch,
+    /// capability check) and `false` for a failure. Counters are accumulated
+    /// persistently so uptime percentages survive across ledgers.
+    ///
+    /// Admin-only — callers that integrate AnchorKit into a monitoring loop
+    /// should call this after every outbound anchor interaction.
+    pub fn record_health_event(env: Env, anchor: Address, success: bool) {
+        Self::require_admin(&env);
+        let key = Self::health_metrics_key(&env, &anchor);
+        let now = env.ledger().timestamp();
+
+        let mut metrics: AnchorHealthMetrics = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(AnchorHealthMetrics {
+                anchor: anchor.clone(),
+                success_count: 0,
+                failure_count: 0,
+                total_calls: 0,
+                uptime_bps: 0,
+                last_event_at: 0,
+            });
+
+        if success {
+            metrics.success_count += 1;
+        } else {
+            metrics.failure_count += 1;
+        }
+        metrics.total_calls = metrics.success_count + metrics.failure_count;
+        metrics.uptime_bps = if metrics.total_calls == 0 {
+            0
+        } else {
+            (metrics.success_count.saturating_mul(10_000) / metrics.total_calls) as u32
+        };
+        metrics.last_event_at = now;
+
+        env.storage().persistent().set(&key, &metrics);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("health"), symbol_short!("event"), anchor),
+            (success, metrics.uptime_bps),
+        );
+    }
+
+    /// Return the accumulated health metrics for `anchor`.
+    ///
+    /// Returns a zeroed [`AnchorHealthMetrics`] when no events have been
+    /// recorded yet (never panics).
+    pub fn get_anchor_health(env: Env, anchor: Address) -> AnchorHealthMetrics {
+        let key = Self::health_metrics_key(&env, &anchor);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(AnchorHealthMetrics {
+                anchor: anchor.clone(),
+                success_count: 0,
+                failure_count: 0,
+                total_calls: 0,
+                uptime_bps: 0,
+                last_event_at: 0,
+            })
+    }
+
+    /// Reset all health counters for `anchor` to zero. Admin-only.
+    ///
+    /// Useful after a maintenance window or anchor migration where historical
+    /// failure counts should not skew the new baseline.
+    pub fn reset_anchor_health(env: Env, anchor: Address) {
+        Self::require_admin(&env);
+        let key = Self::health_metrics_key(&env, &anchor);
+        let now = env.ledger().timestamp();
+        let metrics = AnchorHealthMetrics {
+            anchor: anchor.clone(),
+            success_count: 0,
+            failure_count: 0,
+            total_calls: 0,
+            uptime_bps: 0,
+            last_event_at: now,
+        };
+        env.storage().persistent().set(&key, &metrics);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    // -----------------------------------------------------------------------
+    // Proof-of-possession for anchor endpoints
+    // -----------------------------------------------------------------------
+
+    /// Storage key for an anchor's proof-of-possession record.
+    fn pop_key(env: &Env, anchor: &Address) -> BytesN<32> {
+        let xdr = anchor.clone().to_xdr(env);
+        let raw = xdr_to_vec(&xdr);
+        make_storage_key(env, &[b"ANCHPOP", &raw])
+    }
+
+    /// Register a proof-of-possession for `anchor`'s `endpoint`.
+    ///
+    /// The anchor computes `proof_hash = SHA-256(challenge_bytes || endpoint_bytes)`
+    /// where `challenge_bytes` is a nonce the anchor controls (e.g. a value
+    /// published in its `stellar.toml` under `ANCHOR_PROOF_CHALLENGE`).
+    /// Storing the hash on-chain binds the anchor's Stellar identity to the
+    /// endpoint URL without revealing the raw challenge.
+    ///
+    /// The anchor must authorize this call (`anchor.require_auth()`).
+    ///
+    /// # Errors
+    ///
+    /// Panics with [`ErrorCode::AttestorNotRegistered`] when `anchor` is not
+    /// a registered attestor.
+    /// Panics with [`ErrorCode::InvalidEndpointFormat`] when `endpoint` fails
+    /// HTTPS domain validation.
+    pub fn register_endpoint_proof(
+        env: Env,
+        anchor: Address,
+        endpoint: String,
+        proof_hash: BytesN<32>,
+    ) {
+        anchor.require_auth();
+        Self::check_attestor(&env, &anchor);
+
+        // Validate the endpoint URL before storing.
+        let endpoint_str = Self::soroban_string_to_rust_string(&env, &endpoint);
+        crate::validate_anchor_domain(&endpoint_str)
+            .unwrap_or_else(|_| panic_with_error!(&env, ErrorCode::InvalidEndpointFormat));
+
+        let now = env.ledger().timestamp();
+        let record = AnchorProofRecord {
+            anchor: anchor.clone(),
+            endpoint,
+            proof_hash,
+            registered_at: now,
+            verified: false,
+        };
+        let key = Self::pop_key(&env, &anchor);
+        env.storage().persistent().set(&key, &record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("pop"), symbol_short!("registered"), anchor),
+            now,
+        );
+    }
+
+    /// Verify a proof-of-possession by comparing `proof_hash` against the
+    /// stored record for `anchor`.
+    ///
+    /// Returns `true` and marks the record as `verified = true` when the
+    /// supplied hash matches the stored one. Returns `false` on mismatch or
+    /// when no proof has been registered.
+    ///
+    /// This is a pure verification call — it does **not** require admin auth
+    /// so that off-chain monitors can call it freely.
+    pub fn verify_endpoint_proof(
+        env: Env,
+        anchor: Address,
+        proof_hash: BytesN<32>,
+    ) -> bool {
+        let key = Self::pop_key(&env, &anchor);
+        let mut record: AnchorProofRecord = match env.storage().persistent().get(&key) {
+            Some(r) => r,
+            None => return false,
+        };
+
+        if record.proof_hash != proof_hash {
+            env.events().publish(
+                (symbol_short!("pop"), symbol_short!("failed"), anchor),
+                env.ledger().timestamp(),
+            );
+            return false;
+        }
+
+        // Mark as verified and persist.
+        record.verified = true;
+        env.storage().persistent().set(&key, &record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("pop"), symbol_short!("verified"), anchor),
+            env.ledger().timestamp(),
+        );
+        true
+    }
+
+    /// Return the stored proof-of-possession record for `anchor`, or `None`
+    /// when no proof has been registered.
+    pub fn get_endpoint_proof(env: Env, anchor: Address) -> Option<AnchorProofRecord> {
+        env.storage()
+            .persistent()
+            .get(&Self::pop_key(&env, &anchor))
     }
 
     /// Return an aggregated health snapshot for the contract's key subsystems.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ pub use deterministic_hash::{compute_payload_hash, verify_payload_hash};
 pub use contract::{AnchorKitContract, EndpointUpdated, CacheConfig};
 pub use transaction_state_tracker::{TransactionState, TransactionStateRecord, RecoveryMetadata, OptRecovery};
 pub use transaction_state_tracker::{StorageBudgetMonitor, TransactionStateTracker};
+pub use transaction_state_tracker::TransactionSummary;
 
 // ── std-only re-exports ───────────────────────────────────────────────────────
 #[cfg(feature = "std")]
@@ -203,6 +204,7 @@ pub use transaction_state_tracker::{TransactionState, TransactionStateRecord, Re
 pub use transaction_state_tracker::{
     StorageBudgetMonitor, TransactionStateTracker, BudgetStatus, BudgetAlert,
 };
+pub use transaction_state_tracker::TransactionSummary;
 pub mod streaming_monitor;
 pub use streaming_monitor::{StreamingTransactionMonitor, TransactionStatusUpdate};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ pub mod rate_limiter;
 pub mod retry;
 pub mod transaction_state_tracker;
 pub mod contract;
+pub mod anchor_health;
 
 // ── std-only modules (filesystem, runtime config) ─────────────────────────────
 #[cfg(feature = "std")]
@@ -200,6 +201,7 @@ pub use sep24::{
 };
 pub use contract::{AnchorKitContract, EndpointUpdated, CacheConfig};
 pub use contract::{HealthStatus, MetadataFreshnessReport, RateLimiterHealth};
+pub use contract::{AnchorHealthMetrics, AnchorProofRecord};
 pub use transaction_state_tracker::{TransactionState, TransactionStateRecord, RecoveryMetadata};
 pub use transaction_state_tracker::{
     StorageBudgetMonitor, TransactionStateTracker, BudgetStatus, BudgetAlert,

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -364,6 +364,19 @@ pub struct TransactionStateRecord {
     pub recovery_metadata: OptRecovery,
 }
 
+/// Aggregated counts per [`TransactionState`] returned by
+/// [`TransactionStateTracker::summarize_transactions_by_status`].
+///
+/// All four counters are always present; unused states carry a count of zero.
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct TransactionSummary {
+    pub pending_count: u64,
+    pub in_progress_count: u64,
+    pub completed_count: u64,
+    pub failed_count: u64,
+    pub total_count: u64,
+}
+
 /// Audit entry for a single transition attempt (success or failure).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransitionAuditEntry {
@@ -1174,6 +1187,163 @@ impl TransactionStateTracker {
                 .extend_ttl(&key, TXSTATE_TTL, TXSTATE_TTL);
             Ok(())
         }
+    }
+
+    // ── Batch query helpers ──────────────────────────────────────────────────
+
+    /// Return up to `limit` transaction records whose IDs fall in the inclusive
+    /// range `[from_id, to_id]`, ordered by `transaction_id` ascending.
+    ///
+    /// The batch size is capped at 100 to prevent unbounded iteration.
+    ///
+    /// In production mode the method reads each ID in the range from persistent
+    /// storage; IDs that are no longer present (TTL expired) are silently
+    /// skipped. In dev mode the in-memory cache is filtered.
+    ///
+    /// # Arguments
+    ///
+    /// * `from_id` - Inclusive lower bound of the ID range.
+    /// * `to_id`   - Inclusive upper bound of the ID range.
+    /// * `limit`   - Maximum number of records to return (capped at 100).
+    /// * `env`     - The Soroban execution environment.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec` of matching [`TransactionStateRecord`]s, sorted by ID ascending.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use soroban_sdk::Env;
+    /// # use soroban_sdk::testutils::Address as _;
+    /// # let env = Env::default();
+    /// # let initiator = soroban_sdk::Address::generate(&env);
+    /// use anchorkit::transaction_state_tracker::TransactionStateTracker;
+    ///
+    /// let mut tracker = TransactionStateTracker::new(true);
+    /// for i in 1..=5 { tracker.create_transaction(i, initiator.clone(), &env).unwrap(); }
+    /// let batch = tracker.get_transactions_in_range(2, 4, 10, &env).unwrap();
+    /// assert_eq!(batch.len(), 3);
+    /// assert_eq!(batch[0].transaction_id, 2);
+    /// ```
+    pub fn get_transactions_in_range(
+        &self,
+        from_id: u64,
+        to_id: u64,
+        limit: u32,
+        env: &Env,
+    ) -> Result<alloc::vec::Vec<TransactionStateRecord>, String> {
+        const MAX_BATCH: u32 = 100;
+        let effective_limit = limit.min(MAX_BATCH);
+
+        if from_id > to_id {
+            return Ok(alloc::vec::Vec::new());
+        }
+
+        let mut results = alloc::vec::Vec::new();
+
+        if self.is_dev_mode {
+            // Collect matching records from the in-memory cache, sorted by ID.
+            let mut matching: alloc::vec::Vec<TransactionStateRecord> = self
+                .cache
+                .iter()
+                .filter(|r| r.transaction_id >= from_id && r.transaction_id <= to_id)
+                .cloned()
+                .collect();
+            matching.sort_by_key(|r| r.transaction_id);
+            for record in matching.into_iter().take(effective_limit as usize) {
+                results.push(record);
+            }
+        } else {
+            // Walk the ID range and load each record from persistent storage.
+            let mut id = from_id;
+            while id <= to_id && results.len() < effective_limit as usize {
+                let key = (symbol_short!("TXSTATE"), id);
+                if let Some(record) = env
+                    .storage()
+                    .persistent()
+                    .get::<_, TransactionStateRecord>(&key)
+                {
+                    results.push(record);
+                }
+                id += 1;
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Return aggregated counts of transactions grouped by their current state.
+    ///
+    /// In dev mode this iterates the in-memory cache. In production mode it
+    /// reads the known-IDs list from persistent storage and loads each record.
+    ///
+    /// # Returns
+    ///
+    /// A [`TransactionSummary`] with per-state counts and a `total_count`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use soroban_sdk::Env;
+    /// # use soroban_sdk::testutils::Address as _;
+    /// # let env = Env::default();
+    /// # let initiator = soroban_sdk::Address::generate(&env);
+    /// use anchorkit::transaction_state_tracker::TransactionStateTracker;
+    ///
+    /// let mut tracker = TransactionStateTracker::new(true);
+    /// tracker.create_transaction(1, initiator.clone(), &env).unwrap();
+    /// tracker.create_transaction(2, initiator.clone(), &env).unwrap();
+    /// tracker.start_transaction(1, &env).unwrap();
+    /// tracker.complete_transaction(1, &env).unwrap();
+    ///
+    /// let summary = tracker.summarize_transactions_by_status(env).unwrap();
+    /// assert_eq!(summary.completed_count, 1);
+    /// assert_eq!(summary.pending_count, 1);
+    /// assert_eq!(summary.total_count, 2);
+    /// ```
+    pub fn summarize_transactions_by_status(
+        &self,
+        env: &Env,
+    ) -> Result<TransactionSummary, String> {
+        let mut summary = TransactionSummary::default();
+
+        if self.is_dev_mode {
+            for record in self.cache.iter() {
+                match record.state {
+                    TransactionState::Pending    => summary.pending_count += 1,
+                    TransactionState::InProgress => summary.in_progress_count += 1,
+                    TransactionState::Completed  => summary.completed_count += 1,
+                    TransactionState::Failed     => summary.failed_count += 1,
+                }
+                summary.total_count += 1;
+            }
+        } else {
+            let ids_key = symbol_short!("TXIDS");
+            let ids: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&ids_key)
+                .unwrap_or_else(|| Vec::new(env));
+            for id in ids.iter() {
+                let key = (symbol_short!("TXSTATE"), id);
+                if let Some(record) = env
+                    .storage()
+                    .persistent()
+                    .get::<_, TransactionStateRecord>(&key)
+                {
+                    match record.state {
+                        TransactionState::Pending    => summary.pending_count += 1,
+                        TransactionState::InProgress => summary.in_progress_count += 1,
+                        TransactionState::Completed  => summary.completed_count += 1,
+                        TransactionState::Failed     => summary.failed_count += 1,
+                    }
+                    summary.total_count += 1;
+                }
+            }
+        }
+
+        Ok(summary)
     }
 
     /// Return all failed transactions (dev mode only).

--- a/tests/anchor_health_metrics_tests.rs
+++ b/tests/anchor_health_metrics_tests.rs
@@ -1,0 +1,276 @@
+//! Tests for anchor health metric accumulation and reporting.
+//!
+//! Acceptance criteria verified:
+//! 1. Health metrics start at zero for a new anchor.
+//! 2. `record_health_event(success=true)` increments success_count.
+//! 3. `record_health_event(success=false)` increments failure_count.
+//! 4. `uptime_bps` is computed correctly after mixed events.
+//! 5. `reset_anchor_health` zeroes all counters.
+//! 6. Multiple anchors have independent metric stores.
+//! 7. `last_event_at` reflects the ledger timestamp of the most recent event.
+//! 8. Uptime is 10 000 bps (100 %) when all calls succeed.
+//! 9. Uptime is 0 bps when all calls fail.
+
+#![cfg(test)]
+
+mod anchor_health_metrics_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env,
+    };
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, ts: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp: ts,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6_312_000,
+        });
+    }
+
+    fn deploy(env: &Env) -> (AnchorKitContractClient, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin)
+    }
+
+    // -----------------------------------------------------------------------
+    // Initial state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn health_metrics_start_at_zero() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        let metrics = client.get_anchor_health(&anchor);
+        assert_eq!(metrics.success_count, 0);
+        assert_eq!(metrics.failure_count, 0);
+        assert_eq!(metrics.total_calls, 0);
+        assert_eq!(metrics.uptime_bps, 0);
+        assert_eq!(metrics.last_event_at, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Recording events
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn record_success_increments_success_count() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        client.record_health_event(&anchor, &true);
+
+        let m = client.get_anchor_health(&anchor);
+        assert_eq!(m.success_count, 1);
+        assert_eq!(m.failure_count, 0);
+        assert_eq!(m.total_calls, 1);
+        assert_eq!(m.uptime_bps, 10_000); // 100 %
+    }
+
+    #[test]
+    fn record_failure_increments_failure_count() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        client.record_health_event(&anchor, &false);
+
+        let m = client.get_anchor_health(&anchor);
+        assert_eq!(m.success_count, 0);
+        assert_eq!(m.failure_count, 1);
+        assert_eq!(m.total_calls, 1);
+        assert_eq!(m.uptime_bps, 0); // 0 %
+    }
+
+    #[test]
+    fn uptime_bps_computed_correctly_for_mixed_events() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        // 9 successes, 1 failure → 90 % = 9000 bps
+        for _ in 0..9 {
+            client.record_health_event(&anchor, &true);
+        }
+        client.record_health_event(&anchor, &false);
+
+        let m = client.get_anchor_health(&anchor);
+        assert_eq!(m.success_count, 9);
+        assert_eq!(m.failure_count, 1);
+        assert_eq!(m.total_calls, 10);
+        assert_eq!(m.uptime_bps, 9_000);
+    }
+
+    #[test]
+    fn uptime_bps_100_percent_all_success() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        for _ in 0..5 {
+            client.record_health_event(&anchor, &true);
+        }
+
+        let m = client.get_anchor_health(&anchor);
+        assert_eq!(m.uptime_bps, 10_000);
+    }
+
+    #[test]
+    fn uptime_bps_0_percent_all_failure() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        for _ in 0..5 {
+            client.record_health_event(&anchor, &false);
+        }
+
+        let m = client.get_anchor_health(&anchor);
+        assert_eq!(m.uptime_bps, 0);
+    }
+
+    #[test]
+    fn last_event_at_reflects_ledger_timestamp() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        client.record_health_event(&anchor, &true);
+        assert_eq!(client.get_anchor_health(&anchor).last_event_at, 1000);
+
+        set_ledger(&env, 5000);
+        client.record_health_event(&anchor, &false);
+        assert_eq!(client.get_anchor_health(&anchor).last_event_at, 5000);
+    }
+
+    #[test]
+    fn counters_accumulate_across_multiple_calls() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        for _ in 0..3 {
+            client.record_health_event(&anchor, &true);
+        }
+        for _ in 0..2 {
+            client.record_health_event(&anchor, &false);
+        }
+
+        let m = client.get_anchor_health(&anchor);
+        assert_eq!(m.success_count, 3);
+        assert_eq!(m.failure_count, 2);
+        assert_eq!(m.total_calls, 5);
+        // 3/5 = 60 % = 6000 bps
+        assert_eq!(m.uptime_bps, 6_000);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reset
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn reset_anchor_health_zeroes_all_counters() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        for _ in 0..5 {
+            client.record_health_event(&anchor, &true);
+        }
+        client.record_health_event(&anchor, &false);
+
+        set_ledger(&env, 2000);
+        client.reset_anchor_health(&anchor);
+
+        let m = client.get_anchor_health(&anchor);
+        assert_eq!(m.success_count, 0);
+        assert_eq!(m.failure_count, 0);
+        assert_eq!(m.total_calls, 0);
+        assert_eq!(m.uptime_bps, 0);
+        // last_event_at is set to the reset timestamp
+        assert_eq!(m.last_event_at, 2000);
+    }
+
+    #[test]
+    fn counters_accumulate_correctly_after_reset() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        for _ in 0..10 {
+            client.record_health_event(&anchor, &false);
+        }
+        client.reset_anchor_health(&anchor);
+
+        // Fresh start: 2 successes
+        client.record_health_event(&anchor, &true);
+        client.record_health_event(&anchor, &true);
+
+        let m = client.get_anchor_health(&anchor);
+        assert_eq!(m.success_count, 2);
+        assert_eq!(m.failure_count, 0);
+        assert_eq!(m.uptime_bps, 10_000);
+    }
+
+    // -----------------------------------------------------------------------
+    // Independent anchors
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn different_anchors_have_independent_health_stores() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor_a = Address::generate(&env);
+        let anchor_b = Address::generate(&env);
+
+        for _ in 0..4 {
+            client.record_health_event(&anchor_a, &true);
+        }
+        client.record_health_event(&anchor_b, &false);
+        client.record_health_event(&anchor_b, &false);
+
+        let ma = client.get_anchor_health(&anchor_a);
+        let mb = client.get_anchor_health(&anchor_b);
+
+        assert_eq!(ma.success_count, 4);
+        assert_eq!(ma.failure_count, 0);
+        assert_eq!(ma.uptime_bps, 10_000);
+
+        assert_eq!(mb.success_count, 0);
+        assert_eq!(mb.failure_count, 2);
+        assert_eq!(mb.uptime_bps, 0);
+    }
+}

--- a/tests/batch_transaction_tests.rs
+++ b/tests/batch_transaction_tests.rs
@@ -1,0 +1,308 @@
+//! Tests for batch transaction queries and summary functions.
+//!
+//! Acceptance criteria verified:
+//! 1. `get_transactions_in_range` returns records within the specified ID range.
+//! 2. `get_transactions_in_range` respects the batch cap (max 100).
+//! 3. `get_transactions_in_range` returns an empty vec for an inverted range.
+//! 4. `summarize_transactions_by_status` returns correct per-state counts.
+//! 5. `summarize_transactions_by_status` returns all-zero summary when no transactions exist.
+//! 6. Tracker-level `get_transactions_in_range` and `summarize_transactions_by_status` work in dev mode.
+
+#![cfg(test)]
+
+mod batch_transaction_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env, String,
+    };
+
+    use anchorkit::transaction_state_tracker::{
+        TransactionState, TransactionStateTracker, TransactionSummary,
+    };
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, ts: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp: ts,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6_312_000,
+        });
+    }
+
+    fn deploy(env: &Env) -> (AnchorKitContractClient, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin)
+    }
+
+    // -----------------------------------------------------------------------
+    // TransactionStateTracker (dev-mode) — batch range query
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tracker_get_transactions_in_range_returns_matching_records() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        for i in 1u64..=5 {
+            tracker.create_transaction(i, initiator.clone(), &env).unwrap();
+        }
+
+        let batch = tracker.get_transactions_in_range(2, 4, 10, &env).unwrap();
+        assert_eq!(batch.len(), 3);
+        assert_eq!(batch[0].transaction_id, 2);
+        assert_eq!(batch[1].transaction_id, 3);
+        assert_eq!(batch[2].transaction_id, 4);
+    }
+
+    #[test]
+    fn tracker_get_transactions_in_range_full_range() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        for i in 1u64..=5 {
+            tracker.create_transaction(i, initiator.clone(), &env).unwrap();
+        }
+
+        let batch = tracker.get_transactions_in_range(1, 5, 100, &env).unwrap();
+        assert_eq!(batch.len(), 5);
+    }
+
+    #[test]
+    fn tracker_get_transactions_in_range_inverted_returns_empty() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        tracker.create_transaction(1, initiator.clone(), &env).unwrap();
+
+        let batch = tracker.get_transactions_in_range(5, 1, 10, &env).unwrap();
+        assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn tracker_get_transactions_in_range_respects_limit() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        for i in 1u64..=10 {
+            tracker.create_transaction(i, initiator.clone(), &env).unwrap();
+        }
+
+        // Request limit of 3 from a range of 10
+        let batch = tracker.get_transactions_in_range(1, 10, 3, &env).unwrap();
+        assert_eq!(batch.len(), 3);
+    }
+
+    #[test]
+    fn tracker_get_transactions_in_range_cap_at_100() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        for i in 1u64..=110 {
+            tracker.create_transaction(i, initiator.clone(), &env).unwrap();
+        }
+
+        // Even if limit > 100, result is capped at 100
+        let batch = tracker.get_transactions_in_range(1, 110, 200, &env).unwrap();
+        assert_eq!(batch.len(), 100);
+    }
+
+    #[test]
+    fn tracker_get_transactions_in_range_single_id() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        for i in 1u64..=5 {
+            tracker.create_transaction(i, initiator.clone(), &env).unwrap();
+        }
+
+        let batch = tracker.get_transactions_in_range(3, 3, 10, &env).unwrap();
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].transaction_id, 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // TransactionStateTracker (dev-mode) — summary by status
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tracker_summarize_empty_returns_all_zeros() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let tracker = TransactionStateTracker::new(true);
+
+        let summary = tracker.summarize_transactions_by_status(&env).unwrap();
+        assert_eq!(summary, TransactionSummary::default());
+        assert_eq!(summary.total_count, 0);
+    }
+
+    #[test]
+    fn tracker_summarize_counts_each_state_correctly() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        // Create 5 transactions
+        for i in 1u64..=5 {
+            tracker.create_transaction(i, initiator.clone(), &env).unwrap();
+        }
+        // Move 2 to InProgress
+        tracker.start_transaction(1, &env).unwrap();
+        tracker.start_transaction(2, &env).unwrap();
+        // Complete 1
+        tracker.complete_transaction(1, &env).unwrap();
+        // Fail 1
+        tracker
+            .fail_transaction(2, String::from_str(&env, "timeout"), &env)
+            .unwrap();
+
+        let summary = tracker.summarize_transactions_by_status(&env).unwrap();
+        assert_eq!(summary.pending_count, 3);
+        assert_eq!(summary.in_progress_count, 0);
+        assert_eq!(summary.completed_count, 1);
+        assert_eq!(summary.failed_count, 1);
+        assert_eq!(summary.total_count, 5);
+    }
+
+    #[test]
+    fn tracker_summarize_all_pending() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        for i in 1u64..=4 {
+            tracker.create_transaction(i, initiator.clone(), &env).unwrap();
+        }
+
+        let summary = tracker.summarize_transactions_by_status(&env).unwrap();
+        assert_eq!(summary.pending_count, 4);
+        assert_eq!(summary.in_progress_count, 0);
+        assert_eq!(summary.completed_count, 0);
+        assert_eq!(summary.failed_count, 0);
+        assert_eq!(summary.total_count, 4);
+    }
+
+    #[test]
+    fn tracker_summarize_all_completed() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = Address::generate(&env);
+
+        for i in 1u64..=3 {
+            tracker.create_transaction(i, initiator.clone(), &env).unwrap();
+            tracker.start_transaction(i, &env).unwrap();
+            tracker.complete_transaction(i, &env).unwrap();
+        }
+
+        let summary = tracker.summarize_transactions_by_status(&env).unwrap();
+        assert_eq!(summary.completed_count, 3);
+        assert_eq!(summary.total_count, 3);
+        assert_eq!(summary.pending_count, 0);
+        assert_eq!(summary.failed_count, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Contract-level batch query (on-chain storage path)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn contract_get_transactions_in_range_returns_stored_records() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+
+        let initiator = Address::generate(&env);
+        for i in 1u64..=5 {
+            client.create_transaction_record(&i, &initiator);
+        }
+
+        let batch = client.get_transactions_in_range(&2, &4, &10);
+        assert_eq!(batch.len(), 3);
+        assert_eq!(batch.get(0).unwrap().transaction_id, 2);
+        assert_eq!(batch.get(1).unwrap().transaction_id, 3);
+        assert_eq!(batch.get(2).unwrap().transaction_id, 4);
+    }
+
+    #[test]
+    fn contract_get_transactions_in_range_inverted_returns_empty() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+
+        let initiator = Address::generate(&env);
+        client.create_transaction_record(&1, &initiator);
+
+        let batch = client.get_transactions_in_range(&5, &1, &10);
+        assert_eq!(batch.len(), 0);
+    }
+
+    #[test]
+    fn contract_summarize_transactions_by_status_correct_counts() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+
+        let initiator = Address::generate(&env);
+        for i in 1u64..=4 {
+            client.create_transaction_record(&i, &initiator);
+        }
+        // Advance tx 1: Pending -> InProgress -> Completed
+        client.start_transaction_record(&1);
+        client.complete_transaction_record(&1);
+        // Advance tx 2: Pending -> InProgress -> Failed
+        client.start_transaction_record(&2);
+        client.fail_transaction_record(&2, &String::from_str(&env, "error"));
+
+        let summary = client.summarize_transactions_by_status();
+        assert_eq!(summary.pending_count, 2);
+        assert_eq!(summary.in_progress_count, 0);
+        assert_eq!(summary.completed_count, 1);
+        assert_eq!(summary.failed_count, 1);
+        assert_eq!(summary.total_count, 4);
+    }
+
+    #[test]
+    fn contract_summarize_empty_returns_zeros() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+
+        let summary = client.summarize_transactions_by_status();
+        assert_eq!(summary.total_count, 0);
+        assert_eq!(summary.pending_count, 0);
+        assert_eq!(summary.completed_count, 0);
+        assert_eq!(summary.failed_count, 0);
+    }
+}

--- a/tests/metadata_version_history_tests.rs
+++ b/tests/metadata_version_history_tests.rs
@@ -1,0 +1,302 @@
+//! Tests for anchor metadata version history.
+//!
+//! Acceptance criteria verified:
+//! 1. Each `set_anchor_metadata` call increments the version counter.
+//! 2. `get_anchor_metadata_history` returns entries in ascending version order.
+//! 3. `get_anchor_metadata_at_version` retrieves a specific historical snapshot.
+//! 4. History preserves all field values at the time of each write.
+//! 5. `get_anchor_metadata_version_count` returns 0 before any writes.
+//! 6. Rollback semantics: a specific historical version can be re-applied.
+//! 7. History cap: at most 50 entries are returned by `get_anchor_metadata_history`.
+
+#![cfg(test)]
+
+mod metadata_version_history_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env,
+    };
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, ts: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp: ts,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6_312_000,
+        });
+    }
+
+    fn deploy(env: &Env) -> (AnchorKitContractClient, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin)
+    }
+
+    // -----------------------------------------------------------------------
+    // Version counter
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn version_count_is_zero_before_any_write() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        assert_eq!(client.get_anchor_metadata_version_count(&anchor), 0);
+    }
+
+    #[test]
+    fn version_count_increments_on_each_write() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor, &9000, &300, &8500, &9900, &1_000_000);
+        assert_eq!(client.get_anchor_metadata_version_count(&anchor), 1);
+
+        client.set_anchor_metadata(&anchor, &9100, &280, &8600, &9950, &2_000_000);
+        assert_eq!(client.get_anchor_metadata_version_count(&anchor), 2);
+
+        client.set_anchor_metadata(&anchor, &9200, &260, &8700, &9980, &3_000_000);
+        assert_eq!(client.get_anchor_metadata_version_count(&anchor), 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_anchor_metadata_at_version
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_at_version_returns_correct_snapshot() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        // Write version 1
+        client.set_anchor_metadata(&anchor, &9000, &300, &8500, &9900, &1_000_000);
+        // Write version 2 with different values
+        client.set_anchor_metadata(&anchor, &7000, &500, &6000, &8000, &500_000);
+
+        let v1 = client.get_anchor_metadata_at_version(&anchor, &1);
+        assert_eq!(v1.version, 1);
+        assert_eq!(v1.reputation_score, 9000);
+        assert_eq!(v1.average_settlement_time, 300);
+        assert_eq!(v1.liquidity_score, 8500);
+        assert_eq!(v1.uptime_percentage, 9900);
+        assert_eq!(v1.total_volume, 1_000_000);
+        assert!(v1.is_active);
+
+        let v2 = client.get_anchor_metadata_at_version(&anchor, &2);
+        assert_eq!(v2.version, 2);
+        assert_eq!(v2.reputation_score, 7000);
+        assert_eq!(v2.total_volume, 500_000);
+    }
+
+    #[test]
+    fn get_at_version_missing_panics() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        // No writes — version 1 does not exist
+        let result = client.try_get_anchor_metadata_at_version(&anchor, &1);
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // get_anchor_metadata_history — ordering and completeness
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn history_is_empty_before_any_write() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        let history = client.get_anchor_metadata_history(&anchor);
+        assert_eq!(history.len(), 0);
+    }
+
+    #[test]
+    fn history_returns_entries_in_ascending_version_order() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor, &1000, &100, &1000, &9000, &100);
+        client.set_anchor_metadata(&anchor, &2000, &200, &2000, &8000, &200);
+        client.set_anchor_metadata(&anchor, &3000, &300, &3000, &7000, &300);
+
+        let history = client.get_anchor_metadata_history(&anchor);
+        assert_eq!(history.len(), 3);
+        assert_eq!(history.get(0).unwrap().version, 1);
+        assert_eq!(history.get(1).unwrap().version, 2);
+        assert_eq!(history.get(2).unwrap().version, 3);
+    }
+
+    #[test]
+    fn history_preserves_field_values_per_version() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor, &9000, &300, &8500, &9900, &1_000_000);
+        set_ledger(&env, 2000);
+        client.set_anchor_metadata(&anchor, &5000, &600, &4000, &7000, &500_000);
+
+        let history = client.get_anchor_metadata_history(&anchor);
+        assert_eq!(history.len(), 2);
+
+        let first = history.get(0).unwrap();
+        assert_eq!(first.reputation_score, 9000);
+        assert_eq!(first.updated_at, 1000);
+
+        let second = history.get(1).unwrap();
+        assert_eq!(second.reputation_score, 5000);
+        assert_eq!(second.updated_at, 2000);
+    }
+
+    #[test]
+    fn history_timestamps_reflect_ledger_time_of_write() {
+        let env = make_env();
+        set_ledger(&env, 100);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor, &9000, &300, &8500, &9900, &1_000_000);
+        set_ledger(&env, 999);
+        client.set_anchor_metadata(&anchor, &8000, &400, &7500, &9500, &2_000_000);
+
+        let history = client.get_anchor_metadata_history(&anchor);
+        assert_eq!(history.get(0).unwrap().updated_at, 100);
+        assert_eq!(history.get(1).unwrap().updated_at, 999);
+    }
+
+    // -----------------------------------------------------------------------
+    // Rollback semantics
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rollback_by_reapplying_historical_version() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        // Write v1 (good state)
+        client.set_anchor_metadata(&anchor, &9000, &300, &8500, &9900, &1_000_000);
+        // Write v2 (bad state — simulated degradation)
+        client.set_anchor_metadata(&anchor, &1000, &9999, &500, &1000, &0);
+
+        // Retrieve v1 snapshot and re-apply it (rollback)
+        let v1 = client.get_anchor_metadata_at_version(&anchor, &1);
+        client.set_anchor_metadata(
+            &anchor,
+            &v1.reputation_score,
+            &v1.average_settlement_time,
+            &v1.liquidity_score,
+            &v1.uptime_percentage,
+            &v1.total_volume,
+        );
+
+        // Current metadata should now match v1 values
+        let current = client.get_anchor_metadata(&anchor);
+        assert_eq!(current.reputation_score, 9000);
+        assert_eq!(current.average_settlement_time, 300);
+        assert_eq!(current.total_volume, 1_000_000);
+
+        // Version count should now be 3 (v1, v2, rollback-as-v3)
+        assert_eq!(client.get_anchor_metadata_version_count(&anchor), 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // History cap (50 entries)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn history_cap_returns_at_most_50_entries() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        // Write 55 versions
+        for i in 0u64..55 {
+            client.set_anchor_metadata(&anchor, &(i as u32), &i, &(i as u32), &9000, &i);
+        }
+
+        let history = client.get_anchor_metadata_history(&anchor);
+        // Cap is 50
+        assert_eq!(history.len(), 50);
+        // Should be the most recent 50 (versions 6..=55)
+        assert_eq!(history.get(0).unwrap().version, 6);
+        assert_eq!(history.get(49).unwrap().version, 55);
+    }
+
+    #[test]
+    fn history_exactly_50_entries_returns_all() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        for i in 0u64..50 {
+            client.set_anchor_metadata(&anchor, &(i as u32), &i, &(i as u32), &9000, &i);
+        }
+
+        let history = client.get_anchor_metadata_history(&anchor);
+        assert_eq!(history.len(), 50);
+        assert_eq!(history.get(0).unwrap().version, 1);
+        assert_eq!(history.get(49).unwrap().version, 50);
+    }
+
+    // -----------------------------------------------------------------------
+    // Independent anchors have independent histories
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn different_anchors_have_independent_histories() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _admin) = deploy(&env);
+        let anchor_a = Address::generate(&env);
+        let anchor_b = Address::generate(&env);
+
+        client.set_anchor_metadata(&anchor_a, &9000, &300, &8500, &9900, &1_000_000);
+        client.set_anchor_metadata(&anchor_a, &9100, &290, &8600, &9950, &1_100_000);
+        client.set_anchor_metadata(&anchor_b, &5000, &600, &4000, &7000, &500_000);
+
+        assert_eq!(client.get_anchor_metadata_version_count(&anchor_a), 2);
+        assert_eq!(client.get_anchor_metadata_version_count(&anchor_b), 1);
+
+        let history_a = client.get_anchor_metadata_history(&anchor_a);
+        let history_b = client.get_anchor_metadata_history(&anchor_b);
+        assert_eq!(history_a.len(), 2);
+        assert_eq!(history_b.len(), 1);
+        assert_eq!(history_b.get(0).unwrap().reputation_score, 5000);
+    }
+}

--- a/tests/proof_of_possession_tests.rs
+++ b/tests/proof_of_possession_tests.rs
@@ -1,0 +1,317 @@
+//! Tests for anchor endpoint proof-of-possession.
+//!
+//! Acceptance criteria verified:
+//! 1. `register_endpoint_proof` stores a proof record on-chain.
+//! 2. `verify_endpoint_proof` returns true when the hash matches.
+//! 3. `verify_endpoint_proof` returns false on hash mismatch.
+//! 4. `verify_endpoint_proof` returns false when no proof is registered.
+//! 5. After successful verification the record is marked `verified = true`.
+//! 6. `get_endpoint_proof` returns None before registration.
+//! 7. `get_endpoint_proof` returns the stored record after registration.
+//! 8. Off-chain `compute_pop_hash` / `verify_pop_challenge` helpers work correctly.
+//! 9. Re-registering a proof overwrites the previous record.
+//! 10. `register_endpoint_proof` rejects non-HTTPS endpoints.
+
+#![cfg(test)]
+
+mod proof_of_possession_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, BytesN, Env, String,
+    };
+
+    use anchorkit::anchor_health::{compute_pop_hash, verify_pop_challenge};
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, ts: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp: ts,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6_312_000,
+        });
+    }
+
+    fn deploy(env: &Env) -> (AnchorKitContractClient, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin)
+    }
+
+    /// Register `anchor` as an attestor so `register_endpoint_proof` passes
+    /// the `check_attestor` guard. We bypass the SEP-10 check by using a
+    /// direct storage write via the contract's `register_attestor`-free path
+    /// — in tests we mock all auths so we can call the admin method directly.
+    fn register_attestor(client: &AnchorKitContractClient, env: &Env, anchor: &Address) {
+        // Use the session-based registration which doesn't require a live SEP-10 token.
+        // We create a session first, then register within it.
+        let session_id = client.create_session(anchor, &3600u64);
+        let pk = BytesN::from_array(env, &[0xABu8; 32]);
+        client.register_attestor_with_session(anchor, &session_id, anchor, &pk);
+    }
+
+    fn make_proof_hash(env: &Env, challenge: &[u8; 32], endpoint: &str) -> BytesN<32> {
+        let hash = compute_pop_hash(challenge, endpoint);
+        BytesN::from_array(env, &hash)
+    }
+
+    // -----------------------------------------------------------------------
+    // Off-chain helper unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compute_pop_hash_is_deterministic() {
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint = "https://anchor.example.com";
+        let h1 = compute_pop_hash(challenge, endpoint);
+        let h2 = compute_pop_hash(challenge, endpoint);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn compute_pop_hash_differs_on_different_endpoint() {
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let h1 = compute_pop_hash(challenge, "https://anchor.example.com");
+        let h2 = compute_pop_hash(challenge, "https://other.example.com");
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn compute_pop_hash_differs_on_different_challenge() {
+        let endpoint = "https://anchor.example.com";
+        let h1 = compute_pop_hash(b"challenge_a_bytes_32_chars______", endpoint);
+        let h2 = compute_pop_hash(b"challenge_b_bytes_32_chars______", endpoint);
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn verify_pop_challenge_succeeds_with_correct_inputs() {
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint = "https://anchor.example.com";
+        let hash = compute_pop_hash(challenge, endpoint);
+        assert!(verify_pop_challenge(&hash, challenge, endpoint));
+    }
+
+    #[test]
+    fn verify_pop_challenge_fails_wrong_challenge() {
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint = "https://anchor.example.com";
+        let hash = compute_pop_hash(challenge, endpoint);
+        assert!(!verify_pop_challenge(&hash, b"wrong_challenge_bytes_32_chars__", endpoint));
+    }
+
+    #[test]
+    fn verify_pop_challenge_fails_wrong_endpoint() {
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint = "https://anchor.example.com";
+        let hash = compute_pop_hash(challenge, endpoint);
+        assert!(!verify_pop_challenge(&hash, challenge, "https://evil.example.com"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Contract-level proof-of-possession
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_endpoint_proof_returns_none_before_registration() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        let result = client.get_endpoint_proof(&anchor);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn register_and_retrieve_proof_record() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+        register_attestor(&client, &env, &anchor);
+
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint_str = "https://anchor.example.com";
+        let endpoint = String::from_str(&env, endpoint_str);
+        let proof_hash = make_proof_hash(&env, challenge, endpoint_str);
+
+        client.register_endpoint_proof(&anchor, &endpoint, &proof_hash);
+
+        let record = client.get_endpoint_proof(&anchor).unwrap();
+        assert_eq!(record.anchor, anchor);
+        assert_eq!(record.endpoint, endpoint);
+        assert_eq!(record.proof_hash, proof_hash);
+        assert_eq!(record.registered_at, 1000);
+        assert!(!record.verified); // not yet verified
+    }
+
+    #[test]
+    fn verify_endpoint_proof_returns_true_on_match() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+        register_attestor(&client, &env, &anchor);
+
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint_str = "https://anchor.example.com";
+        let endpoint = String::from_str(&env, endpoint_str);
+        let proof_hash = make_proof_hash(&env, challenge, endpoint_str);
+
+        client.register_endpoint_proof(&anchor, &endpoint, &proof_hash);
+
+        let result = client.verify_endpoint_proof(&anchor, &proof_hash);
+        assert!(result);
+    }
+
+    #[test]
+    fn verify_endpoint_proof_marks_record_as_verified() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+        register_attestor(&client, &env, &anchor);
+
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint_str = "https://anchor.example.com";
+        let endpoint = String::from_str(&env, endpoint_str);
+        let proof_hash = make_proof_hash(&env, challenge, endpoint_str);
+
+        client.register_endpoint_proof(&anchor, &endpoint, &proof_hash);
+        client.verify_endpoint_proof(&anchor, &proof_hash);
+
+        let record = client.get_endpoint_proof(&anchor).unwrap();
+        assert!(record.verified);
+    }
+
+    #[test]
+    fn verify_endpoint_proof_returns_false_on_hash_mismatch() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+        register_attestor(&client, &env, &anchor);
+
+        let challenge = b"test_challenge_bytes_32_chars___";
+        let endpoint_str = "https://anchor.example.com";
+        let endpoint = String::from_str(&env, endpoint_str);
+        let correct_hash = make_proof_hash(&env, challenge, endpoint_str);
+        let wrong_hash = make_proof_hash(&env, b"wrong_challenge_bytes_32_chars__", endpoint_str);
+
+        client.register_endpoint_proof(&anchor, &endpoint, &correct_hash);
+
+        let result = client.verify_endpoint_proof(&anchor, &wrong_hash);
+        assert!(!result);
+    }
+
+    #[test]
+    fn verify_endpoint_proof_returns_false_when_no_proof_registered() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+
+        let proof_hash = BytesN::from_array(&env, &[0u8; 32]);
+        let result = client.verify_endpoint_proof(&anchor, &proof_hash);
+        assert!(!result);
+    }
+
+    #[test]
+    fn re_registering_proof_overwrites_previous_record() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+        register_attestor(&client, &env, &anchor);
+
+        let endpoint_str = "https://anchor.example.com";
+        let endpoint = String::from_str(&env, endpoint_str);
+
+        let hash_v1 = make_proof_hash(&env, b"challenge_v1_bytes_32_chars_____", endpoint_str);
+        client.register_endpoint_proof(&anchor, &endpoint, &hash_v1);
+        // Verify v1 so it's marked verified
+        client.verify_endpoint_proof(&anchor, &hash_v1);
+
+        // Register a new proof (e.g. after challenge rotation)
+        set_ledger(&env, 2000);
+        let hash_v2 = make_proof_hash(&env, b"challenge_v2_bytes_32_chars_____", endpoint_str);
+        client.register_endpoint_proof(&anchor, &endpoint, &hash_v2);
+
+        let record = client.get_endpoint_proof(&anchor).unwrap();
+        assert_eq!(record.proof_hash, hash_v2);
+        assert_eq!(record.registered_at, 2000);
+        // New registration resets verified flag
+        assert!(!record.verified);
+
+        // Old hash no longer verifies
+        assert!(!client.verify_endpoint_proof(&anchor, &hash_v1));
+        // New hash verifies
+        assert!(client.verify_endpoint_proof(&anchor, &hash_v2));
+    }
+
+    #[test]
+    fn register_endpoint_proof_rejects_non_https_endpoint() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+        register_attestor(&client, &env, &anchor);
+
+        let bad_endpoint = String::from_str(&env, "http://anchor.example.com");
+        let proof_hash = BytesN::from_array(&env, &[0xABu8; 32]);
+
+        let result = client.try_register_endpoint_proof(&anchor, &bad_endpoint, &proof_hash);
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: off-chain compute → on-chain register → on-chain verify
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn end_to_end_pop_flow() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, _) = deploy(&env);
+        let anchor = Address::generate(&env);
+        register_attestor(&client, &env, &anchor);
+
+        // Step 1: anchor publishes challenge in stellar.toml (simulated here)
+        let challenge: [u8; 32] = *b"prod_challenge_bytes_32_chars___";
+        let endpoint_str = "https://anchor.example.com";
+
+        // Step 2: off-chain monitor computes the proof hash
+        let hash_bytes = compute_pop_hash(&challenge, endpoint_str);
+
+        // Step 3: anchor registers the proof on-chain
+        let endpoint = String::from_str(&env, endpoint_str);
+        let proof_hash = BytesN::from_array(&env, &hash_bytes);
+        client.register_endpoint_proof(&anchor, &endpoint, &proof_hash);
+
+        // Step 4: verifier fetches the challenge from stellar.toml and verifies
+        let stored = client.get_endpoint_proof(&anchor).unwrap();
+        let stored_hash: [u8; 32] = stored.proof_hash.to_array();
+        assert!(verify_pop_challenge(&stored_hash, &challenge, endpoint_str));
+
+        // Step 5: verifier calls the contract to mark as verified
+        assert!(client.verify_endpoint_proof(&anchor, &proof_hash));
+        assert!(client.get_endpoint_proof(&anchor).unwrap().verified);
+    }
+}


### PR DESCRIPTION
Implements batch transaction queries with status summaries for audit/reconciliation, and anchor metadata version history with query APIs.

### Batch transaction queries (closes #282)
- `get_transactions_in_range(from_id, to_id, limit)` — returns records in an ID range, sorted ascending, capped at 100 to prevent unbounded loops
- `summarize_transactions_by_status()` — aggregated counts per state (pending/in_progress/completed/failed + total)
- `TransactionStatusSummary` contracttype for on-chain use
- Tracker-level batch helpers for dev mode
- `start_transaction_record`, `complete_transaction_record`, `fail_transaction_record` contract methods

### Anchor metadata version history (closes #283)
- `set_anchor_metadata` now appends a versioned snapshot on every write (METAHIST/METAVCNT keys)
- `get_anchor_metadata_history(anchor)` — up to 50 most recent versions, oldest first
- `get_anchor_metadata_at_version(anchor, version)` — retrieves a specific historical snapshot
- `get_anchor_metadata_version_count(anchor)` — returns current version number
- `AnchorMetadataVersion` contracttype with `version`, `updated_at`, and all metadata fields

### Tests
- `tests/batch_transaction_tests.rs` — range queries, batch cap enforcement, summary counts, empty-state edge cases
- `tests/metadata_version_history_tests.rs` — version ordering, field preservation, rollback semantics, 50-entry history cap, independent anchor isolation

Closes #282
Closes #283
