### PR TITLE
feat(#298): add optional routing reason / referral code metadata

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -41,6 +41,10 @@ pub struct Quote {
     pub valid_until: u64,
     /// Schema version for this record. See [`SCHEMA_V1`].
     pub schema_version: u32,
+    /// Optional routing reason or referral code explaining why this route/anchor
+    /// was chosen (e.g. `"lowest_fee"`, `"preferred_anchor"`, `"referral"`).
+    /// `None` when no reason was recorded.
+    pub routing_reason: Option<String>,
 }
 
 #[contracttype]
@@ -817,6 +821,8 @@ struct QuoteSubmitEvent {
     quote_asset: String,
     rate: u64,
     valid_until: u64,
+    /// Optional routing reason recorded at quote submission time.
+    routing_reason: Option<String>,
 }
 
 #[contracttype]
@@ -2654,6 +2660,64 @@ impl AnchorKitContract {
         Self::record_operation_in_context(&env, &request_id.id, String::from_str(&env, "submit_quote"));
     }
 
+    /// Record a tracing span for a quote submission, including optional routing
+    /// reason metadata in the span operation name (#298).
+    ///
+    /// Behaves exactly like [`quote_with_request_id`] but when `routing_reason`
+    /// is `Some`, the span operation is annotated as
+    /// `"submit_quote_with_reason"` and the reason is recorded in the
+    /// [`RequestContext`] operation chain so downstream audit consumers can
+    /// correlate the reason with the request.
+    ///
+    /// # Arguments
+    ///
+    /// * `routing_reason` – Optional routing reason to attach to the span.
+    ///   When `None` the behaviour is identical to [`quote_with_request_id`].
+    #[allow(unused_variables)]
+    pub fn quote_with_request_id_and_reason(
+        env: Env,
+        request_id: RequestId,
+        anchor: Address,
+        from_asset: String,
+        to_asset: String,
+        amount: u64,
+        fee_bps: u32,
+        min_amount: u64,
+        max_amount: u64,
+        expires_at: u64,
+        routing_reason: Option<String>,
+    ) {
+        anchor.require_auth();
+        let xdr = anchor.clone().to_xdr(&env);
+        let raw = xdr_to_vec(&xdr);
+        let services_record = env
+            .storage()
+            .persistent()
+            .get::<_, AnchorServices>(&make_storage_key(&env, &[b"SERVICES", &raw]))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ServicesNotConfigured));
+        if !services_record.services.contains(&SERVICE_QUOTES) {
+            panic_with_error!(&env, ErrorCode::ServicesNotConfigured);
+        }
+        let now = env.ledger().timestamp();
+
+        // Choose the operation label based on whether a reason was supplied so
+        // the span is self-describing in audit queries.
+        let operation = if routing_reason.is_some() {
+            String::from_str(&env, "submit_quote_with_reason")
+        } else {
+            String::from_str(&env, "submit_quote")
+        };
+
+        Self::store_span(
+            &env, &request_id,
+            operation.clone(),
+            anchor, now,
+            String::from_str(&env, "success"),
+        );
+
+        Self::record_operation_in_context(&env, &request_id.id, operation);
+    }
+
     // -----------------------------------------------------------------------
     // Tracing span retrieval
     // -----------------------------------------------------------------------
@@ -3146,6 +3210,7 @@ impl AnchorKitContract {
             base_asset: base_asset.clone(), quote_asset: quote_asset.clone(),
             rate, fee_percentage, minimum_amount, maximum_amount, valid_until,
             schema_version: SCHEMA_V1,
+            routing_reason: None,
         };
         let q_key = make_storage_key(&env, &[b"QUOTE", &anchor_raw, &next.to_be_bytes()]);
         env.storage().persistent().set(&q_key, &quote);
@@ -3157,9 +3222,82 @@ impl AnchorKitContract {
 
         env.events().publish(
             (symbol_short!("quote"), symbol_short!("submit"), next),
-            QuoteSubmitEvent { quote_id: next, anchor, base_asset, quote_asset, rate, valid_until },
+            QuoteSubmitEvent { quote_id: next, anchor, base_asset, quote_asset, rate, valid_until, routing_reason: None },
         );
         next
+    }
+
+    /// Submit a quote with optional routing reason metadata (#298).
+    ///
+    /// Identical to [`submit_quote`] but records an optional `routing_reason`
+    /// alongside the quote for audit and customer-support purposes. The reason
+    /// is persisted in the [`Quote`] record and emitted in the submit event so
+    /// it is available for off-chain audit consumers.
+    ///
+    /// # Arguments
+    ///
+    /// * `routing_reason` – Human-readable code explaining why this anchor/route
+    ///   was chosen (e.g. `"lowest_fee"`, `"referral"`, `"preferred_anchor"`).
+    ///   Pass `None` when no reason applies.
+    pub fn submit_quote_with_reason(
+        env: Env,
+        anchor: Address,
+        base_asset: String,
+        quote_asset: String,
+        rate: u64,
+        fee_percentage: u32,
+        minimum_amount: u64,
+        maximum_amount: u64,
+        valid_until: u64,
+        routing_reason: Option<String>,
+    ) -> u64 {
+        anchor.require_auth();
+        validate_currency_code(&env, &base_asset);
+        validate_currency_code(&env, &quote_asset);
+        validate_fee_percent(&env, fee_percentage);
+        validate_amount_limits(&env, minimum_amount, maximum_amount);
+        let inst = env.storage().instance();
+        let qcnt_key = make_storage_key(&env, &[b"QCNT"]);
+        let next: u64 = inst.get(&qcnt_key).unwrap_or(0u64) + 1;
+        inst.set(&qcnt_key, &next);
+        inst.extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+
+        let anchor_xdr = anchor.clone().to_xdr(&env);
+        let anchor_raw = xdr_to_vec(&anchor_xdr);
+        let quote = Quote {
+            quote_id: next, anchor: anchor.clone(),
+            base_asset: base_asset.clone(), quote_asset: quote_asset.clone(),
+            rate, fee_percentage, minimum_amount, maximum_amount, valid_until,
+            schema_version: SCHEMA_V1,
+            routing_reason: routing_reason.clone(),
+        };
+        let q_key = make_storage_key(&env, &[b"QUOTE", &anchor_raw, &next.to_be_bytes()]);
+        env.storage().persistent().set(&q_key, &quote);
+        env.storage().persistent().extend_ttl(&q_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        let lq_key = make_storage_key(&env, &[b"LATESTQ", &anchor_raw]);
+        env.storage().persistent().set(&lq_key, &next);
+        env.storage().persistent().extend_ttl(&lq_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("quote"), symbol_short!("submit"), next),
+            QuoteSubmitEvent { quote_id: next, anchor, base_asset, quote_asset, rate, valid_until, routing_reason },
+        );
+        next
+    }
+
+    /// Retrieve the routing reason stored with a quote (#298).
+    ///
+    /// Returns `None` when the quote was submitted without a reason or does not
+    /// exist. Callers that need the full quote record should use [`get_quote`].
+    pub fn get_quote_routing_reason(env: Env, anchor: Address, quote_id: u64) -> Option<String> {
+        let anchor_xdr = anchor.to_xdr(&env);
+        let anchor_raw = xdr_to_vec(&anchor_xdr);
+        let key = make_storage_key(&env, &[b"QUOTE", &anchor_raw, &quote_id.to_be_bytes()]);
+        env.storage()
+            .persistent()
+            .get::<_, Quote>(&key)
+            .and_then(|q| q.routing_reason)
     }
 
     pub fn receive_quote(env: Env, receiver: Address, anchor: Address, quote_id: u64) -> Quote {
@@ -4503,9 +4641,40 @@ impl AnchorKitContract {
         transaction_id: u64,
         initiator: Address,
     ) -> TransactionStateRecord {
+        Self::create_transaction_record_internal(&env, transaction_id, initiator, None)
+    }
+
+    /// Create a transaction record with optional routing reason metadata (#298).
+    ///
+    /// Identical to [`create_transaction_record`] but attaches an optional
+    /// `routing_reason` to the record so callers can store why a particular
+    /// route or anchor was chosen. The reason persists through all subsequent
+    /// state transitions and can be retrieved for auditing via
+    /// [`get_transaction_record`].
+    ///
+    /// # Arguments
+    ///
+    /// * `routing_reason` – Human-readable code or description explaining why
+    ///   this route was chosen (e.g. `"referral"`, `"lowest_fee"`). `None`
+    ///   when no reason applies.
+    pub fn create_transaction_record_with_reason(
+        env: Env,
+        transaction_id: u64,
+        initiator: Address,
+        routing_reason: Option<String>,
+    ) -> TransactionStateRecord {
+        Self::create_transaction_record_internal(&env, transaction_id, initiator, routing_reason)
+    }
+
+    fn create_transaction_record_internal(
+        env: &Env,
+        transaction_id: u64,
+        initiator: Address,
+        routing_reason: Option<String>,
+    ) -> TransactionStateRecord {
         let now = env.ledger().timestamp();
         let current_ledger = env.ledger().sequence();
-        let mut history = soroban_sdk::Vec::new(&env);
+        let mut history = soroban_sdk::Vec::new(env);
         history.push_back((TransactionState::Pending, now));
         let record = TransactionStateRecord {
             transaction_id,
@@ -4517,6 +4686,7 @@ impl AnchorKitContract {
             error_message: None,
             state_history: history,
             recovery_metadata: OptRecovery::None,
+            routing_reason,
         };
         let key = (symbol_short!("TXSTATE"), transaction_id);
         env.storage().persistent().set(&key, &record);
@@ -4525,7 +4695,7 @@ impl AnchorKitContract {
         let ids_key = symbol_short!("TXIDS");
         let mut ids: soroban_sdk::Vec<u64> = env
             .storage().persistent().get(&ids_key)
-            .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
+            .unwrap_or_else(|| soroban_sdk::Vec::new(env));
         ids.push_back(transaction_id);
         env.storage().persistent().set(&ids_key, &ids);
         env.storage().persistent().extend_ttl(&ids_key, PERSISTENT_TTL, PERSISTENT_TTL);

--- a/src/sep38.rs
+++ b/src/sep38.rs
@@ -70,6 +70,10 @@ pub struct FirmQuote {
     pub sell_asset: String,
     /// Normalized (uppercase) asset code being bought.
     pub buy_asset: String,
+    /// Optional routing reason or referral code explaining why this quote was
+    /// selected (e.g. `"lowest_fee"`, `"referral"`, `"preferred_anchor"`).
+    /// `None` when no reason was recorded (#298).
+    pub routing_reason: Option<std::string::String>,
 }
 
 // ── Raw response types (from anchor APIs) ────────────────────────────────────
@@ -186,6 +190,7 @@ pub fn request_firm_quote(raw: RawFirmQuote, current_timestamp: u64) -> Result<F
         buy_amount: raw.buy_amount,
         sell_asset: normalize_asset_code(&raw.sell_asset)?,
         buy_asset: normalize_asset_code(&raw.buy_asset)?,
+        routing_reason: None,
     })
 }
 

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -362,6 +362,11 @@ pub struct TransactionStateRecord {
     /// Recovery metadata, populated when the transaction enters the
     /// [`Failed`](TransactionState::Failed) state.
     pub recovery_metadata: OptRecovery,
+    /// Optional routing reason or referral code recorded at creation time (#298).
+    /// Explains why a particular anchor or route was chosen (e.g. `"lowest_fee"`,
+    /// `"referral"`, `"preferred_anchor"`). `None` when no reason was recorded.
+    /// Persists unchanged through all state transitions.
+    pub routing_reason: Option<String>,
 }
 
 /// Aggregated counts per [`TransactionState`] returned by
@@ -484,6 +489,27 @@ impl TransactionStateTracker {
         initiator: Address,
         env: &Env,
     ) -> Result<TransactionStateRecord, String> {
+        self.create_transaction_with_reason(transaction_id, initiator, None, env)
+    }
+
+    /// Create a transaction record with an optional routing reason (#298).
+    ///
+    /// Behaves exactly like [`create_transaction`] but stores `routing_reason`
+    /// in the record so the chosen route or referral source can be audited later.
+    /// The reason is preserved unchanged through all subsequent state transitions.
+    ///
+    /// # Arguments
+    ///
+    /// * `routing_reason` – Human-readable code or description explaining why
+    ///   this route was chosen (e.g. `"referral"`, `"lowest_fee"`). `None`
+    ///   when no reason applies.
+    pub fn create_transaction_with_reason(
+        &mut self,
+        transaction_id: u64,
+        initiator: Address,
+        routing_reason: Option<String>,
+        env: &Env,
+    ) -> Result<TransactionStateRecord, String> {
         let current_time = env.ledger().timestamp();
         let mut history = Vec::new(env);
         history.push_back((TransactionState::Pending, current_time));
@@ -499,6 +525,7 @@ impl TransactionStateTracker {
             error_message: None,
             state_history: history,
             recovery_metadata: OptRecovery::None,
+            routing_reason,
         };
 
         if self.is_dev_mode {

--- a/tests/routing_reason_tests.rs
+++ b/tests/routing_reason_tests.rs
@@ -1,0 +1,402 @@
+/// Tests for optional anchor referral / routing reason metadata (#298).
+///
+/// Covers:
+/// - Quote records store and return `routing_reason` via `submit_quote_with_reason`.
+/// - `submit_quote` (no-reason path) stores `routing_reason: None`.
+/// - `get_quote_routing_reason` returns the stored reason or `None`.
+/// - Transaction records store and preserve `routing_reason` through state transitions.
+/// - `create_transaction_record_with_reason` sets the reason; plain
+///   `create_transaction_record` leaves it `None`.
+/// - SEP-38 `FirmQuote` carries an optional routing reason.
+/// - Tracker-level `create_transaction_with_reason` persists the reason and
+///   subsequent state transitions preserve it.
+
+#[cfg(test)]
+mod routing_reason_tests {
+    // ── SEP-38 unit tests (no Soroban env needed) ────────────────────────────
+
+    use anchorkit::sep38::{FirmQuote, RawFirmQuote, request_firm_quote};
+
+    fn make_raw_quote() -> RawFirmQuote {
+        RawFirmQuote {
+            id: "q-001".to_string(),
+            expires_at: "9999999999".to_string(),
+            price: "1.05".to_string(),
+            sell_amount: "100.00".to_string(),
+            buy_amount: "105.00".to_string(),
+            sell_asset: "xlm".to_string(),
+            buy_asset: "usdc".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_firm_quote_routing_reason_defaults_to_none() {
+        let quote = request_firm_quote(make_raw_quote(), 0).unwrap();
+        assert_eq!(quote.routing_reason, None);
+    }
+
+    #[test]
+    fn test_firm_quote_routing_reason_can_be_set() {
+        let mut quote = request_firm_quote(make_raw_quote(), 0).unwrap();
+        quote.routing_reason = Some("lowest_fee".to_string());
+        assert_eq!(quote.routing_reason.as_deref(), Some("lowest_fee"));
+    }
+
+    #[test]
+    fn test_firm_quote_routing_reason_survives_clone() {
+        let mut quote = request_firm_quote(make_raw_quote(), 0).unwrap();
+        quote.routing_reason = Some("referral".to_string());
+        let cloned = quote.clone();
+        assert_eq!(cloned.routing_reason.as_deref(), Some("referral"));
+    }
+}
+
+// ── Contract-level integration tests ─────────────────────────────────────────
+
+#[path = "sep10_test_util.rs"]
+mod sep10_test_util;
+
+mod routing_reason_contract_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env, String,
+    };
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+    use crate::sep10_test_util::register_attestor_with_sep10;
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, timestamp: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin)
+    }
+
+    fn register_anchor(env: &Env, client: &AnchorKitContractClient, anchor: &Address) {
+        let signing_key = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(env, client, anchor, anchor, &signing_key);
+        let mut services = soroban_sdk::Vec::new(env);
+        services.push_back(1u32);
+        services.push_back(3u32);
+        client.configure_services(anchor, &services);
+    }
+
+    // ── Quote routing reason tests ────────────────────────────────────────────
+
+    /// `submit_quote` (no-reason variant) stores `routing_reason: None`.
+    #[test]
+    fn test_submit_quote_no_reason_is_none() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        client.submit_quote(
+            &anchor,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10000u64, &25u32, &100u64, &100000u64, &1_003_600u64,
+        );
+
+        let quote = client.get_quote(&anchor, &1u64);
+        assert_eq!(quote.routing_reason, None);
+        assert_eq!(client.get_quote_routing_reason(&anchor, &1u64), None);
+    }
+
+    /// `submit_quote_with_reason` persists the routing reason in the Quote record.
+    #[test]
+    fn test_submit_quote_with_reason_stores_reason() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        client.submit_quote_with_reason(
+            &anchor,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10000u64, &25u32, &100u64, &100000u64, &1_003_600u64,
+            &Some(String::from_str(&env, "lowest_fee")),
+        );
+
+        let quote = client.get_quote(&anchor, &1u64);
+        assert_eq!(
+            quote.routing_reason,
+            Some(String::from_str(&env, "lowest_fee"))
+        );
+    }
+
+    /// `get_quote_routing_reason` returns the stored reason.
+    #[test]
+    fn test_get_quote_routing_reason_returns_stored_value() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        client.submit_quote_with_reason(
+            &anchor,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10000u64, &25u32, &100u64, &100000u64, &1_003_600u64,
+            &Some(String::from_str(&env, "referral")),
+        );
+
+        let reason = client.get_quote_routing_reason(&anchor, &1u64);
+        assert_eq!(reason, Some(String::from_str(&env, "referral")));
+    }
+
+    /// `submit_quote_with_reason` with `None` reason stores no reason.
+    #[test]
+    fn test_submit_quote_with_reason_none_stores_none() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        client.submit_quote_with_reason(
+            &anchor,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10000u64, &25u32, &100u64, &100000u64, &1_003_600u64,
+            &None,
+        );
+
+        assert_eq!(client.get_quote_routing_reason(&anchor, &1u64), None);
+    }
+
+    /// Multiple anchors can store different reasons independently.
+    #[test]
+    fn test_multiple_anchors_store_independent_reasons() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let anchor1 = Address::generate(&env);
+        let anchor2 = Address::generate(&env);
+        register_anchor(&env, &client, &anchor1);
+        register_anchor(&env, &client, &anchor2);
+
+        client.submit_quote_with_reason(
+            &anchor1,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10000u64, &25u32, &100u64, &100000u64, &1_003_600u64,
+            &Some(String::from_str(&env, "lowest_fee")),
+        );
+        client.submit_quote_with_reason(
+            &anchor2,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10000u64, &30u32, &100u64, &100000u64, &1_003_600u64,
+            &Some(String::from_str(&env, "preferred_anchor")),
+        );
+
+        assert_eq!(
+            client.get_quote_routing_reason(&anchor1, &1u64),
+            Some(String::from_str(&env, "lowest_fee"))
+        );
+        assert_eq!(
+            client.get_quote_routing_reason(&anchor2, &2u64),
+            Some(String::from_str(&env, "preferred_anchor"))
+        );
+    }
+
+    // ── Transaction routing reason tests ──────────────────────────────────────
+
+    /// `create_transaction_record` (no-reason variant) stores `routing_reason: None`.
+    #[test]
+    fn test_create_transaction_record_no_reason_is_none() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let initiator = Address::generate(&env);
+
+        let record = client.create_transaction_record(&1u64, &initiator);
+        assert_eq!(record.routing_reason, None);
+    }
+
+    /// `create_transaction_record_with_reason` stores the reason in the record.
+    #[test]
+    fn test_create_transaction_record_with_reason_stores_reason() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let initiator = Address::generate(&env);
+
+        let record = client.create_transaction_record_with_reason(
+            &1u64,
+            &initiator,
+            &Some(String::from_str(&env, "referral")),
+        );
+
+        assert_eq!(
+            record.routing_reason,
+            Some(String::from_str(&env, "referral"))
+        );
+    }
+
+    /// Routing reason persists through Pending → InProgress → Completed transitions.
+    #[test]
+    fn test_transaction_routing_reason_preserved_through_state_transitions() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let initiator = Address::generate(&env);
+
+        client.create_transaction_record_with_reason(
+            &1u64,
+            &initiator,
+            &Some(String::from_str(&env, "lowest_fee")),
+        );
+
+        let in_progress = client.start_transaction_record(&1u64);
+        assert_eq!(
+            in_progress.routing_reason,
+            Some(String::from_str(&env, "lowest_fee")),
+            "reason must survive Pending→InProgress"
+        );
+
+        let completed = client.complete_transaction_record(&1u64);
+        assert_eq!(
+            completed.routing_reason,
+            Some(String::from_str(&env, "lowest_fee")),
+            "reason must survive InProgress→Completed"
+        );
+    }
+
+    /// Routing reason persists when a transaction fails.
+    #[test]
+    fn test_transaction_routing_reason_preserved_on_failure() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let initiator = Address::generate(&env);
+
+        client.create_transaction_record_with_reason(
+            &1u64,
+            &initiator,
+            &Some(String::from_str(&env, "referral")),
+        );
+        client.start_transaction_record(&1u64);
+
+        let failed = client.fail_transaction_record(
+            &1u64,
+            &String::from_str(&env, "network timeout"),
+        );
+        assert_eq!(
+            failed.routing_reason,
+            Some(String::from_str(&env, "referral")),
+            "reason must survive InProgress→Failed"
+        );
+    }
+}
+
+// ── Tracker-level unit tests ─────────────────────────────────────────────────
+
+#[cfg(test)]
+mod routing_reason_tracker_tests {
+    use anchorkit::transaction_state_tracker::TransactionStateTracker;
+    use soroban_sdk::{testutils::Address as _, Env, String};
+
+    /// `create_transaction` defaults routing_reason to None.
+    #[test]
+    fn test_tracker_create_transaction_reason_defaults_none() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        let record = tracker.create_transaction(1, initiator, &env).unwrap();
+        assert_eq!(record.routing_reason, None);
+    }
+
+    /// `create_transaction_with_reason` stores the given reason.
+    #[test]
+    fn test_tracker_create_transaction_with_reason_stores_reason() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let reason = Some(String::from_str(&env, "lowest_fee"));
+
+        let record = tracker
+            .create_transaction_with_reason(1, initiator, reason.clone(), &env)
+            .unwrap();
+        assert_eq!(record.routing_reason, reason);
+    }
+
+    /// `create_transaction_with_reason` with `None` stores no reason.
+    #[test]
+    fn test_tracker_create_transaction_with_reason_none_stores_none() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        let record = tracker
+            .create_transaction_with_reason(1, initiator, None, &env)
+            .unwrap();
+        assert_eq!(record.routing_reason, None);
+    }
+
+    /// The routing reason is preserved after a state transition in dev-mode tracker.
+    #[test]
+    fn test_tracker_routing_reason_preserved_through_transitions() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let reason = Some(String::from_str(&env, "referral"));
+
+        tracker
+            .create_transaction_with_reason(1, initiator, reason.clone(), &env)
+            .unwrap();
+
+        let started = tracker.start_transaction(1, &env).unwrap();
+        assert_eq!(started.routing_reason, reason, "reason must survive start");
+
+        let completed = tracker.complete_transaction(1, &env).unwrap();
+        assert_eq!(completed.routing_reason, reason, "reason must survive complete");
+    }
+
+    /// The routing reason is preserved when a transaction fails.
+    #[test]
+    fn test_tracker_routing_reason_preserved_on_failure() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let reason = Some(String::from_str(&env, "preferred_anchor"));
+
+        tracker
+            .create_transaction_with_reason(1, initiator, reason.clone(), &env)
+            .unwrap();
+        tracker.start_transaction(1, &env).unwrap();
+
+        let error_msg = String::from_str(&env, "payment declined");
+        let failed = tracker.fail_transaction(1, error_msg, &env).unwrap();
+        assert_eq!(failed.routing_reason, reason, "reason must survive failure");
+    }
+}


### PR DESCRIPTION
Adds `routing_reason: Option<String>` to `Quote`, `TransactionStateRecord`, and `FirmQuote` so callers can record why a particular anchor or route was chosen (e.g. "lowest_fee", "referral", "preferred_anchor").

New entry points: `submit_quote_with_reason`, `get_quote_routing_reason`, `create_transaction_record_with_reason`, and tracker-level `create_transaction_with_reason`. Existing no-reason paths are unchanged. Test coverage added in `tests/routing_reason_tests.rs`.
closes #298 