### PR TITLE
fix: resolve four correctness and hygiene issues 

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1238,7 +1238,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let admin = Address::random(&env);
+    /// let admin = Address::generate(&env);
     /// AnchorKitContract::initialize(env, admin);
     /// ```
     pub fn initialize(env: Env, admin: Address) {
@@ -1278,10 +1278,7 @@ impl AnchorKitContract {
     /// assert!(initialized);
     /// ```
     pub fn is_initialized(env: Env) -> bool {
-        env.storage()
-            .instance()
-            .get::<_, bool>(&symbol_short!("INITED"))
-            .unwrap_or(false)
+        env.storage().persistent().has(&initialized_key(&env))
     }
 
     /// Retrieve the current admin address.
@@ -2049,8 +2046,8 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let attestor = Address::random(&env);
-    /// let issuer = Address::random(&env);
+    /// let attestor = Address::generate(&env);
+    /// let issuer = Address::generate(&env);
     /// let token = String::from_str(&env, "eyJ...");
     /// let pubkey = BytesN::from_array(&env, &[0u8; 32]);
     /// AnchorKitContract::register_attestor(env, attestor, token, issuer, pubkey);
@@ -2124,7 +2121,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let attestor = Address::random(&env);
+    /// let attestor = Address::generate(&env);
     /// AnchorKitContract::revoke_attestor(env, attestor);
     /// ```
     pub fn revoke_attestor(env: Env, attestor: Address) {
@@ -2174,7 +2171,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let attestor = Address::random(&env);
+    /// let attestor = Address::generate(&env);
     /// let is_registered = AnchorKitContract::is_attestor(env, attestor);
     /// ```
     pub fn is_attestor(env: Env, attestor: Address) -> bool {
@@ -2242,7 +2239,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let attestor = Address::random(&env);
+    /// let attestor = Address::generate(&env);
     /// let profile = AnchorKitContract::get_attestor_profile(env, attestor);
     /// println!("Endpoint: {}", profile.endpoint);
     /// ```
@@ -2290,7 +2287,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let attestor = Address::random(&env);
+    /// let attestor = Address::generate(&env);
     /// let endpoint = String::from_str(&env, "https://api.example.com");
     /// AnchorKitContract::set_endpoint(env, attestor, endpoint);
     /// ```
@@ -2333,7 +2330,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let attestor = Address::random(&env);
+    /// let attestor = Address::generate(&env);
     /// let endpoint = AnchorKitContract::get_endpoint(env, attestor);
     /// ```
     pub fn get_endpoint(env: Env, attestor: Address) -> String {
@@ -2377,7 +2374,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let attestor = Address::random(&env);
+    /// let attestor = Address::generate(&env);
     /// let webhook = String::from_str(&env, "https://api.example.com/webhooks");
     /// AnchorKitContract::register_webhook(env, attestor, webhook);
     /// ```
@@ -2423,7 +2420,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let attestor = Address::random(&env);
+    /// let attestor = Address::generate(&env);
     /// let webhook = AnchorKitContract::get_webhook_url(env, attestor);
     /// ```
     pub fn get_webhook_url(env: Env, attestor: Address) -> String {
@@ -2476,7 +2473,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let anchor = Address::random(&env);
+    /// let anchor = Address::generate(&env);
     /// let services = Vec::from_array(&env, [1u32, 3u32]); // deposits + quotes
     /// AnchorKitContract::configure_services(env, anchor, services);
     /// ```
@@ -2537,7 +2534,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let anchor = Address::random(&env);
+    /// let anchor = Address::generate(&env);
     /// let services = Vec::from_array(&env, [1u32, 2u32]); // deposits + withdrawals
     /// AnchorKitContract::configure_services_versioned(env, anchor, services, 1);
     /// ```
@@ -2671,7 +2668,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let anchor = Address::random(&env);
+    /// let anchor = Address::generate(&env);
     /// let version = AnchorKitContract::get_service_capability_version(env, anchor);
     /// ```
     pub fn get_service_capability_version(env: Env, anchor: Address) -> u32 {
@@ -2706,7 +2703,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let anchor = Address::random(&env);
+    /// let anchor = Address::generate(&env);
     /// let services = AnchorKitContract::get_supported_services(env, anchor);
     /// ```
     pub fn get_supported_services(env: Env, anchor: Address) -> AnchorServices {
@@ -2772,7 +2769,7 @@ impl AnchorKitContract {
     /// use anchorkit::AnchorKitContract;
     ///
     /// let env = Env::default();
-    /// let anchor = Address::random(&env);
+    /// let anchor = Address::generate(&env);
     /// let supports_deposits = AnchorKitContract::supports_service(env, anchor, 1);
     /// ```
     pub fn supports_service(env: Env, anchor: Address, service: u32) -> bool {

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Vec};
 
 /// Default TTL: ~90 days at 5 s/ledger.

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -98,7 +98,7 @@ where
     let last_error_msg: RefCell<String> = RefCell::new(String::new());
     let last_status: RefCell<u16> = RefCell::new(0);
 
-    let mut jitter_source = crate::retry::MockJitterSource::new(vec![0]);
+    let mut jitter_source = crate::retry::LedgerJitterSource::new(0, now_fn());
     let result = retry_with_backoff(
         &retry_cfg,
         |attempt| {


### PR DESCRIPTION
## Summary

This PR resolves four issues in a single changeset across three files.

---

### #458 — Remove blanket `#![allow(dead_code)]` from `transaction_state_tracker.rs`

`src/transaction_state_tracker.rs` was the only file in the codebase with a module-level `#![allow(dead_code)]` suppression, hiding any number of unused items in a 2042-line file. All other files use targeted, item-level attributes.

The blanket attribute has been removed. All items in the module are either `pub` (and therefore not subject to dead-code linting) or private helpers that are actively called internally, so no targeted replacement attributes were required.

---

### #459 — Replace `MockJitterSource` with `LedgerJitterSource` in `deliver_webhook`

`deliver_webhook` (`src/webhook.rs:101`) was using `MockJitterSource::new(vec![0])`, a test-only source that always returns `0`. This meant every retry had zero jitter and identical timing. When many deliveries fail simultaneously (e.g. the endpoint goes down), all callers retry in lockstep.

Replaced with `LedgerJitterSource::new(0, now_fn())`, seeding from the current timestamp so retries are spread out.

---

### #460 — Fix `Address::random` → `Address::generate` in doc examples

Fourteen doc examples in `src/contract.rs` called `Address::random(&env)`, which does not exist in soroban-sdk 21.x. The correct API is `Address::generate(&env)`. All occurrences replaced.

---

### #461 — Fix `is_initialized()` storage/key mismatch (critical)

`initialize()` wrote the init flag to **persistent** storage under `initialized_key()` (`make_storage_key(b"INITIALIZED")`), while `is_initialized()` read from **instance** storage under `symbol_short!("INITED")` — a key never written. The result: `is_initialized()` always returned `false`.

Fixed by aligning the read to use the same persistent key:

```rust
pub fn is_initialized(env: Env) -> bool {
    env.storage().persistent().has(&initialized_key(&env))
}
```

---

## Files changed

| File | Change |
|------|--------|
| `src/transaction_state_tracker.rs` | Remove blanket `#![allow(dead_code)]` |
| `src/webhook.rs` | Use `LedgerJitterSource` instead of `MockJitterSource` |
| `src/contract.rs` | Replace `Address::random` with `Address::generate` (×14); fix `is_initialized()` |

Closes #458
Closes #459
Closes #460
Closes #461