### PR TITLE
fix: implement time-based cooldown logic for kyc transition (#421)

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -993,10 +993,15 @@ fn current_kyc_status(env: &Env, record: &KycRecord) -> KycStatus {
     }
 }
 
-fn validate_kyc_transition(current: KycStatus, next: KycStatus, _record: &KycRecord, _now: u64) -> bool {
+fn validate_kyc_transition(current: KycStatus, next: KycStatus, record: &KycRecord, now: u64) -> bool {
+    if next == KycStatus::Pending && now.saturating_sub(record.submitted_at) < 86400 {
+        return false;
+    }
+
     match (current, next) {
         (KycStatus::NotSubmitted, KycStatus::Pending) => true,
         (KycStatus::Expired, KycStatus::Pending) => true,
+        (KycStatus::Rejected, KycStatus::Pending) => true,
         (KycStatus::Pending, KycStatus::Approved) => true,
         (KycStatus::Pending, KycStatus::Rejected) => true,
         _ => false,


### PR DESCRIPTION
Closes #421.

This PR implements **Option B** from the issue description. It turns out the `_record` and `_now` parameters in `validate_kyc_transition` were intended for time-based cooldown logic but were never implemented. 

### Changes:
- Implemented a 24-hour cooldown for KYC re-submissions: `now.saturating_sub(record.submitted_at) < 86400`.
- Added the missing `(KycStatus::Rejected, KycStatus::Pending) => true` transition so users can actually re-submit after being rejected (subject to the 24h cooldown).
- Removed the unused parameter underscores.