### PR TITLE
feat: audit log retention, compliance queries, SEP-6/24 validation, CLI secret handling

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -981,6 +981,32 @@ fn compliance_check_key(env: &Env, subject: &Address, check_type: &String) -> By
     make_storage_key(env, &[b"COMP", &raw, &ct_bytes])
 }
 
+fn compliance_history_count_key(env: &Env, subject: &Address, check_type: &String) -> BytesN<32> {
+    let xdr = subject.clone().to_xdr(env);
+    let raw = xdr_to_vec(&xdr);
+    let ct_xdr = check_type.clone().to_xdr(env);
+    let ct_bytes = xdr_to_vec(&ct_xdr);
+    make_storage_key(env, &[b"COMPHCNT", &raw, &ct_bytes])
+}
+
+fn compliance_history_entry_key(env: &Env, subject: &Address, check_type: &String, idx: u64) -> BytesN<32> {
+    let xdr = subject.clone().to_xdr(env);
+    let raw = xdr_to_vec(&xdr);
+    let ct_xdr = check_type.clone().to_xdr(env);
+    let ct_bytes = xdr_to_vec(&ct_xdr);
+    make_storage_key(env, &[b"COMPHIST", &raw, &ct_bytes, &idx.to_be_bytes()])
+}
+
+fn compliance_subject_index_key(env: &Env, subject: &Address) -> BytesN<32> {
+    let xdr = subject.clone().to_xdr(env);
+    let raw = xdr_to_vec(&xdr);
+    make_storage_key(env, &[b"COMPIDX", &raw])
+}
+
+fn audit_retention_key(env: &Env) -> BytesN<32> {
+    make_storage_key(env, &[b"AUDITRET"])
+}
+
 fn anchor_meta_key(env: &Env, anchor: &Address) -> BytesN<32> {
     let xdr = anchor.clone().to_xdr(env);
     let raw = xdr_to_vec(&xdr);
@@ -3001,7 +3027,8 @@ impl AnchorKitContract {
     // -----------------------------------------------------------------------
 
     /// Record a compliance check result for a subject (admin-only).
-    /// Stores a `ComplianceCheck` record and emits a `compliance_checked` event.
+    /// Stores the latest `ComplianceCheck` record, appends to history, and updates the
+    /// per-subject check-type index so auditors can query decision histories.
     pub fn record_compliance_check(
         env: Env,
         subject: Address,
@@ -3016,13 +3043,88 @@ impl AnchorKitContract {
             result: if passed { 1u32 } else { 0u32 },
             timestamp: now,
         };
+
+        // Store latest (keyed by subject + check_type)
         let key = compliance_check_key(&env, &subject, &check_type);
         env.storage().persistent().set(&key, &record);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        // Append to ordered history
+        let hist_cnt_key = compliance_history_count_key(&env, &subject, &check_type);
+        let idx: u64 = env
+            .storage()
+            .persistent()
+            .get::<_, u64>(&hist_cnt_key)
+            .unwrap_or(0u64);
+        let hist_key = compliance_history_entry_key(&env, &subject, &check_type, idx);
+        env.storage().persistent().set(&hist_key, &record);
+        env.storage().persistent().extend_ttl(&hist_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        env.storage().persistent().set(&hist_cnt_key, &(idx + 1));
+        env.storage().persistent().extend_ttl(&hist_cnt_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        // Update per-subject check-type index
+        let idx_key = compliance_subject_index_key(&env, &subject);
+        let mut check_types: Vec<String> = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<String>>(&idx_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !check_types.contains(&check_type) {
+            check_types.push_back(check_type.clone());
+            env.storage().persistent().set(&idx_key, &check_types);
+            env.storage().persistent().extend_ttl(&idx_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        }
+
         env.events().publish(
             (symbol_short!("comp"), symbol_short!("checked"), subject),
             record,
         );
+    }
+
+    /// Return the most recent compliance check record for `(subject, check_type)`, or
+    /// `None` if no check has been recorded.
+    pub fn get_latest_compliance_check(
+        env: Env,
+        subject: Address,
+        check_type: String,
+    ) -> Option<ComplianceCheck> {
+        let key = compliance_check_key(&env, &subject, &check_type);
+        env.storage().persistent().get(&key)
+    }
+
+    /// Return the ordered history of compliance checks for `(subject, check_type)`.
+    /// Returns up to `limit` records (capped at 50), most-recent last.
+    pub fn get_compliance_check_history(
+        env: Env,
+        subject: Address,
+        check_type: String,
+        limit: u64,
+    ) -> Vec<ComplianceCheck> {
+        let hist_cnt_key = compliance_history_count_key(&env, &subject, &check_type);
+        let total: u64 = env
+            .storage()
+            .persistent()
+            .get::<_, u64>(&hist_cnt_key)
+            .unwrap_or(0u64);
+        let effective_limit = limit.min(50);
+        let start = if total > effective_limit { total - effective_limit } else { 0 };
+        let mut results = Vec::new(&env);
+        for i in start..total {
+            let hist_key = compliance_history_entry_key(&env, &subject, &check_type, i);
+            if let Some(entry) = env.storage().persistent().get::<_, ComplianceCheck>(&hist_key) {
+                results.push_back(entry);
+            }
+        }
+        results
+    }
+
+    /// Return all check types that have been recorded for a given subject.
+    pub fn list_subject_compliance_checks(env: Env, subject: Address) -> Vec<String> {
+        let idx_key = compliance_subject_index_key(&env, &subject);
+        env.storage()
+            .persistent()
+            .get::<_, Vec<String>>(&idx_key)
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     // -----------------------------------------------------------------------
@@ -3481,6 +3583,97 @@ impl AnchorKitContract {
             .persistent()
             .get::<_, u64>(&make_storage_key(&env, &[b"SOPCNT", &session_id.to_be_bytes()]))
             .unwrap_or(0)
+    }
+
+    // -----------------------------------------------------------------------
+    // Audit log retention and pagination (#251)
+    // -----------------------------------------------------------------------
+
+    /// Set the audit log retention policy in days (admin-only).
+    /// A value of 0 means no automatic retention limit is enforced.
+    pub fn set_audit_log_retention(env: Env, retention_days: u64) {
+        Self::require_admin(&env);
+        let key = audit_retention_key(&env);
+        env.storage().instance().set(&key, &retention_days);
+        env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+    }
+
+    /// Return the configured audit log retention policy in days (0 = unlimited).
+    pub fn get_audit_log_retention(env: Env) -> u64 {
+        let key = audit_retention_key(&env);
+        env.storage().instance().get::<_, u64>(&key).unwrap_or(0u64)
+    }
+
+    /// Return the total number of audit log entries ever written.
+    pub fn get_audit_log_count(env: Env) -> u64 {
+        let acnt_key = make_storage_key(&env, &[b"ACNT"]);
+        env.storage().instance().get::<_, u64>(&acnt_key).unwrap_or(0u64)
+    }
+
+    /// Return a page of audit log entries starting at `offset`, up to `limit` entries
+    /// (capped at 50 per call to bound WASM execution).
+    pub fn get_audit_logs_paginated(env: Env, offset: u64, limit: u64) -> Vec<AuditLog> {
+        let acnt_key = make_storage_key(&env, &[b"ACNT"]);
+        let total: u64 = env.storage().instance().get::<_, u64>(&acnt_key).unwrap_or(0u64);
+        let effective_limit = limit.min(50);
+        let end = (offset + effective_limit).min(total);
+        let mut results = Vec::new(&env);
+        for i in offset..end {
+            let audit_key = make_storage_key(&env, &[b"AUDIT", &i.to_be_bytes()]);
+            if let Some(entry) = env.storage().persistent().get::<_, AuditLog>(&audit_key) {
+                results.push_back(entry);
+            }
+        }
+        results
+    }
+
+    /// Paginated retrieval of audit logs scoped to a specific session.
+    /// Returns up to `limit` entries (capped at 50) starting at `offset` within the session.
+    pub fn get_session_logs_paginated(
+        env: Env,
+        session_id: u64,
+        offset: u64,
+        limit: u64,
+    ) -> Vec<AuditLog> {
+        let total: u64 = env
+            .storage()
+            .persistent()
+            .get(&make_storage_key(&env, &[b"SOPCNT", &session_id.to_be_bytes()]))
+            .unwrap_or(0u64);
+        let effective_limit = limit.min(50);
+        let end = (offset + effective_limit).min(total);
+        let mut results = Vec::new(&env);
+        for i in offset..end {
+            let slog_key = make_storage_key(&env, &[b"SLOG", &session_id.to_be_bytes(), &i.to_be_bytes()]);
+            if let Some(log_id) = env.storage().persistent().get::<_, u64>(&slog_key) {
+                let audit_key = make_storage_key(&env, &[b"AUDIT", &log_id.to_be_bytes()]);
+                if let Some(entry) = env.storage().persistent().get::<_, AuditLog>(&audit_key) {
+                    results.push_back(entry);
+                }
+            }
+        }
+        results
+    }
+
+    /// Remove audit log entries whose `operation.timestamp` is strictly before
+    /// `before_timestamp`. Scans up to the first 100 log IDs to remain WASM-safe.
+    /// Returns the number of entries pruned.
+    pub fn prune_audit_logs(env: Env, before_timestamp: u64) -> u64 {
+        Self::require_admin(&env);
+        let acnt_key = make_storage_key(&env, &[b"ACNT"]);
+        let total: u64 = env.storage().instance().get::<_, u64>(&acnt_key).unwrap_or(0u64);
+        let scan_limit = total.min(100);
+        let mut pruned: u64 = 0;
+        for i in 0..scan_limit {
+            let audit_key = make_storage_key(&env, &[b"AUDIT", &i.to_be_bytes()]);
+            if let Some(entry) = env.storage().persistent().get::<_, AuditLog>(&audit_key) {
+                if entry.operation.timestamp < before_timestamp {
+                    env.storage().persistent().remove(&audit_key);
+                    pruned += 1;
+                }
+            }
+        }
+        pruned
     }
 
     // -----------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,35 +10,10 @@ use serde::Serialize;
 use std::fs::{self, File};
 use std::io::{self, ErrorKind, Read};
 
-// ── SecretKey wrapper ──────────────────────────────────────────────────────────
-
-/// Opaque wrapper around a Stellar secret key string.
-/// Does not implement Debug or Display to prevent accidental logging.
-struct SecretKey(String);
-
-impl SecretKey {
-    fn new(s: impl Into<String>) -> Self {
-        SecretKey(s.into())
-    }
-}
-
-impl std::ops::Deref for SecretKey {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl AsRef<std::ffi::OsStr> for SecretKey {
-    fn as_ref(&self) -> &std::ffi::OsStr {
-        self.0.as_ref()
-    }
-}
-
-// ── Secret key wrapper (zeroizing) ───────────────────────────────────────────
+// ── SecretKey wrapper ─────────────────────────────────────────────────────────
 //
-// Prevents accidental secret leakage through Debug/Display, and zeroizes the
-// key material when the value is dropped (post-use or on error paths).
+// Wraps a Stellar secret key so it is never accidentally emitted to stdout,
+// stderr, or debug output. Zeroizes key material on drop.
 
 struct SecretKey(String);
 
@@ -49,7 +24,7 @@ impl SecretKey {
 
 impl std::fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("SecretKey([REDACTED])")
+        f.write_str("[REDACTED]")
     }
 }
 
@@ -64,49 +39,14 @@ impl std::ops::Deref for SecretKey {
     fn deref(&self) -> &str { &self.0 }
 }
 
+impl AsRef<std::ffi::OsStr> for SecretKey {
+    fn as_ref(&self) -> &std::ffi::OsStr { self.0.as_ref() }
+}
+
 impl Drop for SecretKey {
     fn drop(&mut self) {
         use zeroize::Zeroize;
         self.0.zeroize();
-    }
-}
-
-// ── SecretKey wrapper ─────────────────────────────────────────────────────────
-//
-// Wraps a Stellar secret key so it is never accidentally emitted to stdout,
-// stderr, or debug output. The underlying value is only exposed via `Deref`
-// (→ &str) and `AsRef<OsStr>` so it can be passed to subprocess arguments.
-
-struct SecretKey(String);
-
-impl SecretKey {
-    fn new(s: impl Into<String>) -> Self {
-        SecretKey(s.into())
-    }
-}
-
-impl std::ops::Deref for SecretKey {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl AsRef<std::ffi::OsStr> for SecretKey {
-    fn as_ref(&self) -> &std::ffi::OsStr {
-        self.0.as_ref()
-    }
-}
-
-impl std::fmt::Debug for SecretKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[REDACTED]")
-    }
-}
-
-impl std::fmt::Display for SecretKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[REDACTED]")
     }
 }
 
@@ -405,49 +345,134 @@ fn require_contract_id(global: Option<String>, local: Option<String>, command: &
     })
 }
 
-/// Resolve the signing source from flags or environment.
-/// Priority: --secret-key > ANCHOR_ADMIN_SECRET > --keypair-file > --credential-name
-fn resolve_source(secret_key: Option<&str>, keypair_file: Option<&str>, credential_name: Option<&str>) -> SecretKey {
+/// Validate that `key` looks like a Stellar secret key (starts with 'S', non-empty).
+/// Returns an error string when the key is invalid.
+fn validate_stellar_secret(key: &str, source_label: &str) -> Result<(), String> {
+    if key.is_empty() {
+        return Err(format!("{source_label}: signing key must not be empty"));
+    }
+    if !key.starts_with('S') {
+        return Err(format!(
+            "{source_label}: not a valid Stellar secret key (expected 'S...' format, got a key starting with '{}')",
+            key.chars().next().unwrap_or('?')
+        ));
+    }
+    Ok(())
+}
+
+/// Inner, infallible-return version of secret resolution used for unit testing.
+///
+/// Resolution order:
+///   1. `ephemeral_token` (highest priority; one-time automated flow token)
+///   2. `secret_key` flag
+///   3. `ANCHOR_ADMIN_SECRET` environment variable
+///   4. `keypair_file` (JSON `{"secret_key":"S..."}` or plain-text)
+///   5. `credential_name` (keystore; requires interactive prompt)
+///
+/// Returns `Ok(raw_key_string)` on success or `Err(descriptive_message)` on failure.
+fn try_resolve_source(
+    ephemeral_token: Option<&str>,
+    secret_key: Option<&str>,
+    keypair_file: Option<&str>,
+    credential_name: Option<&str>,
+    no_interactive: bool,
+    read_env: &dyn Fn(&str) -> Option<String>,
+) -> Result<String, String> {
+    // 1. Ephemeral token — highest priority, single-use automated token
+    if let Some(tok) = ephemeral_token {
+        if !tok.is_empty() {
+            validate_stellar_secret(tok, "--ephemeral-token / ANCHORKIT_EPHEMERAL_TOKEN")?;
+            return Ok(tok.to_string());
+        }
+    }
+
+    // 2. Explicit --secret-key flag
     if let Some(sk) = secret_key {
-        return SecretKey::new(sk);
+        validate_stellar_secret(sk, "--secret-key")?;
+        return Ok(sk.to_string());
     }
-    if let Ok(sk) = std::env::var("ANCHOR_ADMIN_SECRET") {
-        if !sk.is_empty() {
-            return SecretKey::new(sk);
+
+    // 3. ANCHOR_ADMIN_SECRET environment variable
+    if let Some(sk) = read_env("ANCHOR_ADMIN_SECRET") {
+        if sk.is_empty() {
+            return Err(
+                "ANCHOR_ADMIN_SECRET is set but empty — provide a valid Stellar secret key \
+                 (expected 'S...' format) or unset the variable"
+                    .to_string(),
+            );
         }
+        validate_stellar_secret(&sk, "ANCHOR_ADMIN_SECRET")?;
+        return Ok(sk);
     }
+
+    // 4. Keypair file
     if let Some(path) = keypair_file {
-        let raw = match secure_read_file(path) {
-            Ok(content) => content,
-            Err(e) => {
-                eprintln!("error: cannot read keypair file '{path}': {e}");
-                std::process::exit(1);
-            }
+        let raw = secure_read_file(path)
+            .map_err(|e| format!("cannot read keypair file '{path}': {e}"))?;
+        let key = if let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw) {
+            v.get("secret_key")
+                .and_then(|s| s.as_str())
+                .unwrap_or_else(|| raw.trim())
+                .to_string()
+        } else {
+            raw.trim().to_string()
         };
-        // Support JSON {"secret_key":"S..."} or plain text.
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw) {
-            if let Some(sk) = v.get("secret_key").and_then(|s| s.as_str()) {
-                return SecretKey::new(sk);
-            }
-        }
-        return SecretKey::new(raw.trim());
+        validate_stellar_secret(&key, &format!("keypair file '{path}'"))?;
+        return Ok(key);
     }
+
+    // 5. Keystore credential — requires interactive password prompt
     if let Some(name) = credential_name {
         if no_interactive {
-            eprintln!("error: --credential-name requires an interactive password prompt; \
-                       use --secret-key, --ephemeral-token, or ANCHOR_ADMIN_SECRET in non-interactive mode");
+            return Err(
+                "--credential-name requires an interactive password prompt; \
+                 use --secret-key, --ephemeral-token, or ANCHOR_ADMIN_SECRET in \
+                 non-interactive mode"
+                    .to_string(),
+            );
+        }
+        // Actual keystore decryption happens in the caller (requires rpassword).
+        return Err(format!("__keystore__{name}"));
+    }
+
+    Err("signing key required — provide one of:\n  \
+         --secret-key <KEY>\n  \
+         export ANCHOR_ADMIN_SECRET=<KEY>\n  \
+         --keypair-file <PATH>\n  \
+         --credential-name <NAME>  (use: anchorkit credentials add --name <NAME>)"
+        .to_string())
+}
+
+/// Resolve the signing source from flags or environment.
+/// Resolution order: ephemeral_token > --secret-key > ANCHOR_ADMIN_SECRET >
+///                   --keypair-file > --credential-name
+fn resolve_source(
+    ephemeral_token: Option<&str>,
+    secret_key: Option<&str>,
+    keypair_file: Option<&str>,
+    credential_name: Option<&str>,
+    no_interactive: bool,
+) -> SecretKey {
+    match try_resolve_source(
+        ephemeral_token,
+        secret_key,
+        keypair_file,
+        credential_name,
+        no_interactive,
+        &|var| std::env::var(var).ok(),
+    ) {
+        Ok(key) => SecretKey::new(key),
+        Err(msg) if msg.starts_with("__keystore__") => {
+            let name = &msg["__keystore__".len()..];
+            let password = rpassword::prompt_password("Keystore password: ")
+                .unwrap_or_else(|e| { eprintln!("error: failed to read password: {e}"); std::process::exit(1); });
+            keystore_get_decrypted(name, &password)
+        }
+        Err(msg) => {
+            eprintln!("error: {msg}");
             std::process::exit(1);
         }
-        let password = rpassword::prompt_password("Keystore password: ")
-            .unwrap_or_else(|e| { eprintln!("error: failed to read password: {e}"); std::process::exit(1); });
-        return SecretKey::new(keystore_get_decrypted(name, &password));
     }
-    eprintln!("error: signing key required — provide one of:");
-    eprintln!("  --secret-key <KEY>");
-    eprintln!("  export ANCHOR_ADMIN_SECRET=<KEY>");
-    eprintln!("  --keypair-file <PATH>");
-    eprintln!("  --credential-name <NAME>  (use: anchorkit credentials add --name <NAME>)");
-    std::process::exit(1);
 }
 
 fn normalize_stellar_public_address(field: &str, address: &str) -> String {
@@ -1809,6 +1834,8 @@ fn offline_simulate(config_path: Option<&str>, workflow: &str) {
 fn main() {
     let cli = Cli::parse();
     let global_contract_id = cli.contract_id.clone();
+    let no_interactive = cli.no_interactive;
+    let ephemeral_token = cli.ephemeral_token.clone();
     let network = cli.network.unwrap_or_else(|| {
         let n = default_network();
         if std::env::var("STELLAR_NETWORK").is_err() && !load_network_profiles().iter().any(|p| p.is_default) {
@@ -1821,7 +1848,10 @@ fn main() {
             let net = cmd_net;
             if upgrade {
                 let contract_id = require_contract_id(global_contract_id, None, "deploy --upgrade");
-                let signing_source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), None);
+                let signing_source = resolve_source(
+                    ephemeral_token.as_deref(), secret_key.as_deref(), keypair_file.as_deref(),
+                    None, no_interactive,
+                );
                 upgrade_contract(&contract_id, &net, &signing_source);
             } else {
                 deploy(&net, &source, admin.as_deref(), dry_run, list);
@@ -1830,17 +1860,26 @@ fn main() {
         Commands::Register { address, services, contract_id, network: cmd_net, secret_key, keypair_file, credential_name, sep10_token, sep10_issuer } => {
             let cid = require_contract_id(global_contract_id, contract_id, "register");
             let net = cmd_net;
-            let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), credential_name.as_deref());
+            let source = resolve_source(
+                ephemeral_token.as_deref(), secret_key.as_deref(), keypair_file.as_deref(),
+                credential_name.as_deref(), no_interactive,
+            );
             register(&address, &services, &cid, &net, &source, &sep10_token, &sep10_issuer);
         }
         Commands::Attest { subject, payload_hash, contract_id, network: cmd_net, secret_key, keypair_file, credential_name, issuer, session_id } => {
             let cid = require_contract_id(global_contract_id, contract_id, "attest");
-            let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), credential_name.as_deref());
+            let source = resolve_source(
+                ephemeral_token.as_deref(), secret_key.as_deref(), keypair_file.as_deref(),
+                credential_name.as_deref(), no_interactive,
+            );
             attest(&subject, &payload_hash, &cid, &cmd_net, &source, &issuer, session_id);
         }
         Commands::Quote { from, to, amount, contract_id, network: cmd_net, secret_key, keypair_file, credential_name } => {
             let cid = require_contract_id(global_contract_id, contract_id, "quote");
-            let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), credential_name.as_deref());
+            let source = resolve_source(
+                ephemeral_token.as_deref(), secret_key.as_deref(), keypair_file.as_deref(),
+                credential_name.as_deref(), no_interactive,
+            );
             quote(&from, &to, amount, &cid, &cmd_net, &source);
         }
         Commands::Status { tx_id, anchor_url, proxy_url, no_proxy } => {
@@ -1848,14 +1887,20 @@ fn main() {
         }
         Commands::Revoke { address, contract_id, network: cmd_net, secret_key, keypair_file, credential_name } => {
             let cid = require_contract_id(global_contract_id, contract_id, "revoke");
-            let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), credential_name.as_deref());
+            let source = resolve_source(
+                ephemeral_token.as_deref(), secret_key.as_deref(), keypair_file.as_deref(),
+                credential_name.as_deref(), no_interactive,
+            );
             revoke(&address, &cid, &cmd_net, &source);
         }
         Commands::Doctor { fix } => {
             doctor(&network, fix);
         }
         Commands::Health { contract_id, network: cmd_net, secret_key, keypair_file, anchor, attestor } => {
-            let source = resolve_source(secret_key.as_deref(), keypair_file.as_deref(), None);
+            let source = resolve_source(
+                ephemeral_token.as_deref(), secret_key.as_deref(), keypair_file.as_deref(),
+                None, no_interactive,
+            );
             health_check(&contract_id, &cmd_net, &source, anchor.as_deref(), attestor.as_deref());
         }
         Commands::Network { action } => {
@@ -1899,6 +1944,113 @@ fn main() {
 }
 
 #[cfg(test)]
+mod secret_resolution_tests {
+    use super::*;
+
+    fn no_env(_: &str) -> Option<String> { None }
+    fn env_with(key: &str, value: &str) -> impl Fn(&str) -> Option<String> + '_ {
+        move |k: &str| if k == key { Some(value.to_string()) } else { None }
+    }
+
+    const VALID_KEY: &str = "SCZANGBA5IIPMEFXBI5LZU7RVJZOLBYHJYFJ2KYN3CQPUOVFRDPCNTY";
+
+    #[test]
+    fn test_validate_stellar_secret_accepts_valid_key() {
+        assert!(validate_stellar_secret(VALID_KEY, "test").is_ok());
+    }
+
+    #[test]
+    fn test_validate_stellar_secret_rejects_empty() {
+        let err = validate_stellar_secret("", "test").unwrap_err();
+        assert!(err.contains("must not be empty"), "got: {err}");
+    }
+
+    #[test]
+    fn test_validate_stellar_secret_rejects_non_s_prefix() {
+        let err = validate_stellar_secret("GABCDE123", "test").unwrap_err();
+        assert!(err.contains("'S...' format"), "got: {err}");
+    }
+
+    #[test]
+    fn test_resolve_uses_explicit_secret_key_first() {
+        let result = try_resolve_source(
+            None, Some(VALID_KEY), None, None, false,
+            &env_with("ANCHOR_ADMIN_SECRET", VALID_KEY),
+        );
+        assert_eq!(result.unwrap(), VALID_KEY);
+    }
+
+    #[test]
+    fn test_resolve_uses_ephemeral_token_over_secret_key() {
+        let result = try_resolve_source(
+            Some(VALID_KEY), Some("Sother"), None, None, false, &no_env,
+        );
+        assert_eq!(result.unwrap(), VALID_KEY);
+    }
+
+    #[test]
+    fn test_resolve_falls_back_to_env_var() {
+        let result = try_resolve_source(None, None, None, None, false, &env_with("ANCHOR_ADMIN_SECRET", VALID_KEY));
+        assert_eq!(result.unwrap(), VALID_KEY);
+    }
+
+    #[test]
+    fn test_resolve_errors_on_empty_env_var() {
+        let err = try_resolve_source(
+            None, None, None, None, false,
+            &env_with("ANCHOR_ADMIN_SECRET", ""),
+        )
+        .unwrap_err();
+        assert!(err.contains("empty"), "expected 'empty' in: {err}");
+    }
+
+    #[test]
+    fn test_resolve_errors_on_invalid_env_var_format() {
+        let err = try_resolve_source(
+            None, None, None, None, false,
+            &env_with("ANCHOR_ADMIN_SECRET", "GABCDE123"),
+        )
+        .unwrap_err();
+        assert!(err.contains("'S...' format"), "expected format error in: {err}");
+    }
+
+    #[test]
+    fn test_resolve_errors_when_no_source_provided() {
+        let err = try_resolve_source(None, None, None, None, false, &no_env).unwrap_err();
+        assert!(err.contains("signing key required"), "got: {err}");
+    }
+
+    #[test]
+    fn test_resolve_errors_on_credential_name_in_non_interactive_mode() {
+        let err = try_resolve_source(
+            None, None, None, Some("my-cred"), true, &no_env,
+        )
+        .unwrap_err();
+        assert!(err.contains("non-interactive"), "got: {err}");
+    }
+
+    #[test]
+    fn test_secret_key_redacted_in_display() {
+        let sk = SecretKey::new(VALID_KEY);
+        assert_eq!(format!("{sk}"), "[REDACTED]");
+        assert_eq!(format!("{sk:?}"), "[REDACTED]");
+    }
+
+    #[test]
+    fn test_secret_key_deref_exposes_value() {
+        let sk = SecretKey::new("STEST");
+        let s: &str = &sk;
+        assert_eq!(s, "STEST");
+    }
+
+    #[test]
+    fn test_secret_key_expose_method() {
+        let sk = SecretKey::new("STEST");
+        assert_eq!(sk.expose(), "STEST");
+    }
+}
+
+#[cfg(test)]
 mod offline_tests {
     use super::*;
 
@@ -1928,17 +2080,4 @@ mod offline_tests {
         assert!(!result, "invalid JSON should fail validation");
     }
 
-    #[test]
-    fn test_secret_key_is_redacted_in_display() {
-        let sk = SecretKey::new("SCZANGBA5IIPMEFXBI5LZU7RVJZOLBYHJYFJ2KYN3CQPUOVFRDPCNTY");
-        assert_eq!(format!("{sk}"), "[REDACTED]");
-        assert_eq!(format!("{sk:?}"), "[REDACTED]");
-    }
-
-    #[test]
-    fn test_secret_key_deref() {
-        let sk = SecretKey::new("STEST");
-        let s: &str = &sk;
-        assert_eq!(s, "STEST");
-    }
 }

--- a/src/sep24.rs
+++ b/src/sep24.rs
@@ -594,4 +594,83 @@ mod tests {
         let result = fetch_sep24_transaction_status(raw).unwrap();
         assert_eq!(result.status, TransactionStatus::PendingUser);
     }
+
+    // ── Optional field combination tests (#255) ───────────────────────────────
+
+    #[test]
+    fn test_sep24_status_pending_stellar_accepted() {
+        let raw = RawSep24TransactionResponse {
+            id: "tx-stellar".to_string(),
+            status: "pending_stellar".to_string(),
+            more_info_url: None,
+            stellar_transaction_id: None,
+            asset_code: None,
+        };
+        let result = fetch_sep24_transaction_status(raw).unwrap();
+        assert_eq!(result.status, TransactionStatus::PendingStellar);
+    }
+
+    #[test]
+    fn test_sep24_status_waiting_customer_action_accepted() {
+        let raw = RawSep24TransactionResponse {
+            id: "tx-wca".to_string(),
+            status: "waiting_customer_action".to_string(),
+            more_info_url: None,
+            stellar_transaction_id: None,
+            asset_code: None,
+        };
+        let result = fetch_sep24_transaction_status(raw).unwrap();
+        assert_eq!(result.status, TransactionStatus::WaitingCustomerAction);
+    }
+
+    #[test]
+    fn test_sep24_stellar_tx_id_optional_absent_is_ok() {
+        let raw = RawSep24TransactionResponse {
+            id: "tx-no-stellar-id".to_string(),
+            status: "completed".to_string(),
+            more_info_url: None,
+            stellar_transaction_id: None,
+            asset_code: None,
+        };
+        let result = fetch_sep24_transaction_status(raw).unwrap();
+        assert!(result.stellar_transaction_id.is_none());
+    }
+
+    #[test]
+    fn test_sep24_stellar_tx_id_optional_present_is_propagated() {
+        let raw = RawSep24TransactionResponse {
+            id: "tx-has-stellar-id".to_string(),
+            status: "completed".to_string(),
+            more_info_url: None,
+            stellar_transaction_id: Some("stellar-abc-123".to_string()),
+            asset_code: None,
+        };
+        let result = fetch_sep24_transaction_status(raw).unwrap();
+        assert_eq!(result.stellar_transaction_id, Some("stellar-abc-123".to_string()));
+    }
+
+    #[test]
+    fn test_sep24_all_optional_fields_absent_accepted() {
+        let raw = RawSep24TransactionResponse {
+            id: "tx-minimal".to_string(),
+            status: "pending_anchor".to_string(),
+            more_info_url: None,
+            stellar_transaction_id: None,
+            asset_code: None,
+        };
+        assert!(fetch_sep24_transaction_status(raw).is_ok());
+    }
+
+    #[test]
+    fn test_sep24_unknown_status_maps_to_error_variant() {
+        let raw = RawSep24TransactionResponse {
+            id: "tx-unk".to_string(),
+            status: "some_future_status".to_string(),
+            more_info_url: None,
+            stellar_transaction_id: None,
+            asset_code: None,
+        };
+        let result = fetch_sep24_transaction_status(raw).unwrap();
+        assert_eq!(result.status, TransactionStatus::Error);
+    }
 }

--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -42,6 +42,10 @@ pub enum TransactionStatus {
     TooSmall,
     /// Requested amount exceeds the anchor's maximum (SEP-6 `too_large`).
     TooLarge,
+    /// Transaction is pending on-chain Stellar network confirmation.
+    PendingStellar,
+    /// Waiting for the customer to take an action (SEP-6 `waiting_customer_action`).
+    WaitingCustomerAction,
     Error,
 }
 
@@ -80,6 +84,8 @@ impl TransactionStatus {
             "no_market" => Self::NoMarket,
             "too_small" => Self::TooSmall,
             "too_large" => Self::TooLarge,
+            "pending_stellar" => Self::PendingStellar,
+            "waiting_customer_action" => Self::WaitingCustomerAction,
             _ => Self::Error,
         }
     }
@@ -111,6 +117,8 @@ impl TransactionStatus {
             Self::NoMarket => "no_market",
             Self::TooSmall => "too_small",
             Self::TooLarge => "too_large",
+            Self::PendingStellar => "pending_stellar",
+            Self::WaitingCustomerAction => "waiting_customer_action",
             Self::Error => "error",
         }
     }
@@ -276,6 +284,28 @@ pub struct RawTransactionResponse {
     pub message: Option<String>,
 }
 
+// ── Optional-field validation ─────────────────────────────────────────────────
+
+/// Valid SEP-6 memo type strings.
+const VALID_MEMO_TYPES: &[&str] = &["text", "id", "hash"];
+
+/// Validate that whenever a memo value is present, a valid memo type is also present.
+/// Returns an error when:
+/// - `memo` is `Some` but `memo_type` is `None`
+/// - `memo_type` is `Some` but not one of `"text"`, `"id"`, `"hash"`
+fn validate_memo_pair(memo: Option<&str>, memo_type: Option<&str>) -> Result<(), crate::errors::Error> {
+    if memo.is_some() {
+        match memo_type {
+            None => return Err(crate::errors::Error::invalid_transaction_intent()),
+            Some(mt) if !VALID_MEMO_TYPES.contains(&mt) => {
+                return Err(crate::errors::Error::invalid_transaction_intent());
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 // ── Service functions ─────────────────────────────────────────────────────────
 
 /// Normalize a raw anchor deposit response into a canonical [`DepositResponse`].
@@ -322,6 +352,7 @@ pub fn initiate_deposit(raw: RawDepositResponse) -> Result<DepositResponse, Erro
     if raw.transaction_id.is_empty() || raw.how.is_empty() {
         return Err(Error::invalid_transaction_intent());
     }
+    validate_memo_pair(raw.stellar_memo.as_deref(), raw.stellar_memo_type.as_deref())?;
     let asset_code = raw.asset_code.as_deref()
         .map(normalize_asset_code)
         .transpose()?;
@@ -385,6 +416,7 @@ pub fn initiate_withdrawal(raw: RawWithdrawalResponse) -> Result<WithdrawalRespo
     if raw.transaction_id.is_empty() || raw.account_id.is_empty() {
         return Err(Error::invalid_transaction_intent());
     }
+    validate_memo_pair(raw.memo.as_deref(), raw.memo_type.as_deref())?;
     let asset_code = raw.asset_code.as_deref()
         .map(normalize_asset_code)
         .transpose()?;
@@ -881,6 +913,101 @@ mod tests {
         );
         assert_eq!(result, PollResult::Completed(make_response(TransactionStatus::Completed)));
         assert_eq!(call_count, 3);
+    }
+
+    // ── Optional field combination tests (#255) ───────────────────────────────
+
+    #[test]
+    fn test_deposit_memo_without_memo_type_is_rejected() {
+        let mut raw = raw_deposit();
+        raw.stellar_memo = Some("12345".to_string());
+        raw.stellar_memo_type = None;
+        assert_eq!(initiate_deposit(raw), Err(Error::invalid_transaction_intent()));
+    }
+
+    #[test]
+    fn test_deposit_memo_with_invalid_memo_type_is_rejected() {
+        let mut raw = raw_deposit();
+        raw.stellar_memo = Some("12345".to_string());
+        raw.stellar_memo_type = Some("fax".to_string()); // invalid type
+        assert_eq!(initiate_deposit(raw), Err(Error::invalid_transaction_intent()));
+    }
+
+    #[test]
+    fn test_deposit_memo_with_valid_text_type_is_accepted() {
+        let mut raw = raw_deposit();
+        raw.stellar_memo = Some("hello".to_string());
+        raw.stellar_memo_type = Some("text".to_string());
+        assert!(initiate_deposit(raw).is_ok());
+    }
+
+    #[test]
+    fn test_deposit_memo_with_valid_id_type_is_accepted() {
+        let mut raw = raw_deposit();
+        raw.stellar_memo = Some("99999".to_string());
+        raw.stellar_memo_type = Some("id".to_string());
+        assert!(initiate_deposit(raw).is_ok());
+    }
+
+    #[test]
+    fn test_deposit_memo_with_valid_hash_type_is_accepted() {
+        let mut raw = raw_deposit();
+        raw.stellar_memo = Some("abc123".to_string());
+        raw.stellar_memo_type = Some("hash".to_string());
+        assert!(initiate_deposit(raw).is_ok());
+    }
+
+    #[test]
+    fn test_deposit_no_memo_no_memo_type_is_accepted() {
+        let mut raw = raw_deposit();
+        raw.stellar_memo = None;
+        raw.stellar_memo_type = None;
+        assert!(initiate_deposit(raw).is_ok());
+    }
+
+    #[test]
+    fn test_withdrawal_memo_without_memo_type_is_rejected() {
+        let mut raw = raw_withdrawal();
+        raw.memo = Some("12345".to_string());
+        raw.memo_type = None;
+        assert_eq!(initiate_withdrawal(raw), Err(Error::invalid_transaction_intent()));
+    }
+
+    #[test]
+    fn test_withdrawal_memo_with_invalid_memo_type_is_rejected() {
+        let mut raw = raw_withdrawal();
+        raw.memo = Some("12345".to_string());
+        raw.memo_type = Some("telegraph".to_string());
+        assert_eq!(initiate_withdrawal(raw), Err(Error::invalid_transaction_intent()));
+    }
+
+    #[test]
+    fn test_withdrawal_memo_with_valid_id_type_is_accepted() {
+        let raw = raw_withdrawal(); // already has memo="12345" and memo_type="id"
+        assert!(initiate_withdrawal(raw).is_ok());
+    }
+
+    #[test]
+    fn test_withdrawal_no_memo_no_memo_type_is_accepted() {
+        let mut raw = raw_withdrawal();
+        raw.memo = None;
+        raw.memo_type = None;
+        assert!(initiate_withdrawal(raw).is_ok());
+    }
+
+    #[test]
+    fn test_status_pending_stellar_round_trip() {
+        assert_eq!(TransactionStatus::from_str("pending_stellar"), TransactionStatus::PendingStellar);
+        assert_eq!(TransactionStatus::PendingStellar.as_str(), "pending_stellar");
+    }
+
+    #[test]
+    fn test_status_waiting_customer_action_round_trip() {
+        assert_eq!(
+            TransactionStatus::from_str("waiting_customer_action"),
+            TransactionStatus::WaitingCustomerAction
+        );
+        assert_eq!(TransactionStatus::WaitingCustomerAction.as_str(), "waiting_customer_action");
     }
 
     #[test]

--- a/tests/audit_log_retention_tests.rs
+++ b/tests/audit_log_retention_tests.rs
@@ -1,0 +1,242 @@
+//! Tests for audit log retention policies, pruning, and paginated retrieval (#251).
+
+#![cfg(test)]
+
+mod sep10_test_util;
+
+mod audit_log_retention_tests {
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+    use soroban_sdk::{Address, Env};
+
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::{AnchorKitContract, AnchorKitContractClient};
+    use crate::sep10_test_util::register_attestor_with_sep10;
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, ts: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp: ts,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6_312_000,
+        });
+    }
+
+    fn setup() -> (Env, Address, AnchorKitContractClient) {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let cid = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &cid);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        (env, admin, client)
+    }
+
+    fn add_attestor(env: &Env, client: &AnchorKitContractClient) -> Address {
+        let attestor = Address::generate(env);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(env, client, &attestor, &attestor, &sk);
+        attestor
+    }
+
+    fn emit_audit_log(
+        env: &Env,
+        client: &AnchorKitContractClient,
+        attestor: &Address,
+        ts: u64,
+    ) {
+        set_ledger(env, ts);
+        let session_id = client.create_session(attestor);
+        let issuer = attestor.clone();
+        let subject = Address::generate(env);
+        let payload = soroban_sdk::Bytes::from_slice(env, b"payload_hash_32bytes_exactly____");
+        let sig = soroban_sdk::Bytes::from_slice(env, b"payload_hash_32bytes_exactly____");
+        client.submit_attestation_with_session(
+            &session_id, &issuer, &subject, &ts, &payload, &sig,
+        );
+        client.close_session(&session_id, attestor);
+    }
+
+    // ── Retention policy ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_default_retention_is_zero_unlimited() {
+        let (_, _, client) = setup();
+        assert_eq!(client.get_audit_log_retention(), 0);
+    }
+
+    #[test]
+    fn test_set_and_get_retention() {
+        let (_, admin, client) = setup();
+        client.set_audit_log_retention(&admin, &30);
+        assert_eq!(client.get_audit_log_retention(), 30);
+    }
+
+    #[test]
+    fn test_update_retention_policy() {
+        let (_, admin, client) = setup();
+        client.set_audit_log_retention(&admin, &90);
+        client.set_audit_log_retention(&admin, &7);
+        assert_eq!(client.get_audit_log_retention(), 7);
+    }
+
+    // ── Audit log count ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_audit_log_count_starts_at_zero() {
+        let (_, _, client) = setup();
+        assert_eq!(client.get_audit_log_count(), 0);
+    }
+
+    #[test]
+    fn test_audit_log_count_increments_with_session_ops() {
+        let (env, _, client) = setup();
+        let attestor = add_attestor(&env, &client);
+        emit_audit_log(&env, &client, &attestor, 2000);
+        assert!(client.get_audit_log_count() >= 1);
+    }
+
+    // ── Pagination ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_paginated_retrieval_empty_returns_empty_vec() {
+        let (_, _, client) = setup();
+        let page = client.get_audit_logs_paginated(&0, &10);
+        assert_eq!(page.len(), 0);
+    }
+
+    #[test]
+    fn test_paginated_retrieval_returns_correct_entries() {
+        let (env, _, client) = setup();
+        let attestor = add_attestor(&env, &client);
+        emit_audit_log(&env, &client, &attestor, 2000);
+        emit_audit_log(&env, &client, &attestor, 3000);
+
+        let total = client.get_audit_log_count();
+        assert!(total >= 2, "expected at least 2 entries, got {total}");
+
+        let page = client.get_audit_logs_paginated(&0, &10);
+        assert!(page.len() >= 2);
+    }
+
+    #[test]
+    fn test_paginated_retrieval_respects_offset() {
+        let (env, _, client) = setup();
+        let attestor = add_attestor(&env, &client);
+        emit_audit_log(&env, &client, &attestor, 2000);
+        emit_audit_log(&env, &client, &attestor, 3000);
+
+        let total = client.get_audit_log_count();
+        let page0 = client.get_audit_logs_paginated(&0, &1);
+        let page1 = client.get_audit_logs_paginated(&1, &1);
+        // Both pages must be non-empty if total >= 2
+        if total >= 2 {
+            assert_eq!(page0.len(), 1);
+            assert_eq!(page1.len(), 1);
+        }
+    }
+
+    #[test]
+    fn test_pagination_limit_capped_at_50() {
+        let (env, _, client) = setup();
+        let attestor = add_attestor(&env, &client);
+        emit_audit_log(&env, &client, &attestor, 2000);
+
+        // Requesting 200 should return at most 50
+        let page = client.get_audit_logs_paginated(&0, &200);
+        assert!(page.len() <= 50);
+    }
+
+    #[test]
+    fn test_pagination_offset_beyond_total_returns_empty() {
+        let (env, _, client) = setup();
+        let attestor = add_attestor(&env, &client);
+        emit_audit_log(&env, &client, &attestor, 2000);
+
+        let page = client.get_audit_logs_paginated(&9999, &10);
+        assert_eq!(page.len(), 0);
+    }
+
+    // ── Session-scoped pagination ─────────────────────────────────────────────
+
+    #[test]
+    fn test_session_audit_logs_paginated_returns_correct_entries() {
+        let (env, _, client) = setup();
+        let attestor = add_attestor(&env, &client);
+        set_ledger(&env, 2000);
+        let session_id = client.create_session(&attestor);
+
+        let subject = Address::generate(&env);
+        let payload = soroban_sdk::Bytes::from_slice(&env, b"payload_hash_32bytes_exactly____");
+        let sig = soroban_sdk::Bytes::from_slice(&env, b"payload_hash_32bytes_exactly____");
+        client.submit_attestation_with_session(
+            &session_id, &attestor, &subject, &2000u64, &payload, &sig,
+        );
+        client.close_session(&session_id, &attestor);
+
+        let page = client.get_session_logs_paginated(&session_id, &0, &10);
+        assert!(page.len() >= 1);
+    }
+
+    #[test]
+    fn test_session_audit_logs_paginated_empty_offset_returns_empty() {
+        let (env, _, client) = setup();
+        let attestor = add_attestor(&env, &client);
+        set_ledger(&env, 2000);
+        let session_id = client.create_session(&attestor);
+        client.close_session(&session_id, &attestor);
+
+        let page = client.get_session_logs_paginated(&session_id, &9999, &10);
+        assert_eq!(page.len(), 0);
+    }
+
+    // ── Pruning ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_prune_removes_old_entries() {
+        let (env, admin, client) = setup();
+        let attestor = add_attestor(&env, &client);
+        // Create two audit entries at different timestamps
+        emit_audit_log(&env, &client, &attestor, 1_000);
+        emit_audit_log(&env, &client, &attestor, 10_000);
+
+        let before_prune = client.get_audit_log_count();
+        assert!(before_prune >= 2);
+
+        // Prune entries older than timestamp 5_000
+        set_ledger(&env, 20_000);
+        let pruned = client.prune_audit_logs(&admin, &5_000u64);
+        assert!(pruned >= 1, "expected at least one entry pruned");
+    }
+
+    #[test]
+    fn test_prune_does_not_remove_recent_entries() {
+        let (env, admin, client) = setup();
+        let attestor = add_attestor(&env, &client);
+        emit_audit_log(&env, &client, &attestor, 10_000);
+
+        set_ledger(&env, 20_000);
+        // Prune with a threshold before all entries — nothing should be removed
+        let pruned = client.prune_audit_logs(&admin, &1u64);
+        assert_eq!(pruned, 0, "no entries should be pruned when threshold is too early");
+    }
+
+    #[test]
+    fn test_prune_with_no_entries_returns_zero() {
+        let (env, admin, client) = setup();
+        set_ledger(&env, 5_000);
+        let pruned = client.prune_audit_logs(&admin, &9_999u64);
+        assert_eq!(pruned, 0);
+    }
+}

--- a/tests/compliance_query_tests.rs
+++ b/tests/compliance_query_tests.rs
@@ -1,0 +1,260 @@
+//! Tests for structured compliance check storage and query APIs (#252).
+
+#![cfg(test)]
+
+mod compliance_query_tests {
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+    use soroban_sdk::{Address, Env, String};
+
+    use anchorkit::{AnchorKitContract, AnchorKitContractClient};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, ts: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp: ts,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6_312_000,
+        });
+    }
+
+    fn setup() -> (Env, Address, AnchorKitContractClient) {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let cid = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &cid);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        (env, admin, client)
+    }
+
+    fn check_type(env: &Env, s: &str) -> String {
+        String::from_str(env, s)
+    }
+
+    // ── get_latest_compliance_check ───────────────────────────────────────────
+
+    #[test]
+    fn test_latest_check_none_before_any_record() {
+        let (env, _, client) = setup();
+        let subject = Address::generate(&env);
+        let result = client.get_latest_compliance_check(&subject, &check_type(&env, "kyc"));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_latest_check_returns_most_recent_passed_record() {
+        let (env, admin, client) = setup();
+        let subject = Address::generate(&env);
+
+        set_ledger(&env, 2000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &false);
+        set_ledger(&env, 3000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &true);
+
+        let latest = client.get_latest_compliance_check(&subject, &check_type(&env, "kyc")).unwrap();
+        assert_eq!(latest.result, 1u32, "latest should be the passed check");
+        assert_eq!(latest.timestamp, 3000);
+    }
+
+    #[test]
+    fn test_latest_check_returns_most_recent_failed_record() {
+        let (env, admin, client) = setup();
+        let subject = Address::generate(&env);
+
+        set_ledger(&env, 2000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "aml"), &true);
+        set_ledger(&env, 4000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "aml"), &false);
+
+        let latest = client.get_latest_compliance_check(&subject, &check_type(&env, "aml")).unwrap();
+        assert_eq!(latest.result, 0u32);
+        assert_eq!(latest.timestamp, 4000);
+    }
+
+    #[test]
+    fn test_latest_check_isolated_by_check_type() {
+        let (env, admin, client) = setup();
+        let subject = Address::generate(&env);
+
+        set_ledger(&env, 2000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &true);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "aml"), &false);
+
+        let kyc = client.get_latest_compliance_check(&subject, &check_type(&env, "kyc")).unwrap();
+        let aml = client.get_latest_compliance_check(&subject, &check_type(&env, "aml")).unwrap();
+        assert_eq!(kyc.result, 1u32);
+        assert_eq!(aml.result, 0u32);
+    }
+
+    // ── get_compliance_check_history ─────────────────────────────────────────
+
+    #[test]
+    fn test_history_empty_before_any_record() {
+        let (env, _, client) = setup();
+        let subject = Address::generate(&env);
+        let history = client.get_compliance_check_history(&subject, &check_type(&env, "kyc"), &10);
+        assert_eq!(history.len(), 0);
+    }
+
+    #[test]
+    fn test_history_single_entry() {
+        let (env, admin, client) = setup();
+        let subject = Address::generate(&env);
+        set_ledger(&env, 2000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &true);
+
+        let history = client.get_compliance_check_history(&subject, &check_type(&env, "kyc"), &10);
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).unwrap().result, 1u32);
+    }
+
+    #[test]
+    fn test_history_multiple_entries_ordered_oldest_first() {
+        let (env, admin, client) = setup();
+        let subject = Address::generate(&env);
+
+        set_ledger(&env, 1000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &false);
+        set_ledger(&env, 2000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &true);
+        set_ledger(&env, 3000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &false);
+
+        let history = client.get_compliance_check_history(&subject, &check_type(&env, "kyc"), &10);
+        assert_eq!(history.len(), 3);
+        assert_eq!(history.get(0).unwrap().timestamp, 1000);
+        assert_eq!(history.get(1).unwrap().timestamp, 2000);
+        assert_eq!(history.get(2).unwrap().timestamp, 3000);
+    }
+
+    #[test]
+    fn test_history_limit_respected() {
+        let (env, admin, client) = setup();
+        let subject = Address::generate(&env);
+
+        for ts in [1000u64, 2000, 3000, 4000, 5000] {
+            set_ledger(&env, ts);
+            client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &true);
+        }
+
+        let history = client.get_compliance_check_history(&subject, &check_type(&env, "kyc"), &3);
+        assert_eq!(history.len(), 3, "limit should restrict to 3 most-recent entries");
+        // Most-recent should be at the end
+        assert_eq!(history.get(2).unwrap().timestamp, 5000);
+    }
+
+    #[test]
+    fn test_history_isolated_by_check_type() {
+        let (env, admin, client) = setup();
+        let subject = Address::generate(&env);
+
+        set_ledger(&env, 2000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &true);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "aml"), &false);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "aml"), &true);
+
+        let kyc_history = client.get_compliance_check_history(&subject, &check_type(&env, "kyc"), &10);
+        let aml_history = client.get_compliance_check_history(&subject, &check_type(&env, "aml"), &10);
+        assert_eq!(kyc_history.len(), 1);
+        assert_eq!(aml_history.len(), 2);
+    }
+
+    // ── list_subject_compliance_checks ────────────────────────────────────
+
+    #[test]
+    fn test_list_empty_for_new_subject() {
+        let (env, _, client) = setup();
+        let subject = Address::generate(&env);
+        let types = client.list_subject_compliance_checks(&subject);
+        assert_eq!(types.len(), 0);
+    }
+
+    #[test]
+    fn test_list_returns_all_recorded_check_types() {
+        let (env, admin, client) = setup();
+        let subject = Address::generate(&env);
+        set_ledger(&env, 2000);
+
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &true);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "aml"), &false);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "sanctions"), &true);
+
+        let types = client.list_subject_compliance_checks(&subject);
+        assert_eq!(types.len(), 3);
+    }
+
+    #[test]
+    fn test_list_does_not_duplicate_same_check_type() {
+        let (env, admin, client) = setup();
+        let subject = Address::generate(&env);
+
+        for ts in [1000u64, 2000, 3000] {
+            set_ledger(&env, ts);
+            client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &true);
+        }
+
+        let types = client.list_subject_compliance_checks(&subject);
+        assert_eq!(types.len(), 1, "same check_type should appear only once in index");
+    }
+
+    #[test]
+    fn test_list_isolated_by_subject() {
+        let (env, admin, client) = setup();
+        let subject_a = Address::generate(&env);
+        let subject_b = Address::generate(&env);
+        set_ledger(&env, 2000);
+
+        client.record_compliance_check(&admin, &subject_a, &check_type(&env, "kyc"), &true);
+        client.record_compliance_check(&admin, &subject_b, &check_type(&env, "aml"), &false);
+
+        let types_a = client.list_subject_compliance_checks(&subject_a);
+        let types_b = client.list_subject_compliance_checks(&subject_b);
+        assert_eq!(types_a.len(), 1);
+        assert_eq!(types_b.len(), 1);
+    }
+
+    // ── Compound workflow ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_full_compliance_workflow() {
+        let (env, admin, client) = setup();
+        let subject = Address::generate(&env);
+
+        // First KYC check: failed
+        set_ledger(&env, 1000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &false);
+
+        // AML check: passed
+        set_ledger(&env, 1500);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "aml"), &true);
+
+        // Second KYC check (re-review): passed
+        set_ledger(&env, 2000);
+        client.record_compliance_check(&admin, &subject, &check_type(&env, "kyc"), &true);
+
+        // Latest KYC should be the passing check
+        let latest_kyc = client.get_latest_compliance_check(&subject, &check_type(&env, "kyc")).unwrap();
+        assert_eq!(latest_kyc.result, 1u32);
+        assert_eq!(latest_kyc.timestamp, 2000);
+
+        // KYC history should contain both entries in order
+        let kyc_history = client.get_compliance_check_history(&subject, &check_type(&env, "kyc"), &10);
+        assert_eq!(kyc_history.len(), 2);
+        assert_eq!(kyc_history.get(0).unwrap().result, 0u32); // failed first
+        assert_eq!(kyc_history.get(1).unwrap().result, 1u32); // passed second
+
+        // Subject index should have both check types
+        let types = client.list_subject_compliance_checks(&subject);
+        assert_eq!(types.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

This PR resolves four production-readiness issues across the SorobanAnchor contract and CLI:

- **#251** — Contract-level audit log retention and pruning: `set_audit_log_retention`, `get_audit_log_count`, `get_audit_logs_paginated`, `get_session_logs_paginated`, and `prune_audit_logs` (WASM-safe, max 100 entries per call).
- **#252** — Structured compliance check storage and query APIs: `record_compliance_check` now appends to ordered history; new methods `get_latest_compliance_check`, `get_compliance_check_history`, and `list_subject_compliance_checks` expose decision histories with timestamps for auditors.
- **#255** — Deterministic SEP-6 and SEP-24 optional field validation: added `validate_memo_pair` to reject memo-without-type and invalid memo type values; added `PendingStellar` and `WaitingCustomerAction` status variants with full round-trip coverage.
- **#248** — Consolidated CLI secret resolution: removed three duplicate `SecretKey` struct definitions, fixed the `no_interactive`/`ephemeral_token` threading bug, added `validate_stellar_secret` (non-empty, `S...` format), explicit descriptive errors for every failure path, and refactored `resolve_source` into a testable `try_resolve_source`.

## Test plan

- [ ] `tests/audit_log_retention_tests.rs` — retention policy CRUD, pagination, pruning behavior, session-scoped pagination
- [ ] `tests/compliance_query_tests.rs` — latest check, ordered history, subject index, compound workflow, subject/type isolation
- [ ] `src/sep6.rs` inline tests — memo pair validation, new status variants, existing normalization unchanged
- [ ] `src/sep24.rs` inline tests — new status variants, optional field combinations
- [ ] `src/main.rs` `secret_resolution_tests` module — precedence order, env var fallback, format validation, non-interactive guard, display redaction

closes #251
closes #252
closes #255
closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)