### PR TITLE
test: add nonce to emit_audit_log to fix ReplayAttack in tests (#405)

### DIFF
--- a/tests/audit_log_retention_tests.rs
+++ b/tests/audit_log_retention_tests.rs
@@ -55,11 +55,14 @@ mod audit_log_retention_tests {
         attestor: &Address,
         sk: &SigningKey,
         ts: u64,
+        nonce: u8,
     ) {
         set_ledger(env, ts);
         let session_id = client.create_session(attestor);
         let subject = Address::generate(env);
-        let payload = soroban_sdk::Bytes::from_slice(env, b"payload_hash_32bytes_exactly____");
+        let mut payload_bytes = [0u8; 32];
+        payload_bytes[0] = nonce;
+        let payload = soroban_sdk::Bytes::from_slice(env, &payload_bytes);
         let sig = sign_payload(env, sk, &payload);
         client.submit_attestation_with_session(
             &session_id, attestor, &subject, &ts, &payload, &sig,
@@ -102,7 +105,7 @@ mod audit_log_retention_tests {
     fn test_audit_log_count_increments_with_session_ops() {
         let env = make_env(); let (_, client) = setup(&env);
         let (attestor, sk) = add_attestor(&env, &client);
-        emit_audit_log(&env, &client, &attestor, &sk, 2000);
+        emit_audit_log(&env, &client, &attestor, &sk, 2000, 1);
         assert!(client.get_audit_log_count() >= 1);
     }
 
@@ -119,8 +122,8 @@ mod audit_log_retention_tests {
     fn test_paginated_retrieval_returns_correct_entries() {
         let env = make_env(); let (_, client) = setup(&env);
         let (attestor, sk) = add_attestor(&env, &client);
-        emit_audit_log(&env, &client, &attestor, &sk, 2000);
-        emit_audit_log(&env, &client, &attestor, &sk, 3000);
+        emit_audit_log(&env, &client, &attestor, &sk, 2000, 1);
+        emit_audit_log(&env, &client, &attestor, &sk, 3000, 2);
 
         let total = client.get_audit_log_count();
         assert!(total >= 2, "expected at least 2 entries, got {total}");
@@ -133,8 +136,8 @@ mod audit_log_retention_tests {
     fn test_paginated_retrieval_respects_offset() {
         let env = make_env(); let (_, client) = setup(&env);
         let (attestor, sk) = add_attestor(&env, &client);
-        emit_audit_log(&env, &client, &attestor, &sk, 2000);
-        emit_audit_log(&env, &client, &attestor, &sk, 3000);
+        emit_audit_log(&env, &client, &attestor, &sk, 2000, 1);
+        emit_audit_log(&env, &client, &attestor, &sk, 3000, 2);
 
         let total = client.get_audit_log_count();
         let page0 = client.get_audit_logs_paginated(&0, &1);
@@ -150,7 +153,7 @@ mod audit_log_retention_tests {
     fn test_pagination_limit_capped_at_50() {
         let env = make_env(); let (_, client) = setup(&env);
         let (attestor, sk) = add_attestor(&env, &client);
-        emit_audit_log(&env, &client, &attestor, &sk, 2000);
+        emit_audit_log(&env, &client, &attestor, &sk, 2000, 1);
 
         // Requesting 200 should return at most 50
         let page = client.get_audit_logs_paginated(&0, &200);
@@ -161,7 +164,7 @@ mod audit_log_retention_tests {
     fn test_pagination_offset_beyond_total_returns_empty() {
         let env = make_env(); let (_, client) = setup(&env);
         let (attestor, sk) = add_attestor(&env, &client);
-        emit_audit_log(&env, &client, &attestor, &sk, 2000);
+        emit_audit_log(&env, &client, &attestor, &sk, 2000, 1);
 
         let page = client.get_audit_logs_paginated(&9999, &10);
         assert_eq!(page.len(), 0);
@@ -207,8 +210,8 @@ mod audit_log_retention_tests {
         let env = make_env(); let (admin, client) = setup(&env);
         let (attestor, sk) = add_attestor(&env, &client);
         // Create two audit entries at different timestamps
-        emit_audit_log(&env, &client, &attestor, &sk, 1_000);
-        emit_audit_log(&env, &client, &attestor, &sk, 10_000);
+        emit_audit_log(&env, &client, &attestor, &sk, 1_000, 1);
+        emit_audit_log(&env, &client, &attestor, &sk, 10_000, 2);
 
         let before_prune = client.get_audit_log_count();
         assert!(before_prune >= 2);
@@ -223,7 +226,7 @@ mod audit_log_retention_tests {
     fn test_prune_does_not_remove_recent_entries() {
         let env = make_env(); let (admin, client) = setup(&env);
         let (attestor, sk) = add_attestor(&env, &client);
-        emit_audit_log(&env, &client, &attestor, &sk, 10_000);
+        emit_audit_log(&env, &client, &attestor, &sk, 10_000, 1);
 
         set_ledger(&env, 20_000);
         // Prune with a threshold before all entries — nothing should be removed


### PR DESCRIPTION
Closes #405.

This PR resolves the `ReplayAttack` test failures in `tests/audit_log_retention_tests.rs`. 
The `emit_audit_log` test helper previously used a hardcoded payload hash, causing tests that emit multiple audit logs in the same session to fail when the contract's replay protection correctly rejected the identical payload.

### Changes:
- Updated the `emit_audit_log` helper to accept a `nonce: u8` parameter.
- The first byte of the 32-byte payload is now set to this `nonce`, ensuring uniqueness across multiple invocations.
- Updated all callers in the test suite to pass a unique nonce (e.g., `1`, `2`) for sequential calls.