### PR TITLE
Title: Fix four routing/CLI bugs: KYC gate, strategy case, doctor check, register public key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ argon2 = { version = "0.5.3" }
 rand = { version = "0.8", features = ["std"] }
 base64 = { version = "0.22" }
 rpassword = { version = "7.3" }
+ed25519-dalek = "2"
+stellar-strkey = "0.0.9"
 
 [build-dependencies]
 serde_json = "1"
@@ -51,7 +53,6 @@ jsonschema = "0.17"
 [dev-dependencies]
 soroban-sdk = { version = "21.7.0", features = ["testutils"] }
 base64 = "0.22"
-ed25519-dalek = "2"
 rand = "0.8"
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -2205,6 +2205,20 @@ impl AnchorKitContract {
             }
         }
 
+        // Enforce KYC check (#439)
+        if options.require_kyc {
+            let kyc_status = Self::get_kyc_status(env.clone(), options.subject.clone());
+            if kyc_status != KycStatus::Approved {
+                match kyc_status {
+                    KycStatus::Pending      => panic_with_error!(&env, ErrorCode::KycPending),
+                    KycStatus::Rejected     => panic_with_error!(&env, ErrorCode::KycRejected),
+                    KycStatus::Expired      => panic_with_error!(&env, ErrorCode::ComplianceNotMet),
+                    KycStatus::NotSubmitted => panic_with_error!(&env, ErrorCode::KycNotFound),
+                    _ => panic_with_error!(&env, ErrorCode::ComplianceNotMet),
+                }
+            }
+        }
+
         // Apply strategy: pick best candidate
         let strategy_sym = options.strategy.get(0)
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::NoQuotesAvailable));

--- a/src/main.rs
+++ b/src/main.rs
@@ -578,6 +578,18 @@ fn parse_services(services: &[String]) -> Vec<u32> {
     }).collect()
 }
 
+fn derive_ed25519_public_key_hex(source: &str) -> String {
+    use stellar_strkey::Strkey;
+    let strkey = Strkey::from_string(source)
+        .unwrap_or_else(|e| { eprintln!("error: invalid secret key '{}': {e}", source); std::process::exit(1); });
+    let seed = match strkey {
+        Strkey::PrivateKeyEd25519(k) => k.0,
+        _ => { eprintln!("error: expected an Ed25519 secret key (starts with 'S')"); std::process::exit(1); }
+    };
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
+    signing_key.verifying_key().as_bytes().iter().map(|b| format!("{:02x}", b)).collect()
+}
+
 fn register(
     address: &str, services: &[String], contract_id: &str,
     network: &str, source: &str, sep10_token: &str, sep10_issuer: &str,
@@ -585,12 +597,13 @@ fn register(
     let service_ids = parse_services(services)
         .iter().map(|id| id.to_string()).collect::<Vec<_>>().join(",");
 
+    let pk_hex = derive_ed25519_public_key_hex(source);
     stellar_invoke(contract_id, source, network, &[
         "register_attestor",
         "--attestor", address,
         "--sep10_token", sep10_token,
         "--sep10_issuer", sep10_issuer,
-        "--public_key", "0000000000000000000000000000000000000000000000000000000000000000",
+        "--public_key", &pk_hex,
     ]);
     stellar_invoke(contract_id, source, network, &[
         "configure_services",
@@ -639,7 +652,7 @@ fn quote(from: &str, to: &str, amount: u64, contract_id: &str, network: &str, so
         "--quote_asset", to,
         "--amount", &amount_str,
         "--operation_type", "1",   // 1 = deposit
-        "--strategy", "lowest_fee",
+        "--strategy", "LowestFee",
         "--min_reputation", "0",
         "--max_anchors", "10",
         "--require_kyc", "false",
@@ -805,7 +818,7 @@ fn check_contract_deployment(contract_id: &str, network: &str) -> CheckResult {
                "--rpc-url", &rpc_url_for(network),
                "--network-passphrase", &passphrase_for(network),
                "--",
-               "get_attestor_count"])
+               "is_initialized"])
         .output();
     
     match output {


### PR DESCRIPTION


Body:

Summary
closes #439  — RoutingOptions.require_kyc was declared but never enforced in route_transaction. Added a KYC status check (matching each KycStatus variant to its error code) consistent with submit_attestation_kyc_check.
closes #438 — CLI quote command passed "lowest_fee" (snake_case) but the contract compares against Symbol::new(&env, "LowestFee") (PascalCase), so the strategy never matched. Fixed by aligning the CLI value to "LowestFee".
closes #437 — CLI doctor health check invoked get_attestor_count, which does not exist on AnchorKitContract, causing it to always report the contract as broken. Replaced with is_initialized.
closes #436 — CLI register hardcoded an all-zero 64-hex public key, making every registered attestor permanently unable to produce valid signatures. Fixed by deriving the real Ed25519 verifying key from the signing key before calling register_attestor. Added stellar-strkey and moved ed25519-dalek from dev-deps to main dependencies to support this.
Test plan
 route_transaction with require_kyc: true and a non-approved subject panics with the correct error code
 route_transaction with require_kyc: true and an approved subject returns a quote
 CLI quote command returns the lowest-fee quote instead of falling through all strategy branches
 CLI doctor reports the contract as healthy when it is deployed and initialized
 CLI register stores the correct Ed25519 public key; subsequent submit_attestation calls verify successfully