### PR TITLE
fix: correct sep38 doc visibility, mock account IDs, and error code semantics

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -4170,7 +4170,7 @@ impl AnchorKitContract {
         env.storage()
             .persistent()
             .get::<_, AuditLog>(&make_storage_key(&env, &[b"AUDIT", &log_id.to_be_bytes()]))
-            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestationNotFound))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AuditLogNotFound))
     }
 
     pub fn get_session_audit_logs(env: Env, session_id: u64, limit: u64) -> Vec<AuditLog> {
@@ -5523,7 +5523,7 @@ impl AnchorKitContract {
             .storage()
             .persistent()
             .get(&key)
-            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::AttestationNotFound));
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::TransactionNotFound));
 
         let from_state = record.state;
         if !from_state.is_valid_transition(new_state) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -77,6 +77,8 @@ pub enum ErrorCode {
     // Item not found errors (specific variants — replaces reuse of AttestationNotFound)
     SessionNotFound           = 32,
     QuoteNotFound             = 33,
+    AuditLogNotFound          = 34,
+    TransactionNotFound       = 35,
 
     // KYC / webhook / state errors (20–29)
     KycPending                = 20,
@@ -174,6 +176,8 @@ impl ErrorCode {
             ErrorCode::InvalidSessionMetadata    => "Session metadata is invalid",
             ErrorCode::InvalidAssetCode          => "Asset code is invalid",
             ErrorCode::QuoteNotFound             => "Quote not found",
+            ErrorCode::AuditLogNotFound          => "Audit log not found",
+            ErrorCode::TransactionNotFound       => "Transaction record not found",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! |--------|-----|---------|
 //! | [`sep6`] | SEP-6 | Non-interactive deposit / withdrawal |
 //! | [`sep24`] | SEP-24 | Interactive deposit / withdrawal |
-//! | `sep38` (internal) | SEP-38 | Anchor RFQ / firm quotes |
+//! | [`sep38`] | SEP-38 | Anchor RFQ / firm quotes |
 //!
 //! ### Cross-cutting utilities
 //! | Module | Purpose |

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -49,6 +49,9 @@ pub const MOCK_TXN_ID_24: &str = "mock-txn-24-001";
 /// Epoch timestamp used in quote mock responses (2024-01-15 00:00:00 UTC).
 pub const MOCK_EXPIRES_AT: u64 = 1_705_276_800;
 
+/// A known-valid Stellar testnet account address (correct base32 checksum).
+pub const MOCK_ACCOUNT_ID: &str = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
 // ── SEP-6 mocks ───────────────────────────────────────────────────────────────
 
 /// Returns a valid [`RawDepositResponse`] suitable for passing to [`initiate_deposit`].
@@ -76,7 +79,7 @@ pub fn mock_deposit_response() -> RawDepositResponse {
 pub fn mock_withdrawal_response() -> RawWithdrawalResponse {
     RawWithdrawalResponse {
         transaction_id: MOCK_TXN_ID.to_string(),
-        account_id: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_string(),
+        account_id: MOCK_ACCOUNT_ID.to_string(),
         memo: Some("MOCK-WITHDRAW".to_string()),
         memo_type: Some("text".to_string()),
         min_amount: Some(5),
@@ -257,7 +260,7 @@ pub fn mock_deposit_response_full() -> RawDepositResponse {
 pub fn mock_withdrawal_response_minimal() -> RawWithdrawalResponse {
     RawWithdrawalResponse {
         transaction_id: "withdraw-min-001".to_string(),
-        account_id: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_string(),
+        account_id: MOCK_ACCOUNT_ID.to_string(),
         memo: None,
         memo_type: None,
         min_amount: None,
@@ -272,7 +275,7 @@ pub fn mock_withdrawal_response_minimal() -> RawWithdrawalResponse {
 pub fn mock_withdrawal_response_full() -> RawWithdrawalResponse {
     RawWithdrawalResponse {
         transaction_id: "withdraw-full-001".to_string(),
-        account_id: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX".to_string(),
+        account_id: MOCK_ACCOUNT_ID.to_string(),
         memo: Some("WITHDRAWMEMO".to_string()),
         memo_type: Some("text".to_string()),
         min_amount: Some(10),


### PR DESCRIPTION
## Summary

This PR resolves four related issues across documentation, mock fixtures, and error code semantics.

### `src/lib.rs` — sep38 doc/visibility mismatch (#441, #456)

The crate-level module table incorrectly labelled `sep38` as `(internal)` despite the module being declared `pub mod sep38`. The entry now uses a doc-link `[\`sep38\`]` consistent with `sep6` and `sep24`, so rustdoc renders the module as a clickable reference and readers can discover the public SEP-38 API (types: `FirmQuote`, `RawPrice`, `QuoteConstraints`; functions: `request_firm_quote`, `select_best_quote`).

### `src/mock.rs` — invalid mock account IDs (#455)

Three mock response functions (`mock_withdrawal_response`, `mock_withdrawal_response_minimal`, `mock_withdrawal_response_full`) returned `account_id: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"`. Although the string is 56 characters and starts with `G`, the all-X body does not form a valid Stellar strkey checksum. Any pipeline that passes mock data through `validate_deposit_response` or `validate_withdraw_response` would fail with "account_id checksum is invalid".

All three occurrences now reference a new `MOCK_ACCOUNT_ID` constant set to the known-valid testnet address `GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN`.

### `src/errors.rs` + `src/contract.rs` — wrong error codes for non-attestation lookups (#457)

`get_audit_log` panicked with `AttestationNotFound` (code 17) when no audit-log record existed, and `advance_transaction_state_internal` did the same when a transaction-state record was missing. An attestation, an audit log, and a transaction-state record are distinct concepts; reusing `AttestationNotFound` confused callers reading error codes.

Two new error codes are added to the `ErrorCode` enum in the existing "item not found" group (codes 32–35, joining `SessionNotFound = 32` and `QuoteNotFound = 33`):
- `AuditLogNotFound = 34` — "Audit log not found"
- `TransactionNotFound = 35` — "Transaction record not found"

`get_audit_log` and `advance_transaction_state_internal` now panic with their respective codes. `AttestationNotFound` is now only raised by `get_attestation`, `get_attestation_by_hash`, and `verify_payload_hash` — the three functions that actually look up attestation records.

## Files changed

| File | Change |
|------|--------|
| `src/lib.rs` | Fix `sep38` table entry: `(internal)` → doc-link `[\`sep38\`]` |
| `src/mock.rs` | Add `MOCK_ACCOUNT_ID` constant; replace 3 invalid `GXXX…` account strings |
| `src/errors.rs` | Add `AuditLogNotFound = 34` and `TransactionNotFound = 35`; update `default_message()` |
| `src/contract.rs` | Use `AuditLogNotFound` in `get_audit_log`; use `TransactionNotFound` in `advance_transaction_state_internal` |

Closes #441
Closes #456
Closes #455
Closes #457