### PR TITLE
feat: add explicit contract-level supported SEP list and feature flags (#353)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,28 @@ anchorkit attest --subject GUSER123... --payload-hash abc123...
 anchorkit doctor
 ```
 
+## Supported SEP Versions
+
+The contract explicitly exposes which Stellar Ecosystem Proposals (SEPs) it supports via two on-chain methods:
+
+```rust
+// Returns [6, 10, 24, 38]
+let seps: Vec<u32> = AnchorKitContract::supported_seps(env);
+
+// Returns per-SEP boolean flags
+let flags: SepFeatureFlags = AnchorKitContract::supported_sep_feature_flags(env);
+assert!(flags.sep10); // SEP-10 JWT authentication is supported
+```
+
+| SEP | Description | Supported |
+|-----|-------------|-----------|
+| [SEP-6](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) | Non-interactive deposit and withdrawal | ✓ |
+| [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) | Stellar Web Authentication (JWT) | ✓ |
+| [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md) | Interactive deposit and withdrawal | ✓ |
+| [SEP-38](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md) | Anchor RFQ / firm quotes | ✓ |
+
+Constants are also exported from the `contract` module: `SEP_6`, `SEP_10`, `SEP_24`, `SEP_38`.
+
 ## Key APIs
 
 ```rust

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -803,6 +803,33 @@ pub struct AnchorProofRecord {
 /// stored data to detect version skew.
 pub const SCHEMA_V1: u32 = 1;
 
+// ---------------------------------------------------------------------------
+// Supported SEP versions (#353)
+// ---------------------------------------------------------------------------
+
+/// SEP-6: Non-interactive deposit and withdrawal
+pub const SEP_6: u32 = 6;
+/// SEP-10: Stellar Web Authentication (JWT)
+pub const SEP_10: u32 = 10;
+/// SEP-24: Interactive deposit and withdrawal
+pub const SEP_24: u32 = 24;
+/// SEP-38: Anchor Request for Quote (RFQ)
+pub const SEP_38: u32 = 38;
+
+/// Feature flags indicating which SEP capabilities this contract supports.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SepFeatureFlags {
+    /// SEP-6 non-interactive deposit/withdrawal support.
+    pub sep6: bool,
+    /// SEP-10 JWT authentication support.
+    pub sep10: bool,
+    /// SEP-24 interactive deposit/withdrawal support.
+    pub sep24: bool,
+    /// SEP-38 RFQ / firm quote support.
+    pub sep38: bool,
+}
+
 /// Aggregated transaction counts returned by
 /// [`AnchorKitContract::summarize_transactions_by_status`].
 #[contracttype]
@@ -6258,5 +6285,61 @@ impl AnchorKitContract {
     /// Returns 0 if no replay attempts have been recorded for this ID.
     pub fn get_replay_count_for_id(env: Env, request_id: Bytes) -> u64 {
         replay_detection::get_replay_count_for_id(&env, &request_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // SEP version & feature flag introspection (#353)
+    // -----------------------------------------------------------------------
+
+    /// Return the list of SEP version numbers explicitly supported by this contract.
+    ///
+    /// # Returns
+    ///
+    /// A [`Vec<u32>`] containing the SEP numbers: `[6, 10, 24, 38]`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use soroban_sdk::Env;
+    /// use anchorkit::contract::{AnchorKitContract, SEP_6, SEP_10, SEP_24, SEP_38};
+    ///
+    /// let env = Env::default();
+    /// let seps = AnchorKitContract::supported_seps(env);
+    /// assert!(seps.contains(&SEP_6));
+    /// ```
+    pub fn supported_seps(env: Env) -> Vec<u32> {
+        let mut v = Vec::new(&env);
+        v.push_back(SEP_6);
+        v.push_back(SEP_10);
+        v.push_back(SEP_24);
+        v.push_back(SEP_38);
+        v
+    }
+
+    /// Return a [`SepFeatureFlags`] struct indicating which SEP capabilities
+    /// this contract supports.
+    ///
+    /// # Returns
+    ///
+    /// A [`SepFeatureFlags`] with all current support flags set.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use soroban_sdk::Env;
+    /// use anchorkit::contract::AnchorKitContract;
+    ///
+    /// let env = Env::default();
+    /// let flags = AnchorKitContract::supported_sep_feature_flags(env);
+    /// assert!(flags.sep10);
+    /// ```
+    pub fn supported_sep_feature_flags(env: Env) -> SepFeatureFlags {
+        let _ = env;
+        SepFeatureFlags {
+            sep6: true,
+            sep10: true,
+            sep24: true,
+            sep38: true,
+        }
     }
 }

--- a/tests/supported_seps_tests.rs
+++ b/tests/supported_seps_tests.rs
@@ -1,0 +1,35 @@
+//! Tests for issue #353: contract-level supported SEP list and feature flags.
+
+use anchorkit::contract::{
+    AnchorKitContract, SepFeatureFlags, SEP_10, SEP_24, SEP_38, SEP_6,
+};
+use soroban_sdk::Env;
+
+#[test]
+fn supported_seps_returns_expected_list() {
+    let env = Env::default();
+    let seps = AnchorKitContract::supported_seps(env);
+    assert_eq!(seps.len(), 4);
+    assert!(seps.contains(&SEP_6));
+    assert!(seps.contains(&SEP_10));
+    assert!(seps.contains(&SEP_24));
+    assert!(seps.contains(&SEP_38));
+}
+
+#[test]
+fn supported_seps_constants_have_correct_values() {
+    assert_eq!(SEP_6, 6);
+    assert_eq!(SEP_10, 10);
+    assert_eq!(SEP_24, 24);
+    assert_eq!(SEP_38, 38);
+}
+
+#[test]
+fn supported_sep_feature_flags_all_enabled() {
+    let env = Env::default();
+    let flags: SepFeatureFlags = AnchorKitContract::supported_sep_feature_flags(env);
+    assert!(flags.sep6);
+    assert!(flags.sep10);
+    assert!(flags.sep24);
+    assert!(flags.sep38);
+}


### PR DESCRIPTION
## Summary

Closes #353

Exposes the supported SEP versions and feature flags explicitly from the contract, so anchors and integrators can query them on-chain.

## Changes

### `src/contract.rs`
- Added constants: `SEP_6 = 6`, `SEP_10 = 10`, `SEP_24 = 24`, `SEP_38 = 38`
- Added `SepFeatureFlags` contracttype struct with `sep6`, `sep10`, `sep24`, `sep38` boolean fields
- Added `supported_seps(env) -> Vec<u32>` — returns `[6, 10, 24, 38]`
- Added `supported_sep_feature_flags(env) -> SepFeatureFlags` — returns all flags set to `true`

### `tests/supported_seps_tests.rs` (new)
- `supported_seps_returns_expected_list` — verifies the 4 SEP numbers are present
- `supported_seps_constants_have_correct_values` — checks constant values
- `supported_sep_feature_flags_all_enabled` — checks all flags are `true`

### `README.md`
- Added **Supported SEP Versions** section with a table and code example

## Testing

```
cargo test --test supported_seps_tests
test supported_sep_feature_flags_all_enabled ... ok
test supported_seps_constants_have_correct_values ... ok
test supported_seps_returns_expected_list ... ok
test result: ok. 3 passed; 0 failed
```