### PR TITLE
feat: add replay detection metrics and structured logging

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -10,6 +10,7 @@ use crate::errors::ErrorCode;
 use crate::rate_limiter::RateLimiter;
 use crate::sep10_jwt;
 use crate::transaction_state_tracker::{OptRecovery, TransactionState, TransactionStateRecord};
+use crate::replay_detection::{self, ReplayMetrics};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -2471,6 +2472,9 @@ impl AnchorKitContract {
         let hash_raw = xdr_to_vec(&payload_hash);
         let used_key = make_storage_key(&env, &[b"USED", &issuer_raw, &hash_raw]);
         if env.storage().persistent().has(&used_key) {
+            // Record replay detection event and metrics before panicking
+            let replay_event = replay_detection::record_replay_detection(&env, &payload_hash, &issuer);
+            replay_detection::emit_replay_detection_log(&env, &replay_event);
             panic_with_error!(&env, ErrorCode::ReplayAttack);
         }
 
@@ -2526,6 +2530,9 @@ impl AnchorKitContract {
         let hash_raw = xdr_to_vec(&payload_hash);
         let used_key = make_storage_key(&env, &[b"USED", &issuer_raw, &hash_raw]);
         if env.storage().persistent().has(&used_key) {
+            // Record replay detection event and metrics before panicking
+            let replay_event = replay_detection::record_replay_detection(&env, &payload_hash, &issuer);
+            replay_detection::emit_replay_detection_log(&env, &replay_event);
             panic_with_error!(&env, ErrorCode::ReplayAttack);
         }
 
@@ -2577,6 +2584,9 @@ impl AnchorKitContract {
         let hash_raw = xdr_to_vec(&payload_hash);
         let used_key = make_storage_key(&env, &[b"USED", &issuer_raw, &hash_raw]);
         if env.storage().persistent().has(&used_key) {
+            // Record replay detection event and metrics before panicking
+            let replay_event = replay_detection::record_replay_detection(&env, &payload_hash, &issuer);
+            replay_detection::emit_replay_detection_log(&env, &replay_event);
             panic_with_error!(&env, ErrorCode::ReplayAttack);
         }
 
@@ -3257,6 +3267,9 @@ impl AnchorKitContract {
             &env, &[b"SESSREQ", &session_id.to_be_bytes(), &hash_raw],
         );
         if env.storage().persistent().has(&sess_req_key) {
+            // Record replay detection event and metrics before panicking
+            let replay_event = replay_detection::record_replay_detection(&env, &payload_hash, &issuer);
+            replay_detection::emit_replay_detection_log(&env, &replay_event);
             panic_with_error!(&env, ErrorCode::ReplayAttack);
         }
         env.storage().persistent().set(&sess_req_key, &true);
@@ -3266,6 +3279,9 @@ impl AnchorKitContract {
         let issuer_raw = xdr_to_vec(&issuer_xdr);
         let used_key = make_storage_key(&env, &[b"USED", &issuer_raw, &hash_raw]);
         if env.storage().persistent().has(&used_key) {
+            // Record replay detection event and metrics before panicking
+            let replay_event = replay_detection::record_replay_detection(&env, &payload_hash, &issuer);
+            replay_detection::emit_replay_detection_log(&env, &replay_event);
             panic_with_error!(&env, ErrorCode::ReplayAttack);
         }
 
@@ -5439,5 +5455,17 @@ impl AnchorKitContract {
             rate_limit_window_length: config.window_length,
             checked_at: now,
         }
+    }
+
+    /// Retrieve current replay detection metrics.
+    /// Returns aggregated statistics about detected replay attacks.
+    pub fn get_replay_metrics(env: Env) -> ReplayMetrics {
+        replay_detection::get_replay_metrics(&env)
+    }
+
+    /// Retrieve the attempt count for a specific request ID that was replayed.
+    /// Returns 0 if no replay attempts have been recorded for this ID.
+    pub fn get_replay_count_for_id(env: Env, request_id: Bytes) -> u64 {
+        replay_detection::get_replay_count_for_id(&env, &request_id)
     }
 }

--- a/src/replay_detection.rs
+++ b/src/replay_detection.rs
@@ -1,0 +1,320 @@
+//! Replay detection metrics and structured logging for duplicate request IDs.
+//!
+//! This module provides tracking and instrumentation for replay attack detection,
+//! recording metrics when duplicate request IDs are detected.
+//!
+//! # Overview
+//!
+//! Production systems need to know when replay attempts occur and whether they are malicious.
+//! This module instruments request ID processing with replay detection hooks and records
+//! metrics or logs when a duplicate request is rejected.
+
+use soroban_sdk::{contracttype, Address, Bytes, Env};
+
+/// Structured log entry for a replay detection event.
+#[derive(Clone, Debug)]
+pub struct ReplayDetectionEvent {
+    /// The request/payload ID that triggered the replay detection
+    pub request_id: Bytes,
+    /// The actor (issuer, address) attempting the replay
+    pub actor: Address,
+    /// Timestamp when the duplicate was detected
+    pub detected_at: u64,
+    /// Number of previous occurrences of this request ID (before this one)
+    pub attempt_count: u32,
+    /// Ledger sequence number when detected
+    pub ledger_sequence: u32,
+}
+
+/// Metrics snapshot for replay detection statistics.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReplayMetrics {
+    /// Total number of replay attempts detected since initialization
+    pub total_replay_attempts: u64,
+    /// Number of unique request IDs that have been replayed
+    pub unique_replayed_ids: u64,
+    /// Timestamp of the most recent replay attempt
+    pub last_replay_at: u64,
+    /// Ledger sequence when metrics were last updated
+    pub last_updated_ledger: u32,
+}
+
+impl Default for ReplayMetrics {
+    fn default() -> Self {
+        ReplayMetrics {
+            total_replay_attempts: 0,
+            unique_replayed_ids: 0,
+            last_replay_at: 0,
+            last_updated_ledger: 0,
+        }
+    }
+}
+
+/// Internal tracking for a single replay attempt
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ReplayAttemptRecord {
+    /// Request ID that was replayed
+    pub request_id: Bytes,
+    /// Actor attempting the replay
+    pub actor: Address,
+    /// Count of duplicate attempts for this ID
+    pub attempt_number: u32,
+    /// Timestamp of this attempt
+    pub timestamp: u64,
+    /// Ledger sequence when this replay was detected
+    pub ledger_sequence: u32,
+}
+
+/// Record a replay detection event in contract storage and emit structured logs.
+///
+/// This function should be called when a duplicate request ID is detected.
+/// It updates metrics, records the event for auditing, and returns event details
+/// for potential external logging systems.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+/// * `request_id` - The duplicate request/payload ID
+/// * `actor` - The address attempting the replay
+///
+/// # Returns
+///
+/// A `ReplayDetectionEvent` with full details for logging
+pub fn record_replay_detection(
+    env: &Env,
+    request_id: &Bytes,
+    actor: &Address,
+) -> ReplayDetectionEvent {
+    let now = env.ledger().timestamp();
+    let ledger_seq = env.ledger().sequence();
+
+    // Increment the global replay metrics
+    let metrics_key = soroban_sdk::symbol_short!("REPLAYM");
+    let mut metrics: ReplayMetrics = env
+        .storage()
+        .instance()
+        .get::<_, ReplayMetrics>(&metrics_key)
+        .unwrap_or_default();
+
+    // Track attempt count for this specific request ID using a (Symbol, Bytes) tuple key
+    let attempt_key = (soroban_sdk::symbol_short!("REPLAYAT"), request_id.clone());
+    let mut attempt_count: u32 = env
+        .storage()
+        .instance()
+        .get::<_, u32>(&attempt_key)
+        .unwrap_or(0);
+    attempt_count += 1;
+
+    // Update global metrics
+    metrics.total_replay_attempts += 1;
+    if attempt_count == 1 {
+        // This is the first replay of this request ID
+        metrics.unique_replayed_ids += 1;
+    }
+    metrics.last_replay_at = now;
+    metrics.last_updated_ledger = ledger_seq;
+
+    // Persist the updated metrics and attempt count
+    env.storage().instance().set(&metrics_key, &metrics);
+    env.storage().instance().set(&attempt_key, &attempt_count);
+
+    // Store detailed replay event for audit trail
+    let event_id = next_replay_event_id(env);
+    let event = ReplayAttemptRecord {
+        request_id: request_id.clone(),
+        actor: actor.clone(),
+        attempt_number: attempt_count,
+        timestamp: now,
+        ledger_sequence: ledger_seq,
+    };
+    let event_key = (soroban_sdk::symbol_short!("REPLAYEV"), event_id);
+    env.storage().instance().set(&event_key, &event);
+
+    // Create the event for external logging
+    ReplayDetectionEvent {
+        request_id: request_id.clone(),
+        actor: actor.clone(),
+        detected_at: now,
+        attempt_count,
+        ledger_sequence: ledger_seq,
+    }
+}
+
+/// Retrieve current replay detection metrics.
+///
+/// Returns aggregated statistics on replay detection since contract initialization.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+///
+/// # Returns
+///
+/// A `ReplayMetrics` snapshot with current statistics
+pub fn get_replay_metrics(env: &Env) -> ReplayMetrics {
+    let metrics_key = soroban_sdk::symbol_short!("REPLAYM");
+    env.storage()
+        .instance()
+        .get::<_, ReplayMetrics>(&metrics_key)
+        .unwrap_or_default()
+}
+
+/// Get the count of replay attempts for a specific request ID.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+/// * `request_id` - The request ID to check
+///
+/// # Returns
+///
+/// Number of times this request ID has been replayed (0 if never seen)
+pub fn get_replay_count_for_id(env: &Env, request_id: &Bytes) -> u64 {
+    let attempt_key = (soroban_sdk::symbol_short!("REPLAYAT"), request_id.clone());
+    env.storage()
+        .instance()
+        .get::<_, u32>(&attempt_key)
+        .unwrap_or(0) as u64
+}
+
+/// Get a specific replay detection event record by ID.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+/// * `event_id` - The event ID to retrieve
+///
+/// # Returns
+///
+/// The `ReplayAttemptRecord` if found, or None
+pub fn get_replay_event(env: &Env, event_id: u64) -> Option<ReplayAttemptRecord> {
+    let event_key = (soroban_sdk::symbol_short!("REPLAYEV"), event_id);
+    env.storage().instance().get::<_, ReplayAttemptRecord>(&event_key)
+}
+
+/// Get the next sequential replay event ID.
+fn next_replay_event_id(env: &Env) -> u64 {
+    let id_key = soroban_sdk::symbol_short!("REPLAYID");
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get::<_, u64>(&id_key)
+        .unwrap_or(0);
+    let next = current + 1;
+    env.storage().instance().set(&id_key, &next);
+    current
+}
+
+/// Log a replay detection event with structured information.
+///
+/// Emits a contract event that can be captured by indexers and monitoring systems.
+pub fn emit_replay_detection_log(env: &Env, event: &ReplayDetectionEvent) {
+    env.events().publish(
+        (soroban_sdk::symbol_short!("replay"), soroban_sdk::symbol_short!("detected")),
+        (
+            event.request_id.clone(),
+            event.actor.clone(),
+            event.detected_at,
+            event.attempt_count,
+            event.ledger_sequence,
+        ),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+
+    fn make_test_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set(LedgerInfo {
+            timestamp: 1_000_000,
+            protocol_version: 21,
+            sequence_number: 100,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+        env
+    }
+
+    #[test]
+    fn test_record_first_replay_detection() {
+        let env = make_test_env();
+        let request_id = Bytes::from_slice(&env, &[0x01, 0x02, 0x03]);
+        let actor = Address::generate(&env);
+
+        let event = record_replay_detection(&env, &request_id, &actor);
+
+        assert_eq!(event.attempt_count, 1);
+        assert_eq!(event.detected_at, 1_000_000);
+        assert_eq!(event.ledger_sequence, 100);
+    }
+
+    #[test]
+    fn test_replay_metrics_accumulate() {
+        let env = make_test_env();
+        let request_id = Bytes::from_slice(&env, &[0x01, 0x02, 0x03]);
+        let actor = Address::generate(&env);
+
+        // First replay
+        record_replay_detection(&env, &request_id, &actor);
+
+        // Second replay of same ID
+        record_replay_detection(&env, &request_id, &actor);
+
+        let metrics = get_replay_metrics(&env);
+        assert_eq!(metrics.total_replay_attempts, 2);
+        assert_eq!(metrics.unique_replayed_ids, 1);
+    }
+
+    #[test]
+    fn test_multiple_request_ids_tracked() {
+        let env = make_test_env();
+        let req_id_1 = Bytes::from_slice(&env, &[0x01]);
+        let req_id_2 = Bytes::from_slice(&env, &[0x02]);
+        let actor = Address::generate(&env);
+
+        record_replay_detection(&env, &req_id_1, &actor);
+        record_replay_detection(&env, &req_id_2, &actor);
+
+        let metrics = get_replay_metrics(&env);
+        assert_eq!(metrics.total_replay_attempts, 2);
+        assert_eq!(metrics.unique_replayed_ids, 2);
+    }
+
+    #[test]
+    fn test_get_replay_count_for_id() {
+        let env = make_test_env();
+        let request_id = Bytes::from_slice(&env, &[0x05]);
+        let actor = Address::generate(&env);
+
+        assert_eq!(get_replay_count_for_id(&env, &request_id), 0);
+
+        record_replay_detection(&env, &request_id, &actor);
+        assert_eq!(get_replay_count_for_id(&env, &request_id), 1);
+
+        record_replay_detection(&env, &request_id, &actor);
+        assert_eq!(get_replay_count_for_id(&env, &request_id), 2);
+    }
+
+    #[test]
+    fn test_replay_event_retrieval() {
+        let env = make_test_env();
+        let request_id = Bytes::from_slice(&env, &[0x10]);
+        let actor = Address::generate(&env);
+
+        record_replay_detection(&env, &request_id, &actor);
+
+        let event_opt = get_replay_event(&env, 0);
+        assert!(event_opt.is_some());
+        let event = event_opt.unwrap();
+        assert_eq!(event.attempt_number, 1);
+    }
+}

--- a/tests/replay_protection_tests.rs
+++ b/tests/replay_protection_tests.rs
@@ -73,6 +73,29 @@ mod replay_protection_tests {
         client.submit_attestation(&issuer, &subject, &1_000_002u64, &hash, &sig(&env));
     }
 
+    #[test]
+    fn test_duplicate_attestation_updates_replay_metrics() {
+        let env = make_env();
+        let (client, _, issuer, subject) = setup(&env);
+
+        let hash = payload(&env, 0x55);
+        client.submit_attestation(&issuer, &subject, &1_000_001u64, &hash, &sig(&env));
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.submit_attestation(&issuer, &subject, &1_000_002u64, &hash, &sig(&env));
+        }));
+
+        assert!(result.is_err(), "Duplicate attestation submission should panic");
+
+        let metrics = client.get_replay_metrics();
+        assert_eq!(metrics.total_replay_attempts, 1);
+        assert_eq!(metrics.unique_replayed_ids, 1);
+        assert_eq!(metrics.last_updated_ledger, 0);
+
+        let replayed_count = client.get_replay_count_for_id(hash.clone());
+        assert_eq!(replayed_count, 1);
+    }
+
     // -----------------------------------------------------------------------
     // Different payload hash from same issuer is accepted
     // -----------------------------------------------------------------------


### PR DESCRIPTION
- Add #[contracttype] to ReplayMetrics and ReplayAttemptRecord for Soroban storage compatibility
- Fix storage keys from Vec to (Symbol, Bytes) tuples
- Remove unused String import from replay_detection.rs
- Change get_replay_count_for_id return type to u64
- Import ReplayMetrics in contract.rs; fix get_replay_count_for_id param from Hash to Bytes
- Wrap catch_unwind closure with AssertUnwindSafe in replay_protection_tests.rs

Closes #302
Closes #301
Closes #304 
