### PR TITLE
fix: remove unused imports and add fee_percent boundary tests

### DIFF
--- a/src/anchor_health.rs
+++ b/src/anchor_health.rs
@@ -30,7 +30,6 @@
 extern crate alloc;
 
 use alloc::string::String;
-use alloc::vec::Vec;
 
 // ---------------------------------------------------------------------------
 // Proof-of-possession helpers

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 #[cfg(feature = "std")]
-use std::{fs, io::{self, ErrorKind, Read}, path::Path};
+use std::{fs, io::Read, path::Path};
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,7 +1,6 @@
-use alloc::{string::String as RustString, vec::Vec as RustVec};
 use soroban_sdk::{
     contract, contractimpl, contracttype, panic_with_error, symbol_short, Address,
-    xdr::ToXdr, Bytes, BytesN, Env, IntoVal, String, Symbol, Vec,
+    xdr::ToXdr, Bytes, BytesN, Env, String, Symbol, Vec,
 };
 extern crate alloc;
 
@@ -10,7 +9,7 @@ use crate::errors::ErrorCode;
 use crate::rate_limiter::RateLimiter;
 use crate::sep10_jwt;
 use crate::transaction_state_tracker::{OptRecovery, TransactionState, TransactionStateRecord};
-use crate::replay_detection::{self, ReplayMetrics};
+use crate::replay_detection;
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,7 @@
 
 use clap::{Parser, Subcommand};
 use serde::Serialize;
-use std::fs::{self, File};
-use std::io::{self, ErrorKind, Read};
+use std::io::Read;
 use anchorkit::normalize_stellar_account_id;
 
 // ── SecretKey wrapper ─────────────────────────────────────────────────────────

--- a/src/service_management.rs
+++ b/src/service_management.rs
@@ -196,7 +196,7 @@ impl ServiceManager {
         if let Some(snapshot) = Self::get_snapshot(env, snapshot_id) {
             let state_key = (soroban_sdk::Symbol::new(env, "SVC_STATE"), &snapshot.anchor);
 
-            let mut state = ServiceToggleState {
+            let state = ServiceToggleState {
                 anchor: snapshot.anchor.clone(),
                 enabled_services: snapshot.services.clone(),
                 disabled_services: Vec::new(env),

--- a/tests/anchor_info_discovery_tests.rs
+++ b/tests/anchor_info_discovery_tests.rs
@@ -473,6 +473,85 @@ mod anchor_info_discovery_tests {
         client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, bad_asset), &3600u64);
     }
 
+    /// deposit_fee_percent = 0 bps (free) must be accepted.
+    #[test]
+    fn test_fee_percent_zero_accepted() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+
+        let asset = AssetInfo {
+            code: String::from_str(&env, "USDC"),
+            issuer: String::from_str(&env, "GABC"),
+            deposit_enabled: true,
+            withdrawal_enabled: false,
+            deposit_fee_fixed: 0,
+            deposit_fee_percent: 0, // 0 bps — free
+            withdrawal_fee_fixed: 0,
+            withdrawal_fee_percent: 0,
+            deposit_min_amount: 100,
+            deposit_max_amount: 1_000,
+            withdrawal_min_amount: 0,
+            withdrawal_max_amount: 0,
+        };
+        // Must not panic
+        client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, asset), &3600u64);
+        let info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "USDC"));
+        assert_eq!(info.deposit_fee_percent, 0);
+    }
+
+    /// deposit_fee_percent = 10_000 bps (100%) must be accepted as the maximum valid value.
+    #[test]
+    fn test_fee_percent_max_ten_thousand_accepted() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+
+        let asset = AssetInfo {
+            code: String::from_str(&env, "USDC"),
+            issuer: String::from_str(&env, "GABC"),
+            deposit_enabled: true,
+            withdrawal_enabled: false,
+            deposit_fee_fixed: 0,
+            deposit_fee_percent: 10_000, // 10 000 bps = 100 % — maximum allowed
+            withdrawal_fee_fixed: 0,
+            withdrawal_fee_percent: 0,
+            deposit_min_amount: 100,
+            deposit_max_amount: 1_000,
+            withdrawal_min_amount: 0,
+            withdrawal_max_amount: 0,
+        };
+        // Must not panic — 10 000 is the inclusive upper bound
+        client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, asset), &3600u64);
+        let info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "USDC"));
+        assert_eq!(info.deposit_fee_percent, 10_000);
+    }
+
+    /// deposit_fee_percent = 10_001 bps (> 100%) must be rejected.
+    #[test]
+    #[should_panic]
+    fn test_fee_percent_ten_thousand_one_rejected() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+
+        let bad_asset = AssetInfo {
+            code: String::from_str(&env, "USDC"),
+            issuer: String::from_str(&env, "GABC"),
+            deposit_enabled: true,
+            withdrawal_enabled: false,
+            deposit_fee_fixed: 0,
+            deposit_fee_percent: 10_001, // one bps over the 100 % ceiling
+            withdrawal_fee_fixed: 0,
+            withdrawal_fee_percent: 0,
+            deposit_min_amount: 100,
+            deposit_max_amount: 1_000,
+            withdrawal_min_amount: 0,
+            withdrawal_max_amount: 0,
+        };
+        client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, bad_asset), &3600u64);
+    }
+
     /// deposit_min_amount > deposit_max_amount (inverted range) must be rejected.
     #[test]
     #[should_panic]


### PR DESCRIPTION
closes #431 
closes #433 
closes #434 


- Remove redundant `use alloc::vec::Vec` in anchor_health.rs
- Remove unused `io::{self, ErrorKind}` in config.rs and main.rs
- Remove unused `RustString`, `RustVec`, `IntoVal`, `ReplayMetrics` in contract.rs
- Fix `unused_mut` warning in service_management.rs rollback_to_snapshot
- Add boundary tests for validate_fee_percent: 0 bps, 10000 bps (both accepted), 10001 bps (rejected)

Fixes all clippy -D warnings failures that would break CI.
