### PR TITLE
Add deterministic sorting for service registration

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1336,6 +1336,9 @@ impl AnchorKitContract {
     /// - the service list is empty, contains duplicates, or contains a code the
     ///   current version does not recognise (`InvalidServiceType`)
     ///
+    /// Services are stored in deterministic sorted order (ascending) regardless
+    /// of submission order, ensuring consistent storage and event emission (#258).
+    ///
     /// On success the record is stored stamped with `version` so capability
     /// discovery is explicit. Re-configuring overwrites the previous record,
     /// which is how an anchor migrates to a newer version.
@@ -1357,7 +1360,12 @@ impl AnchorKitContract {
         if services.is_empty() {
             panic_with_error!(&env, ErrorCode::InvalidServiceType);
         }
+        
+        // Validate and normalize services: check for duplicates, validate codes,
+        // and sort deterministically for consistent storage and event emission.
         let mut seen = Vec::new(&env);
+        let mut normalized = Vec::new(&env);
+        
         for s in services.iter() {
             if seen.contains(&s) {
                 panic_with_error!(&env, ErrorCode::InvalidServiceType);
@@ -1366,10 +1374,16 @@ impl AnchorKitContract {
                 panic_with_error!(&env, ErrorCode::InvalidServiceType);
             }
             seen.push_back(s);
+            normalized.push_back(s);
         }
+        
+        // Sort services deterministically (ascending order) for consistent storage
+        // and predictable behavior regardless of submission order.
+        Self::sort_services(&env, &mut normalized);
+        
         let record = AnchorServices {
             anchor: anchor.clone(),
-            services: services.clone(),
+            services: normalized,
             service_capability_version: version,
         };
         let key = make_storage_key(&env, &[b"SERVICES", &raw]);
@@ -3223,6 +3237,23 @@ impl AnchorKitContract {
     /// current [`SERVICE_CAPABILITY_VERSION`] (#239).
     fn is_known_service_code(code: u32) -> bool {
         code >= SERVICE_DEPOSITS && code <= MAX_KNOWN_SERVICE_CODE
+    }
+
+    /// Sort services in ascending order for deterministic storage.
+    /// This ensures consistent behavior regardless of submission order.
+    fn sort_services(_env: &Env, services: &mut Vec<u32>) {
+        // Simple bubble sort for small vectors (typically 1-4 elements)
+        let len = services.len();
+        for i in 0..len {
+            for j in 0..len - i - 1 {
+                let a = services.get(j).unwrap();
+                let b = services.get(j + 1).unwrap();
+                if a > b {
+                    services.set(j, b);
+                    services.set(j + 1, a);
+                }
+            }
+        }
     }
 
     /// Returns `true` iff `anchor` has configured services that include

--- a/tests/capability_detection_tests.rs
+++ b/tests/capability_detection_tests.rs
@@ -320,4 +320,125 @@ mod capability_detection_tests {
             SERVICE_CAPABILITY_VERSION
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Deterministic sorting (#258)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_services_sorted_deterministically() {
+        let env = make_env();
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        { let sk = SigningKey::generate(&mut OsRng); register_attestor_with_sep10(&env, &client, &anchor, &anchor, &sk); }
+
+        // Submit services in reverse order
+        client.configure_services(
+            &anchor,
+            &services(&env, &[SERVICE_KYC, SERVICE_QUOTES, SERVICE_WITHDRAWALS, SERVICE_DEPOSITS]),
+        );
+
+        // Verify they are stored in sorted order
+        let record = client.get_supported_services(&anchor);
+        assert_eq!(record.services.len(), 4);
+        assert_eq!(record.services.get(0).unwrap(), SERVICE_DEPOSITS);
+        assert_eq!(record.services.get(1).unwrap(), SERVICE_WITHDRAWALS);
+        assert_eq!(record.services.get(2).unwrap(), SERVICE_QUOTES);
+        assert_eq!(record.services.get(3).unwrap(), SERVICE_KYC);
+    }
+
+    #[test]
+    fn test_services_sorted_regardless_of_input_order() {
+        let env = make_env();
+        let (client, _) = setup(&env);
+        let anchor1 = Address::generate(&env);
+        let anchor2 = Address::generate(&env);
+        { 
+            let sk1 = SigningKey::generate(&mut OsRng); 
+            register_attestor_with_sep10(&env, &client, &anchor1, &anchor1, &sk1);
+            let sk2 = SigningKey::generate(&mut OsRng);
+            register_attestor_with_sep10(&env, &client, &anchor2, &anchor2, &sk2);
+        }
+
+        // Configure anchor1 with services in one order
+        client.configure_services(
+            &anchor1,
+            &services(&env, &[SERVICE_QUOTES, SERVICE_DEPOSITS, SERVICE_WITHDRAWALS]),
+        );
+
+        // Configure anchor2 with same services in different order
+        client.configure_services(
+            &anchor2,
+            &services(&env, &[SERVICE_WITHDRAWALS, SERVICE_QUOTES, SERVICE_DEPOSITS]),
+        );
+
+        // Both should have identical sorted service lists
+        let record1 = client.get_supported_services(&anchor1);
+        let record2 = client.get_supported_services(&anchor2);
+        
+        assert_eq!(record1.services.len(), record2.services.len());
+        for i in 0..record1.services.len() {
+            assert_eq!(record1.services.get(i).unwrap(), record2.services.get(i).unwrap());
+        }
+        
+        // Verify the sorted order
+        assert_eq!(record1.services.get(0).unwrap(), SERVICE_DEPOSITS);
+        assert_eq!(record1.services.get(1).unwrap(), SERVICE_WITHDRAWALS);
+        assert_eq!(record1.services.get(2).unwrap(), SERVICE_QUOTES);
+    }
+
+    #[test]
+    fn test_single_service_remains_unchanged() {
+        let env = make_env();
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        { let sk = SigningKey::generate(&mut OsRng); register_attestor_with_sep10(&env, &client, &anchor, &anchor, &sk); }
+
+        client.configure_services(&anchor, &services(&env, &[SERVICE_QUOTES]));
+
+        let record = client.get_supported_services(&anchor);
+        assert_eq!(record.services.len(), 1);
+        assert_eq!(record.services.get(0).unwrap(), SERVICE_QUOTES);
+    }
+
+    #[test]
+    fn test_two_services_sorted() {
+        let env = make_env();
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        { let sk = SigningKey::generate(&mut OsRng); register_attestor_with_sep10(&env, &client, &anchor, &anchor, &sk); }
+
+        // Submit in reverse order
+        client.configure_services(&anchor, &services(&env, &[SERVICE_WITHDRAWALS, SERVICE_DEPOSITS]));
+
+        let record = client.get_supported_services(&anchor);
+        assert_eq!(record.services.len(), 2);
+        assert_eq!(record.services.get(0).unwrap(), SERVICE_DEPOSITS);
+        assert_eq!(record.services.get(1).unwrap(), SERVICE_WITHDRAWALS);
+    }
+
+    #[test]
+    fn test_reconfigure_maintains_sorting() {
+        let env = make_env();
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        { let sk = SigningKey::generate(&mut OsRng); register_attestor_with_sep10(&env, &client, &anchor, &anchor, &sk); }
+
+        // Initial configuration in random order
+        client.configure_services(&anchor, &services(&env, &[SERVICE_QUOTES, SERVICE_DEPOSITS]));
+        
+        let record1 = client.get_supported_services(&anchor);
+        assert_eq!(record1.services.get(0).unwrap(), SERVICE_DEPOSITS);
+        assert_eq!(record1.services.get(1).unwrap(), SERVICE_QUOTES);
+
+        // Reconfigure with different services in random order
+        client.configure_services(&anchor, &services(&env, &[SERVICE_KYC, SERVICE_WITHDRAWALS, SERVICE_DEPOSITS]));
+        
+        let record2 = client.get_supported_services(&anchor);
+        assert_eq!(record2.services.len(), 3);
+        assert_eq!(record2.services.get(0).unwrap(), SERVICE_DEPOSITS);
+        assert_eq!(record2.services.get(1).unwrap(), SERVICE_WITHDRAWALS);
+        assert_eq!(record2.services.get(2).unwrap(), SERVICE_KYC);
+    }
 }
+


### PR DESCRIPTION
- Implement deterministic sorting of services in ascending order
- Services are now stored consistently regardless of submission order
- Add sort_services helper function using bubble sort for small vectors
- Update configure_services_versioned to normalize and sort services
- Add comprehensive tests for deterministic sorting behavior
- Update documentation to reflect sorting behavior

This ensures:
- Consistent storage and event emission
- Predictable behavior across different submission orders
- Easier comparison of service sets between anchors

Closes #258
Closes #257 
Closes #260 
Closes #263 