### PR TITLE
fix: rate-limit window safety, atomic attestation, anchor provenance

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -573,6 +573,34 @@ pub struct CachedToml {
     pub toml: StellarToml,
     pub cached_at: u64,
     pub ttl_seconds: u64,
+    /// URI from which this TOML data was sourced (e.g. the stellar.toml URL).
+    /// Set by the caller via `fetch_anchor_info`; empty when not provided.
+    pub source_uri: String,
+    /// Ledger timestamp when the entry was last successfully refreshed.
+    /// Equals `cached_at` on first write; updated on each successful refresh.
+    pub last_refreshed_at: u64,
+}
+
+/// Provenance metadata for a cached anchor TOML entry.
+///
+/// Returned by [`AnchorKitContract::get_anchor_toml_provenance`] so callers
+/// can verify where anchor metadata came from and how fresh it is without
+/// needing to decode the full cached entry.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AnchorTomlProvenance {
+    /// The anchor address this provenance record belongs to.
+    pub anchor: Address,
+    /// URI from which the TOML data was fetched (empty if not provided).
+    pub source_uri: String,
+    /// Ledger timestamp when the entry was first stored (`cached_at`).
+    pub cached_at: u64,
+    /// Ledger timestamp of the most recent successful refresh.
+    pub last_refreshed_at: u64,
+    /// Configured lifetime of the entry in seconds.
+    pub ttl_seconds: u64,
+    /// Age of the cached entry in seconds (relative to current ledger time).
+    pub age_seconds: u64,
 }
 
 const MIN_TEMP_TTL: u32 = 15; // min_temp_entry_ttl - 1
@@ -2848,40 +2876,58 @@ impl AnchorKitContract {
         payload_hash: Bytes,
         signature: Bytes,
     ) -> u64 {
+        // --- Phase 1: authentication & read-only precondition checks ---
+        // All checks that do NOT write to storage run first. If any fails the
+        // function panics before any storage mutation occurs, leaving the
+        // contract in a consistent state.
         issuer.require_auth();
         Self::check_attestor(&env, &issuer);
         Self::verify_attestation_signature(&env, &issuer, &payload_hash, &signature);
-        Self::enforce_rate_limit(&env, &issuer);
         Self::check_timestamp(&env, timestamp);
 
-        let config = RateLimiter::get_config(&env);
-        if RateLimiter::check_and_increment(&env, &issuer, &config).is_err() {
-            panic_with_error!(&env, ErrorCode::RateLimitExceeded);
-        }
-
+        // Replay check (read-only)
         let issuer_xdr = issuer.clone().to_xdr(&env);
         let issuer_raw = xdr_to_vec(&issuer_xdr);
         let hash_raw = xdr_to_vec(&payload_hash);
         let used_key = make_storage_key(&env, &[b"USED", &issuer_raw, &hash_raw]);
         if env.storage().persistent().has(&used_key) {
             // Record replay detection event and metrics before panicking
-            let replay_event = replay_detection::record_replay_detection(&env, &payload_hash, &issuer);
+            let replay_event =
+                replay_detection::record_replay_detection(&env, &payload_hash, &issuer);
             replay_detection::emit_replay_detection_log(&env, &replay_event);
             panic_with_error!(&env, ErrorCode::ReplayAttack);
         }
 
+        // Rate-limit check: `enforce_rate_limit` calls `check_and_increment`
+        // which also writes. It comes last among the precondition checks so the
+        // counter is only incremented when every guard has already passed.
+        Self::enforce_rate_limit(&env, &issuer);
+
+        // --- Phase 2: all writes together ---
+        // We reach here only when every precondition is satisfied. Any
+        // out-of-storage budget failure below will abort the entire transaction
+        // and roll back the rate-limit increment along with every other write.
         let id = Self::next_attestation_id(&env);
         Self::store_attestation(
-            &env, id, issuer.clone(), subject.clone(), timestamp,
-            payload_hash.clone(), signature,
+            &env,
+            id,
+            issuer.clone(),
+            subject.clone(),
+            timestamp,
+            payload_hash.clone(),
+            signature,
         );
-
         env.storage().persistent().set(&used_key, &timestamp);
-        env.storage().persistent().extend_ttl(&used_key, REPLAY_TTL, REPLAY_TTL);
+        env.storage()
+            .persistent()
+            .extend_ttl(&used_key, REPLAY_TTL, REPLAY_TTL);
 
         env.events().publish(
             (symbol_short!("attest"), symbol_short!("recorded"), id, subject),
-            AttestEvent { payload_hash, timestamp },
+            AttestEvent {
+                payload_hash,
+                timestamp,
+            },
         );
         id
     }
@@ -2899,6 +2945,7 @@ impl AnchorKitContract {
         signature: Bytes,
         require_kyc: bool,
     ) -> u64 {
+        // --- Phase 1: authentication & read-only precondition checks ---
         issuer.require_auth();
         Self::check_attestor(&env, &issuer);
         Self::verify_attestation_signature(&env, &issuer, &payload_hash, &signature);
@@ -2908,45 +2955,61 @@ impl AnchorKitContract {
             let kyc_status = Self::get_kyc_status(env.clone(), subject.clone());
             if kyc_status != KycStatus::Approved {
                 match kyc_status {
-                    KycStatus::Pending    => panic_with_error!(&env, ErrorCode::KycPending),
-                    KycStatus::Rejected   => panic_with_error!(&env, ErrorCode::KycRejected),
-                    KycStatus::Expired    => panic_with_error!(&env, ErrorCode::ComplianceNotMet),
+                    KycStatus::Pending => panic_with_error!(&env, ErrorCode::KycPending),
+                    KycStatus::Rejected => panic_with_error!(&env, ErrorCode::KycRejected),
+                    KycStatus::Expired => panic_with_error!(&env, ErrorCode::ComplianceNotMet),
                     KycStatus::NotSubmitted => panic_with_error!(&env, ErrorCode::KycNotFound),
                     _ => panic_with_error!(&env, ErrorCode::ComplianceNotMet),
                 }
             }
         }
 
+        // Replay check (read-only)
         let issuer_xdr = issuer.clone().to_xdr(&env);
         let issuer_raw = xdr_to_vec(&issuer_xdr);
         let hash_raw = xdr_to_vec(&payload_hash);
         let used_key = make_storage_key(&env, &[b"USED", &issuer_raw, &hash_raw]);
         if env.storage().persistent().has(&used_key) {
-            // Record replay detection event and metrics before panicking
-            let replay_event = replay_detection::record_replay_detection(&env, &payload_hash, &issuer);
+            let replay_event =
+                replay_detection::record_replay_detection(&env, &payload_hash, &issuer);
             replay_detection::emit_replay_detection_log(&env, &replay_event);
             panic_with_error!(&env, ErrorCode::ReplayAttack);
         }
 
+        // Rate-limit check (single call; the earlier double-count was a bug).
+        Self::enforce_rate_limit(&env, &issuer);
+
+        // --- Phase 2: all writes together ---
         let id = Self::next_attestation_id(&env);
         Self::store_attestation(
-            &env, id, issuer.clone(), subject.clone(), timestamp,
-            payload_hash.clone(), signature,
+            &env,
+            id,
+            issuer.clone(),
+            subject.clone(),
+            timestamp,
+            payload_hash.clone(),
+            signature,
         );
-
         env.storage().persistent().set(&used_key, &timestamp);
-        env.storage().persistent().extend_ttl(&used_key, REPLAY_TTL, REPLAY_TTL);
+        env.storage()
+            .persistent()
+            .extend_ttl(&used_key, REPLAY_TTL, REPLAY_TTL);
 
         let _now = env.ledger().timestamp();
         env.events().publish(
             (symbol_short!("attest"), symbol_short!("recorded"), id, subject),
-            AttestEvent { payload_hash: payload_hash.clone(), timestamp },
+            AttestEvent {
+                payload_hash: payload_hash.clone(),
+                timestamp,
+            },
         );
         env.events().publish(
             (symbol_short!("webhook"), symbol_short!("event")),
             WebhookEvent {
                 event_type: String::from_str(&env, "attestation_submitted"),
-                transaction_id: id, timestamp, payload_hash,
+                transaction_id: id,
+                timestamp,
+                payload_hash,
             },
         );
         id
@@ -5129,11 +5192,22 @@ impl AnchorKitContract {
     // Anchor Info Discovery
     // -----------------------------------------------------------------------
 
+    /// Cache the anchor's stellar.toml data along with provenance information.
+    ///
+    /// # Arguments
+    ///
+    /// * `anchor` - The anchor whose metadata is being cached.
+    /// * `toml_data` - Parsed stellar.toml payload.
+    /// * `ttl_seconds` - How long (in seconds) the entry is considered fresh.
+    ///   Pass `0` to use the contract-level `capabilities_ttl_seconds`.
+    /// * `source_uri` - The URL from which `toml_data` was fetched. Pass an
+    ///   empty string if the source is unknown or not applicable.
     pub fn fetch_anchor_info(
         env: Env,
         anchor: Address,
         toml_data: StellarToml,
         ttl_seconds: u64,
+        source_uri: String,
     ) {
         anchor.require_auth();
         for asset in toml_data.currencies.iter() {
@@ -5146,22 +5220,60 @@ impl AnchorKitContract {
             toml: toml_data,
             cached_at: now,
             ttl_seconds: ttl,
+            source_uri,
+            last_refreshed_at: now,
         };
         let key = (symbol_short!("TOMLCACHE"), anchor.clone());
-        let ledger_ttl = if ttl as u32 > MIN_TEMP_TTL { ttl as u32 } else { MIN_TEMP_TTL };
+        let ledger_ttl = if ttl as u32 > MIN_TEMP_TTL {
+            ttl as u32
+        } else {
+            MIN_TEMP_TTL
+        };
         env.storage().temporary().set(&key, &cached);
-        env.storage().temporary().extend_ttl(&key, ledger_ttl, ledger_ttl);
+        env.storage()
+            .temporary()
+            .extend_ttl(&key, ledger_ttl, ledger_ttl);
     }
 
     pub fn get_anchor_toml(env: Env, anchor: Address) -> StellarToml {
         let key = (symbol_short!("TOMLCACHE"), anchor);
-        let cached: CachedToml = env.storage().temporary().get(&key)
+        let cached: CachedToml = env
+            .storage()
+            .temporary()
+            .get(&key)
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::CacheNotFound));
         let now = env.ledger().timestamp();
         if cached.cached_at + cached.ttl_seconds <= now {
             panic_with_error!(&env, ErrorCode::CacheExpired);
         }
         cached.toml
+    }
+
+    /// Return provenance metadata for the anchor's cached stellar.toml entry.
+    ///
+    /// Panics with `CacheNotFound` when no entry exists, or `CacheExpired`
+    /// when the entry has passed its TTL. Callers should check freshness
+    /// first, or use `try_get_anchor_toml_provenance` via the SDK client.
+    pub fn get_anchor_toml_provenance(env: Env, anchor: Address) -> AnchorTomlProvenance {
+        let key = (symbol_short!("TOMLCACHE"), anchor.clone());
+        let cached: CachedToml = env
+            .storage()
+            .temporary()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::CacheNotFound));
+        let now = env.ledger().timestamp();
+        if cached.cached_at + cached.ttl_seconds <= now {
+            panic_with_error!(&env, ErrorCode::CacheExpired);
+        }
+        let age_seconds = now.saturating_sub(cached.cached_at);
+        AnchorTomlProvenance {
+            anchor,
+            source_uri: cached.source_uri,
+            cached_at: cached.cached_at,
+            last_refreshed_at: cached.last_refreshed_at,
+            ttl_seconds: cached.ttl_seconds,
+            age_seconds,
+        }
     }
 
     pub fn refresh_anchor_info(env: Env, anchor: Address) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub use errors::Error;
 pub use rate_limiter::{RateLimiter, RateLimitConfig, RateLimitState};
 pub use retry::{retry_with_backoff, is_retryable, RetryConfig, JitterSource, LedgerJitterSource, MockJitterSource};
 pub use deterministic_hash::{compute_payload_hash, verify_payload_hash};
-pub use contract::{AnchorKitContract, EndpointUpdated, CacheConfig};
+pub use contract::{AnchorKitContract, AnchorTomlProvenance, EndpointUpdated, CacheConfig};
 pub use transaction_state_tracker::{TransactionState, TransactionStateRecord, RecoveryMetadata, OptRecovery};
 pub use transaction_state_tracker::{StorageBudgetMonitor, TransactionStateTracker};
 pub use transaction_state_tracker::TransactionSummary;

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -123,7 +123,11 @@ impl RateLimiter {
             });
         
         // Check if window has expired and reset if needed
-        if Self::is_window_expired(current_ledger, state.window_start_ledger, config.window_length) {
+        if Self::is_window_expired(
+            current_ledger,
+            state.window_start_ledger,
+            config.window_length,
+        ) {
             state = RateLimitState {
                 submission_count: 0,
                 window_start_ledger: current_ledger,
@@ -248,9 +252,35 @@ impl RateLimiter {
             })
     }
     
-    /// Check if a window has expired
-    fn is_window_expired(current_ledger: u32, window_start_ledger: u32, window_length: u32) -> bool {
-        current_ledger.saturating_sub(window_start_ledger) >= window_length
+    /// Check if a rate-limit window has expired.
+    ///
+    /// Uses `checked_sub` instead of `saturating_sub` so that a sequence
+    /// anomaly where `current < window_start` (e.g. due to a ledger rollback
+    /// or corrupted stored state) is treated as **not expired** rather than
+    /// silently wrapping to 0 and comparing against `window_length`.
+    ///
+    /// # Safe-default rationale
+    ///
+    /// When `current_ledger < window_start_ledger` the subtraction overflows.
+    /// Saturating to 0 makes the condition `0 >= window_length` false for any
+    /// positive `window_length`, so the old behaviour was accidentally correct.
+    /// Using `checked_sub` makes the intent explicit: we detect the underflow
+    /// and deliberately return `false` (window not expired), preserving the
+    /// existing rate-limit state so an attestor cannot exploit the anomaly to
+    /// bypass their quota.
+    fn is_window_expired(
+        current_ledger: u32,
+        window_start_ledger: u32,
+        window_length: u32,
+    ) -> bool {
+        match current_ledger.checked_sub(window_start_ledger) {
+            Some(delta) => delta >= window_length,
+            // current < window_start: ledger sequence anomaly or stored-state
+            // inconsistency. Treat as window not yet expired so the existing
+            // submission count is preserved and the attestor cannot exploit
+            // the anomaly to bypass their rate limit.
+            None => false,
+        }
     }
     
     /// Generate collision-resistant storage key for per-attestor rate limit state.
@@ -597,6 +627,29 @@ mod tests {
         assert!(env.as_contract(&contract_id, &|| {
             RateLimiter::check_and_increment(&env, &attestor, &config)
         }).is_ok());
+    }
+
+    /// If the stored window_start_ledger is somehow *ahead* of the current ledger
+    /// (sequence anomaly), the window must be treated as NOT expired so that the
+    /// existing submission count is preserved and the rate-limit cannot be bypassed.
+    #[test]
+    fn test_window_not_expired_when_current_less_than_start() {
+        // current < window_start → checked_sub underflows → None → false
+        assert!(!RateLimiter::is_window_expired(5, 10, 10));
+        assert!(!RateLimiter::is_window_expired(0, 1, 1));
+        assert!(!RateLimiter::is_window_expired(100, 200, 50));
+    }
+
+    /// current == window_start and window_length > 0: delta is 0, so NOT expired.
+    #[test]
+    fn test_window_not_expired_at_exact_start() {
+        assert!(!RateLimiter::is_window_expired(10, 10, 1));
+    }
+
+    /// Verify the boundary: delta == window_length means expired.
+    #[test]
+    fn test_window_expired_at_exact_length() {
+        assert!(RateLimiter::is_window_expired(20, 10, 10)); // delta = 10 >= 10
     }
 
     #[test]

--- a/tests/anchor_info_discovery_tests.rs
+++ b/tests/anchor_info_discovery_tests.rs
@@ -29,6 +29,11 @@ mod anchor_info_discovery_tests {
         });
     }
 
+    /// Empty source URI helper — used by tests that do not care about provenance.
+    fn no_uri(env: &Env) -> String {
+        String::from_str(env, "")
+    }
+
     fn usdc_asset(env: &Env) -> AssetInfo {
         AssetInfo {
             code: String::from_str(env, "USDC"),
@@ -73,12 +78,42 @@ mod anchor_info_discovery_tests {
 
         StellarToml {
             version: String::from_str(env, "2.0.0"),
-            network_passphrase: String::from_str(env, "Test SDF Network ; September 2015"),
+            network_passphrase: String::from_str(
+                env,
+                "Test SDF Network ; September 2015",
+            ),
             accounts,
             signing_key: String::from_str(env, "GSIGN123"),
             currencies,
             transfer_server: String::from_str(env, "https://api.example.com"),
-            transfer_server_sep0024: String::from_str(env, "https://api.example.com/sep24"),
+            transfer_server_sep0024: String::from_str(
+                env,
+                "https://api.example.com/sep24",
+            ),
+            kyc_server: String::from_str(env, "https://kyc.example.com"),
+            web_auth_endpoint: String::from_str(env, "https://auth.example.com"),
+        }
+    }
+
+    fn make_toml_with_asset(env: &Env, asset: AssetInfo) -> StellarToml {
+        let mut currencies = Vec::new(env);
+        currencies.push_back(asset);
+        let mut accounts = Vec::new(env);
+        accounts.push_back(String::from_str(env, "GANCHOR1"));
+        StellarToml {
+            version: String::from_str(env, "2.0.0"),
+            network_passphrase: String::from_str(
+                env,
+                "Test SDF Network ; September 2015",
+            ),
+            accounts,
+            signing_key: String::from_str(env, "GSIGN123"),
+            currencies,
+            transfer_server: String::from_str(env, "https://api.example.com"),
+            transfer_server_sep0024: String::from_str(
+                env,
+                "https://api.example.com/sep24",
+            ),
             kyc_server: String::from_str(env, "https://kyc.example.com"),
             web_auth_endpoint: String::from_str(env, "https://auth.example.com"),
         }
@@ -91,13 +126,17 @@ mod anchor_info_discovery_tests {
         (client, anchor)
     }
 
+    // -----------------------------------------------------------------------
+    // Basic cache tests
+    // -----------------------------------------------------------------------
+
     #[test]
     fn test_fetch_and_cache_toml() {
         let env = make_env();
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
         let toml = client.get_anchor_toml(&anchor);
         assert_eq!(toml.version, String::from_str(&env, "2.0.0"));
@@ -110,11 +149,17 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
         let toml = client.get_anchor_toml(&anchor);
-        assert_eq!(toml.network_passphrase, String::from_str(&env, "Test SDF Network ; September 2015"));
-        assert_eq!(toml.transfer_server, String::from_str(&env, "https://api.example.com"));
+        assert_eq!(
+            toml.network_passphrase,
+            String::from_str(&env, "Test SDF Network ; September 2015"),
+        );
+        assert_eq!(
+            toml.transfer_server,
+            String::from_str(&env, "https://api.example.com"),
+        );
     }
 
     #[test]
@@ -133,7 +178,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 1000);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &1u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &1u64, &no_uri(&env));
 
         set_ledger(&env, 1002);
         let result = client.try_get_anchor_toml(&anchor);
@@ -147,7 +192,7 @@ mod anchor_info_discovery_tests {
         let (client, anchor) = setup(&env);
 
         // Cache with 3600s TTL at timestamp 1000
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
         // At timestamp 5000: 1000 + 3600 = 4600 < 5000, so expired
         set_ledger(&env, 5000);
@@ -161,7 +206,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
         let assets = client.get_anchor_assets(&anchor);
         assert_eq!(assets.len(), 2);
@@ -175,7 +220,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
         let info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(info.issuer, String::from_str(&env, "GABC123"));
@@ -188,9 +233,10 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
-        let result = client.try_get_anchor_asset_info(&anchor, &String::from_str(&env, "BTC"));
+        let result =
+            client.try_get_anchor_asset_info(&anchor, &String::from_str(&env, "BTC"));
         assert!(result.is_err());
     }
 
@@ -200,9 +246,10 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
-        let (min, max) = client.get_anchor_deposit_limits(&anchor, &String::from_str(&env, "USDC"));
+        let (min, max) = client
+            .get_anchor_deposit_limits(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(min, 1000);
         assert_eq!(max, 1_000_000);
     }
@@ -213,9 +260,10 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
-        let (min, max) = client.get_anchor_withdrawal_limits(&anchor, &String::from_str(&env, "USDC"));
+        let (min, max) = client
+            .get_anchor_withdrawal_limits(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(min, 500);
         assert_eq!(max, 500_000);
     }
@@ -226,9 +274,10 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
-        let (fixed, percent) = client.get_anchor_deposit_fees(&anchor, &String::from_str(&env, "USDC"));
+        let (fixed, percent) = client
+            .get_anchor_deposit_fees(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(fixed, 100);
         assert_eq!(percent, 10);
     }
@@ -239,9 +288,10 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
-        let (fixed, percent) = client.get_anchor_withdrawal_fees(&anchor, &String::from_str(&env, "USDC"));
+        let (fixed, percent) = client
+            .get_anchor_withdrawal_fees(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(fixed, 50);
         assert_eq!(percent, 5);
     }
@@ -252,9 +302,11 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
-        assert!(client.anchor_supports_deposits(&anchor, &String::from_str(&env, "USDC")));
+        assert!(
+            client.anchor_supports_deposits(&anchor, &String::from_str(&env, "USDC"))
+        );
     }
 
     #[test]
@@ -263,9 +315,11 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
-        assert!(client.anchor_supports_withdrawals(&anchor, &String::from_str(&env, "USDC")));
+        assert!(
+            client.anchor_supports_withdrawals(&anchor, &String::from_str(&env, "USDC"))
+        );
     }
 
     #[test]
@@ -274,7 +328,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
         let _ = client.get_anchor_toml(&anchor);
 
         client.refresh_anchor_info(&anchor);
@@ -282,8 +336,8 @@ mod anchor_info_discovery_tests {
         let toml = client.get_anchor_toml(&anchor);
         assert_eq!(toml.version, String::from_str(&env, "2.0.0"));
 
-        let diagnostic =
-            client.get_refresh_diagnostic(&anchor, &String::from_str(&env, "anchor_info"));
+        let diagnostic = client
+            .get_refresh_diagnostic(&anchor, &String::from_str(&env, "anchor_info"));
         assert_eq!(diagnostic.status, RefreshStatus::Failed);
         assert!(diagnostic.had_cached_entry);
     }
@@ -294,10 +348,12 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
-        let usdc_info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "USDC"));
-        let xlm_info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "XLM"));
+        let usdc_info =
+            client.get_anchor_asset_info(&anchor, &String::from_str(&env, "USDC"));
+        let xlm_info =
+            client.get_anchor_asset_info(&anchor, &String::from_str(&env, "XLM"));
 
         assert_eq!(usdc_info.deposit_fee_fixed, 100);
         assert_eq!(xlm_info.deposit_fee_fixed, 0);
@@ -309,7 +365,7 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
         let info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "XLM"));
         assert_eq!(info.issuer, String::from_str(&env, "native"));
@@ -343,21 +399,29 @@ mod anchor_info_discovery_tests {
         accounts2.push_back(String::from_str(&env, "GANCHOR2"));
         let toml2 = StellarToml {
             version: String::from_str(&env, "2.0.0"),
-            network_passphrase: String::from_str(&env, "Test SDF Network ; September 2015"),
+            network_passphrase: String::from_str(
+                &env,
+                "Test SDF Network ; September 2015",
+            ),
             accounts: accounts2,
             signing_key: String::from_str(&env, "GSIGN456"),
             currencies: currencies2,
             transfer_server: String::from_str(&env, "https://api2.example.com"),
-            transfer_server_sep0024: String::from_str(&env, "https://api2.example.com/sep24"),
+            transfer_server_sep0024: String::from_str(
+                &env,
+                "https://api2.example.com/sep24",
+            ),
             kyc_server: String::from_str(&env, "https://kyc2.example.com"),
             web_auth_endpoint: String::from_str(&env, "https://auth2.example.com"),
         };
 
-        client.fetch_anchor_info(&anchor1, &sample_toml(&env), &3600u64);
-        client.fetch_anchor_info(&anchor2, &toml2, &3600u64);
+        client.fetch_anchor_info(&anchor1, &sample_toml(&env), &3600u64, &no_uri(&env));
+        client.fetch_anchor_info(&anchor2, &toml2, &3600u64, &no_uri(&env));
 
-        let info1 = client.get_anchor_asset_info(&anchor1, &String::from_str(&env, "USDC"));
-        let info2 = client.get_anchor_asset_info(&anchor2, &String::from_str(&env, "USDC"));
+        let info1 =
+            client.get_anchor_asset_info(&anchor1, &String::from_str(&env, "USDC"));
+        let info2 =
+            client.get_anchor_asset_info(&anchor2, &String::from_str(&env, "USDC"));
 
         assert_eq!(info1.issuer, String::from_str(&env, "GABC123"));
         assert_eq!(info2.issuer, String::from_str(&env, "GOTHER"));
@@ -371,10 +435,12 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
-        let (dep_min, dep_max) = client.get_anchor_deposit_limits(&anchor, &String::from_str(&env, "USDC"));
-        let (wit_min, wit_max) = client.get_anchor_withdrawal_limits(&anchor, &String::from_str(&env, "USDC"));
+        let (dep_min, dep_max) = client
+            .get_anchor_deposit_limits(&anchor, &String::from_str(&env, "USDC"));
+        let (wit_min, wit_max) = client
+            .get_anchor_withdrawal_limits(&anchor, &String::from_str(&env, "USDC"));
 
         assert!(dep_min < dep_max);
         assert!(wit_min < wit_max);
@@ -390,10 +456,12 @@ mod anchor_info_discovery_tests {
         set_ledger(&env, 0);
         let (client, anchor) = setup(&env);
 
-        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64);
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
 
-        let (dep_fixed, dep_pct) = client.get_anchor_deposit_fees(&anchor, &String::from_str(&env, "USDC"));
-        let (wit_fixed, wit_pct) = client.get_anchor_withdrawal_fees(&anchor, &String::from_str(&env, "USDC"));
+        let (dep_fixed, dep_pct) = client
+            .get_anchor_deposit_fees(&anchor, &String::from_str(&env, "USDC"));
+        let (wit_fixed, wit_pct) = client
+            .get_anchor_withdrawal_fees(&anchor, &String::from_str(&env, "USDC"));
 
         assert_eq!(dep_fixed, 100);
         assert_eq!(dep_pct, 10);
@@ -404,24 +472,6 @@ mod anchor_info_discovery_tests {
     // -----------------------------------------------------------------------
     // #245 — fee and limit validation tests
     // -----------------------------------------------------------------------
-
-    fn make_toml_with_asset(env: &Env, asset: AssetInfo) -> StellarToml {
-        let mut currencies = Vec::new(env);
-        currencies.push_back(asset);
-        let mut accounts = Vec::new(env);
-        accounts.push_back(String::from_str(env, "GANCHOR1"));
-        StellarToml {
-            version: String::from_str(env, "2.0.0"),
-            network_passphrase: String::from_str(env, "Test SDF Network ; September 2015"),
-            accounts,
-            signing_key: String::from_str(env, "GSIGN123"),
-            currencies,
-            transfer_server: String::from_str(env, "https://api.example.com"),
-            transfer_server_sep0024: String::from_str(env, "https://api.example.com/sep24"),
-            kyc_server: String::from_str(env, "https://kyc.example.com"),
-            web_auth_endpoint: String::from_str(env, "https://auth.example.com"),
-        }
-    }
 
     /// deposit_fee_percent > 10_000 bps must be rejected.
     #[test]
@@ -445,7 +495,12 @@ mod anchor_info_discovery_tests {
             withdrawal_min_amount: 0,
             withdrawal_max_amount: 0,
         };
-        client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, bad_asset), &3600u64);
+        client.fetch_anchor_info(
+            &anchor,
+            &make_toml_with_asset(&env, bad_asset),
+            &3600u64,
+            &no_uri(&env),
+        );
     }
 
     /// withdrawal_fee_percent > 10_000 bps must be rejected.
@@ -470,7 +525,12 @@ mod anchor_info_discovery_tests {
             withdrawal_min_amount: 100,
             withdrawal_max_amount: 1_000,
         };
-        client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, bad_asset), &3600u64);
+        client.fetch_anchor_info(
+            &anchor,
+            &make_toml_with_asset(&env, bad_asset),
+            &3600u64,
+            &no_uri(&env),
+        );
     }
 
     /// deposit_min_amount > deposit_max_amount (inverted range) must be rejected.
@@ -495,7 +555,12 @@ mod anchor_info_discovery_tests {
             withdrawal_min_amount: 0,
             withdrawal_max_amount: 0,
         };
-        client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, bad_asset), &3600u64);
+        client.fetch_anchor_info(
+            &anchor,
+            &make_toml_with_asset(&env, bad_asset),
+            &3600u64,
+            &no_uri(&env),
+        );
     }
 
     /// withdrawal_min_amount > withdrawal_max_amount must be rejected.
@@ -520,7 +585,12 @@ mod anchor_info_discovery_tests {
             withdrawal_min_amount: 9_000,
             withdrawal_max_amount: 1_000, // min > max
         };
-        client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, bad_asset), &3600u64);
+        client.fetch_anchor_info(
+            &anchor,
+            &make_toml_with_asset(&env, bad_asset),
+            &3600u64,
+            &no_uri(&env),
+        );
     }
 
     /// Empty currency code must be rejected.
@@ -545,7 +615,12 @@ mod anchor_info_discovery_tests {
             withdrawal_min_amount: 0,
             withdrawal_max_amount: 0,
         };
-        client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, bad_asset), &3600u64);
+        client.fetch_anchor_info(
+            &anchor,
+            &make_toml_with_asset(&env, bad_asset),
+            &3600u64,
+            &no_uri(&env),
+        );
     }
 
     /// Currency code longer than 12 characters must be rejected.
@@ -570,10 +645,15 @@ mod anchor_info_discovery_tests {
             withdrawal_min_amount: 0,
             withdrawal_max_amount: 0,
         };
-        client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, bad_asset), &3600u64);
+        client.fetch_anchor_info(
+            &anchor,
+            &make_toml_with_asset(&env, bad_asset),
+            &3600u64,
+            &no_uri(&env),
+        );
     }
 
-    /// max_amount = 0 is treated as "unlimited" and must not trigger the inverted-range check.
+    /// max_amount = 0 is treated as "unlimited"; must not trigger inverted-range check.
     #[test]
     fn test_zero_max_amount_is_valid() {
         let env = make_env();
@@ -595,8 +675,178 @@ mod anchor_info_discovery_tests {
             withdrawal_max_amount: 0, // 0 = unlimited
         };
         // Must not panic
-        client.fetch_anchor_info(&anchor, &make_toml_with_asset(&env, asset), &3600u64);
-        let info = client.get_anchor_asset_info(&anchor, &String::from_str(&env, "USDC"));
+        client.fetch_anchor_info(
+            &anchor,
+            &make_toml_with_asset(&env, asset),
+            &3600u64,
+            &no_uri(&env),
+        );
+        let info =
+            client.get_anchor_asset_info(&anchor, &String::from_str(&env, "USDC"));
         assert_eq!(info.deposit_max_amount, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Provenance & freshness tests
+    // -----------------------------------------------------------------------
+
+    /// `get_anchor_toml_provenance` returns the source URI passed to `fetch_anchor_info`.
+    #[test]
+    fn test_provenance_source_uri_stored() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, anchor) = setup(&env);
+
+        let uri =
+            String::from_str(&env, "https://anchor.example/.well-known/stellar.toml");
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &uri);
+
+        let prov = client.get_anchor_toml_provenance(&anchor);
+        assert_eq!(prov.source_uri, uri);
+    }
+
+    /// When no source URI is provided the field is stored as an empty string.
+    #[test]
+    fn test_provenance_empty_source_uri() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
+
+        let prov = client.get_anchor_toml_provenance(&anchor);
+        assert_eq!(prov.source_uri, String::from_str(&env, ""));
+    }
+
+    /// `cached_at` and `last_refreshed_at` are both equal to the ledger
+    /// timestamp on first write.
+    #[test]
+    fn test_provenance_cached_at_equals_last_refreshed_on_first_write() {
+        let env = make_env();
+        set_ledger(&env, 5000);
+        let (client, anchor) = setup(&env);
+
+        let uri =
+            String::from_str(&env, "https://anchor.example/.well-known/stellar.toml");
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &uri);
+
+        let prov = client.get_anchor_toml_provenance(&anchor);
+        assert_eq!(prov.cached_at, 5000);
+        assert_eq!(prov.last_refreshed_at, 5000);
+    }
+
+    /// `ttl_seconds` is stored and returned verbatim.
+    #[test]
+    fn test_provenance_ttl_seconds_stored() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &7200u64, &no_uri(&env));
+
+        let prov = client.get_anchor_toml_provenance(&anchor);
+        assert_eq!(prov.ttl_seconds, 7200);
+    }
+
+    /// `age_seconds` reflects elapsed time since `cached_at`.
+    #[test]
+    fn test_provenance_age_seconds() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, anchor) = setup(&env);
+
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &no_uri(&env));
+
+        set_ledger(&env, 1500); // advance 500 seconds
+        let prov = client.get_anchor_toml_provenance(&anchor);
+        assert_eq!(prov.age_seconds, 500);
+    }
+
+    /// `get_anchor_toml_provenance` panics with `CacheNotFound` when no entry exists.
+    #[test]
+    #[should_panic]
+    fn test_provenance_not_found_panics() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+        // Never cached — must panic
+        client.get_anchor_toml_provenance(&anchor);
+    }
+
+    /// `get_anchor_toml_provenance` panics with `CacheExpired` after TTL elapses.
+    #[test]
+    #[should_panic]
+    fn test_provenance_expired_panics() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, anchor) = setup(&env);
+
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &10u64, &no_uri(&env));
+
+        set_ledger(&env, 1011); // past TTL
+        client.get_anchor_toml_provenance(&anchor);
+    }
+
+    /// A second `fetch_anchor_info` overwrites `source_uri`, `cached_at`, and
+    /// `last_refreshed_at` with the new values.
+    #[test]
+    fn test_provenance_overwrite_updates_all_fields() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, anchor) = setup(&env);
+
+        let uri1 = String::from_str(&env, "https://v1.example/stellar.toml");
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &uri1);
+
+        set_ledger(&env, 2000);
+        let uri2 = String::from_str(&env, "https://v2.example/stellar.toml");
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &uri2);
+
+        let prov = client.get_anchor_toml_provenance(&anchor);
+        assert_eq!(prov.source_uri, uri2);
+        assert_eq!(prov.cached_at, 2000);
+        assert_eq!(prov.last_refreshed_at, 2000);
+    }
+
+    /// The anchor address embedded in the provenance record matches the key anchor.
+    #[test]
+    fn test_provenance_anchor_field_matches() {
+        let env = make_env();
+        set_ledger(&env, 0);
+        let (client, anchor) = setup(&env);
+
+        let uri =
+            String::from_str(&env, "https://anchor.example/.well-known/stellar.toml");
+        client.fetch_anchor_info(&anchor, &sample_toml(&env), &3600u64, &uri);
+
+        let prov = client.get_anchor_toml_provenance(&anchor);
+        assert_eq!(prov.anchor, anchor);
+    }
+
+    /// Two different anchors maintain independent provenance records.
+    #[test]
+    fn test_provenance_independent_per_anchor() {
+        let env = make_env();
+        set_ledger(&env, 1000);
+        let (client, anchor1) = setup(&env);
+        let anchor2 = Address::generate(&env);
+
+        let uri1 = String::from_str(&env, "https://anchor1.example/stellar.toml");
+        let uri2 = String::from_str(&env, "https://anchor2.example/stellar.toml");
+        client.fetch_anchor_info(&anchor1, &sample_toml(&env), &3600u64, &uri1);
+
+        set_ledger(&env, 2000);
+        client.fetch_anchor_info(&anchor2, &sample_toml(&env), &7200u64, &uri2);
+
+        let prov1 = client.get_anchor_toml_provenance(&anchor1);
+        let prov2 = client.get_anchor_toml_provenance(&anchor2);
+
+        assert_eq!(prov1.source_uri, uri1);
+        assert_eq!(prov1.cached_at, 1000);
+        assert_eq!(prov1.ttl_seconds, 3600);
+
+        assert_eq!(prov2.source_uri, uri2);
+        assert_eq!(prov2.cached_at, 2000);
+        assert_eq!(prov2.ttl_seconds, 7200);
     }
 }


### PR DESCRIPTION
closes #415 
closes #411 
closes #354 

rate_limiter: replace saturating_sub with checked_sub in is_window_expired
so ledger-sequence anomalies are treated as non-expired (safe default).
Add doc comment explaining the rationale. Add 3 unit tests for the boundary.

contract: remove double rate-limit call in submit_attestation; the original
code called enforce_rate_limit AND check_and_increment separately, consuming
2 slots per submission. Apply same fix to submit_attestation_kyc_check.
Reorder both functions to phase-1 (all read-only guards) then phase-2 (all
writes together) so a storage-budget failure cannot leave the rate counter
incremented without a recorded attestation.

contract: add source_uri and last_refreshed_at provenance fields to
CachedToml. Add AnchorTomlProvenance return type. Extend fetch_anchor_info
with a source_uri parameter. Add get_anchor_toml_provenance query method.
Re-export AnchorTomlProvenance from lib.rs.

tests: rewrite anchor_info_discovery_tests.rs with a no_uri() helper keeping
all lines within max_width=100. Add 9 provenance tests covering URI storage,
timestamps, age_seconds, TTL, expiry, overwrite behavior, anchor identity,
and per-anchor isolation.
