### PR TITLE
fix: eliminate env.clone(), expose txn state history, fix misleading errors, add rate-limit boundary tests

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1443,7 +1443,7 @@ impl AnchorKitContract {
         Self::require_admin(&env);
 
         let now = env.ledger().timestamp();
-        let old_version = Self::get_version(env.clone());
+        let old_version = Self::get_version_internal(&env);
 
         let old_hash_key = make_storage_key(&env, &[b"OLDHASH"]);
         let old_wasm_hash: BytesN<32> = env
@@ -2060,12 +2060,12 @@ impl AnchorKitContract {
         Self::verify_sep10_token_matches_attestor(&env, &sep10_token, &sep10_issuer, &attestor);
         
         // Check capacity
-        let config = Self::get_capacity_config(env.clone());
-        let current_count = Self::get_attestor_count(env.clone());
+        let config = Self::get_capacity_config_internal(&env);
+        let current_count = Self::get_attestor_count_internal(&env);
         if current_count >= config.max_attestors {
             panic_with_error!(&env, ErrorCode::AttestorCapacityExceeded);
         }
-        
+
         let xdr = attestor.clone().to_xdr(&env);
         let raw = xdr_to_vec(&xdr);
         let key = make_storage_key(&env, &[b"ATTESTOR", &raw]);
@@ -2140,7 +2140,7 @@ impl AnchorKitContract {
         env.storage().persistent().remove(&pk_key);
         
         // Decrement count
-        let current_count = Self::get_attestor_count(env.clone());
+        let current_count = Self::get_attestor_count_internal(&env);
         if current_count > 0 {
             env.storage().instance().set(&Self::attestor_count_key(&env), &(current_count - 1));
             env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
@@ -2247,9 +2247,7 @@ impl AnchorKitContract {
     /// println!("Endpoint: {}", profile.endpoint);
     /// ```
     pub fn get_attestor_profile(env: Env, attestor: Address) -> AttestorProfile {
-        if !Self::is_attestor(env.clone(), attestor.clone()) {
-            panic_with_error!(&env, ErrorCode::AttestorNotRegistered);
-        }
+        Self::check_attestor(&env, &attestor);
         Self::load_or_init_profile(&env, &attestor)
     }
 
@@ -2337,12 +2335,10 @@ impl AnchorKitContract {
     /// let endpoint = AnchorKitContract::get_endpoint(env, attestor);
     /// ```
     pub fn get_endpoint(env: Env, attestor: Address) -> String {
-        if !Self::is_attestor(env.clone(), attestor.clone()) {
-            panic_with_error!(&env, ErrorCode::AttestorNotRegistered);
-        }
+        Self::check_attestor(&env, &attestor);
         let profile = Self::load_or_init_profile(&env, &attestor);
         if profile.endpoint.len() == 0 {
-            panic_with_error!(&env, ErrorCode::AttestorNotRegistered);
+            panic_with_error!(&env, ErrorCode::EndpointNotSet);
         }
         profile.endpoint
     }
@@ -2427,12 +2423,10 @@ impl AnchorKitContract {
     /// let webhook = AnchorKitContract::get_webhook_url(env, attestor);
     /// ```
     pub fn get_webhook_url(env: Env, attestor: Address) -> String {
-        if !Self::is_attestor(env.clone(), attestor.clone()) {
-            panic_with_error!(&env, ErrorCode::AttestorNotRegistered);
-        }
+        Self::check_attestor(&env, &attestor);
         let profile = Self::load_or_init_profile(&env, &attestor);
         if profile.webhook_url.len() == 0 {
-            panic_with_error!(&env, ErrorCode::AttestorNotRegistered);
+            panic_with_error!(&env, ErrorCode::WebhookUrlNotSet);
         }
         profile.webhook_url
     }
@@ -2729,7 +2723,7 @@ impl AnchorKitContract {
     ///
     /// Vector of active service type codes.
     pub fn get_active_services(env: Env, anchor: Address) -> Vec<u32> {
-        let record = Self::get_supported_services(env.clone(), anchor);
+        let record = Self::get_supported_services_internal(&env, &anchor);
         let mut active = Vec::new(&env);
         for service in record.services.iter() {
             if !Self::is_service_retired(&record, service) {
@@ -2798,7 +2792,7 @@ impl AnchorKitContract {
     ///
     /// `Option<ServiceRetirementInfo>` with retirement metadata if found.
     pub fn get_service_retirement_info(env: Env, anchor: Address, service: u32) -> Option<ServiceRetirementInfo> {
-        let record = Self::get_supported_services(env, anchor);
+        let record = Self::get_supported_services_internal(&env, &anchor);
         for retirement in record.service_retirements.iter() {
             if retirement.service_code == service {
                 return Some(retirement);
@@ -2988,7 +2982,7 @@ impl AnchorKitContract {
         Self::check_timestamp(&env, timestamp);
 
         if require_kyc {
-            let kyc_status = Self::get_kyc_status(env.clone(), subject.clone());
+            let kyc_status = Self::get_kyc_status_internal(&env, &subject);
             if kyc_status != KycStatus::Approved {
                 match kyc_status {
                     KycStatus::Pending => panic_with_error!(&env, ErrorCode::KycPending),
@@ -4302,15 +4296,15 @@ impl AnchorKitContract {
         
         // Check capacity only if adding a new entry
         if !entry_exists {
-            let config = Self::get_capacity_config(env.clone());
-            let current_count = Self::get_cache_count(env.clone());
+            let config = Self::get_capacity_config_internal(&env);
+            let current_count = Self::get_cache_count_internal(&env);
             if current_count >= config.max_cache_entries {
                 panic_with_error!(&env, ErrorCode::CacheCapacityExceeded);
             }
         }
-        
+
         let now = env.ledger().timestamp();
-        let cfg = Self::get_cache_config(env.clone());
+        let cfg = Self::get_cache_config_internal(&env);
         let ttl = Self::effective_ttl(ttl_seconds, cfg.metadata_ttl_seconds);
         let entry = MetadataCache {
             metadata,
@@ -4322,10 +4316,10 @@ impl AnchorKitContract {
         let ledger_ttl = if ttl as u32 > MIN_TEMP_TTL { ttl as u32 } else { MIN_TEMP_TTL };
         env.storage().temporary().set(&key, &entry);
         env.storage().temporary().extend_ttl(&key, ledger_ttl, ledger_ttl);
-        
+
         // Increment count if new entry
         if !entry_exists {
-            let current_count = Self::get_cache_count(env.clone());
+            let current_count = Self::get_cache_count_internal(&env);
             env.storage().instance().set(&Self::cache_count_key(&env), &(current_count + 1));
             env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
         }
@@ -4372,15 +4366,15 @@ impl AnchorKitContract {
         
         // Check capacity only if adding a new entry
         if !entry_exists {
-            let config = Self::get_capacity_config(env.clone());
-            let current_count = Self::get_cache_count(env.clone());
+            let config = Self::get_capacity_config_internal(&env);
+            let current_count = Self::get_cache_count_internal(&env);
             if current_count >= config.max_cache_entries {
                 panic_with_error!(&env, ErrorCode::CacheCapacityExceeded);
             }
         }
-        
+
         let now = env.ledger().timestamp();
-        let cfg = Self::get_cache_config(env.clone());
+        let cfg = Self::get_cache_config_internal(&env);
         let ttl = Self::effective_ttl(ttl_seconds, cfg.metadata_ttl_seconds);
         let stale = Self::effective_ttl(stale_ttl_seconds, cfg.swr_ttl_seconds);
         let entry = MetadataCache {
@@ -4394,10 +4388,10 @@ impl AnchorKitContract {
         let ledger_ttl = if total_ttl as u32 > MIN_TEMP_TTL { total_ttl as u32 } else { MIN_TEMP_TTL };
         env.storage().temporary().set(&key, &entry);
         env.storage().temporary().extend_ttl(&key, ledger_ttl, ledger_ttl);
-        
+
         // Increment count if new entry
         if !entry_exists {
-            let current_count = Self::get_cache_count(env.clone());
+            let current_count = Self::get_cache_count_internal(&env);
             env.storage().instance().set(&Self::cache_count_key(&env), &(current_count + 1));
             env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
         }
@@ -4440,7 +4434,7 @@ impl AnchorKitContract {
     ) {
         Self::require_admin(&env);
         let now = env.ledger().timestamp();
-        let cfg = Self::get_cache_config(env.clone());
+        let cfg = Self::get_cache_config_internal(&env);
         let ttl = Self::effective_ttl(ttl_seconds, cfg.metadata_ttl_seconds);
         let stale = Self::effective_ttl(stale_ttl_seconds, cfg.swr_ttl_seconds);
         let entry = MetadataCache {
@@ -4550,24 +4544,24 @@ impl AnchorKitContract {
         
         // Check capacity only if adding a new entry
         if !entry_exists {
-            let config = Self::get_capacity_config(env.clone());
-            let current_count = Self::get_cache_count(env.clone());
+            let config = Self::get_capacity_config_internal(&env);
+            let current_count = Self::get_cache_count_internal(&env);
             if current_count >= config.max_cache_entries {
                 panic_with_error!(&env, ErrorCode::CacheCapacityExceeded);
             }
         }
-        
+
         let now = env.ledger().timestamp();
-        let cfg = Self::get_cache_config(env.clone());
+        let cfg = Self::get_cache_config_internal(&env);
         let ttl = Self::effective_ttl(ttl_seconds, cfg.capabilities_ttl_seconds);
         let entry = CapabilitiesCache { toml_url, capabilities, cached_at: now, ttl_seconds: ttl };
         let ledger_ttl = if ttl as u32 > MIN_TEMP_TTL { ttl as u32 } else { MIN_TEMP_TTL };
         env.storage().temporary().set(&key, &entry);
         env.storage().temporary().extend_ttl(&key, ledger_ttl, ledger_ttl);
-        
+
         // Increment count if new entry
         if !entry_exists {
-            let current_count = Self::get_cache_count(env.clone());
+            let current_count = Self::get_cache_count_internal(&env);
             env.storage().instance().set(&Self::cache_count_key(&env), &(current_count + 1));
             env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
         }
@@ -4969,7 +4963,7 @@ impl AnchorKitContract {
         let mut candidates: Vec<Quote> = Vec::new(&env);
         for anchor in anchors.iter() {
             // #296: Skip blacklisted anchors
-            if Self::is_anchor_blacklisted(env.clone(), anchor.clone()) {
+            if Self::is_anchor_blacklisted_internal(&env, &anchor) {
                 continue;
             }
 
@@ -5043,7 +5037,7 @@ impl AnchorKitContract {
 
         // Enforce KYC check (#439)
         if options.require_kyc {
-            let kyc_status = Self::get_kyc_status(env.clone(), options.subject.clone());
+            let kyc_status = Self::get_kyc_status_internal(&env, &options.subject);
             if kyc_status != KycStatus::Approved {
                 match kyc_status {
                     KycStatus::Pending      => panic_with_error!(&env, ErrorCode::KycPending),
@@ -5272,7 +5266,7 @@ impl AnchorKitContract {
             validate_asset_info(&env, &asset);
         }
         let now = env.ledger().timestamp();
-        let cfg = Self::get_cache_config(env.clone());
+        let cfg = Self::get_cache_config_internal(&env);
         let ttl = Self::effective_ttl(ttl_seconds, cfg.capabilities_ttl_seconds);
         let cached = CachedToml {
             toml: toml_data,
@@ -5349,7 +5343,7 @@ impl AnchorKitContract {
     }
 
     pub fn get_anchor_assets(env: Env, anchor: Address) -> Vec<String> {
-        let toml = Self::get_anchor_toml(env.clone(), anchor);
+        let toml = Self::get_anchor_toml_internal(&env, &anchor);
         let mut assets = Vec::new(&env);
         for asset in toml.currencies.iter() {
             assets.push_back(asset.code.clone());
@@ -5362,7 +5356,7 @@ impl AnchorKitContract {
         anchor: Address,
         asset_code: String,
     ) -> AssetInfo {
-        let toml = Self::get_anchor_toml(env.clone(), anchor);
+        let toml = Self::get_anchor_toml_internal(&env, &anchor);
         for asset in toml.currencies.iter() {
             if asset.code == asset_code {
                 return asset;
@@ -5512,6 +5506,24 @@ impl AnchorKitContract {
         Self::advance_transaction_state_internal(&env, transaction_id, TransactionState::Failed, Some(error_message))
     }
 
+    /// Return the full state-transition history for a transaction record.
+    ///
+    /// Each entry is `(state, ledger_timestamp)` in chronological order.
+    /// Panics with [`ErrorCode::AttestationNotFound`] if no record exists for
+    /// `transaction_id`.
+    pub fn get_txn_state_history(
+        env: Env,
+        transaction_id: u64,
+    ) -> soroban_sdk::Vec<(TransactionState, u64)> {
+        let key = (symbol_short!("TXSTATE"), transaction_id);
+        let record: TransactionStateRecord = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestationNotFound));
+        record.state_history
+    }
+
     fn advance_transaction_state_internal(
         env: &Env,
         transaction_id: u64,
@@ -5568,7 +5580,7 @@ impl AnchorKitContract {
     pub fn set_rate_limit_config(env: Env, max_submissions: u32, window_length: u32) {
         Self::require_admin(&env);
         let config = crate::rate_limiter::RateLimitConfig { max_submissions, window_length };
-        RateLimiter::update_config(&env, &Self::get_admin(env.clone()), &config)
+        RateLimiter::update_config(&env, &Self::get_admin_internal(&env), &config)
             .unwrap_or_else(|_| panic_with_error!(&env, ErrorCode::ValidationError));
     }
 
@@ -5698,6 +5710,117 @@ impl AnchorKitContract {
         {
             panic_with_error!(env, ErrorCode::AttestorNotRegistered);
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Private &Env helpers — avoid env.clone() at internal call sites
+    // ------------------------------------------------------------------
+
+    fn get_version_internal(env: &Env) -> ContractVersion {
+        env.storage()
+            .instance()
+            .get::<_, ContractVersion>(&Self::version_key(env))
+            .unwrap_or(ContractVersion { major: 0, minor: 1, patch: 0, upgraded_at: 0 })
+    }
+
+    fn get_admin_internal(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get::<_, Address>(&admin_key(env))
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::NotInitialized))
+    }
+
+    fn get_capacity_config_internal(env: &Env) -> CapacityConfig {
+        env.storage()
+            .instance()
+            .get::<_, CapacityConfig>(&Self::capacity_config_key(env))
+            .unwrap_or_else(CapacityConfig::default_config)
+    }
+
+    fn get_attestor_count_internal(env: &Env) -> u64 {
+        env.storage()
+            .instance()
+            .get::<_, u64>(&Self::attestor_count_key(env))
+            .unwrap_or(0)
+    }
+
+    fn get_cache_count_internal(env: &Env) -> u64 {
+        env.storage()
+            .instance()
+            .get::<_, u64>(&Self::cache_count_key(env))
+            .unwrap_or(0)
+    }
+
+    fn get_cache_config_internal(env: &Env) -> CacheConfig {
+        env.storage()
+            .instance()
+            .get::<_, CacheConfig>(&Self::cache_config_key(env))
+            .unwrap_or_else(CacheConfig::default_config)
+    }
+
+    fn is_attestor_internal(env: &Env, attestor: &Address) -> bool {
+        let xdr = attestor.clone().to_xdr(env);
+        let raw = xdr_to_vec(&xdr);
+        env.storage()
+            .persistent()
+            .get::<_, bool>(&make_storage_key(env, &[b"ATTESTOR", &raw]))
+            .unwrap_or(false)
+    }
+
+    fn get_supported_services_internal(env: &Env, anchor: &Address) -> AnchorServices {
+        let xdr = anchor.clone().to_xdr(env);
+        let raw = xdr_to_vec(&xdr);
+        env.storage()
+            .persistent()
+            .get::<_, AnchorServices>(&make_storage_key(env, &[b"SERVICES", &raw]))
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::ServicesNotConfigured))
+    }
+
+    fn get_kyc_status_internal(env: &Env, subject: &Address) -> KycStatus {
+        let key = kyc_record_key(env, subject);
+        if !env.storage().persistent().has(&key) {
+            return KycStatus::NotSubmitted;
+        }
+        let record: KycRecord = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::KycNotFound));
+        if let Some(expiry) = record.expiry {
+            if env.ledger().timestamp() > expiry {
+                return KycStatus::Expired;
+            }
+        }
+        match record.status {
+            0 => KycStatus::NotSubmitted,
+            1 => KycStatus::Pending,
+            2 => KycStatus::Approved,
+            3 => KycStatus::Rejected,
+            4 => KycStatus::Expired,
+            _ => KycStatus::NotSubmitted,
+        }
+    }
+
+    fn is_anchor_blacklisted_internal(env: &Env, anchor: &Address) -> bool {
+        let key = anchor_blacklist_key(env, anchor);
+        env.storage()
+            .persistent()
+            .get::<_, AnchorBlacklistEntry>(&key)
+            .is_some()
+    }
+
+    fn get_anchor_toml_internal(env: &Env, anchor: &Address) -> StellarToml {
+        let key = (symbol_short!("TOMLCACHE"), anchor.clone());
+        let cached: CachedToml = env
+            .storage()
+            .temporary()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(env, ErrorCode::CacheNotFound));
+        let now = env.ledger().timestamp();
+        if cached.cached_at + cached.ttl_seconds <= now {
+            panic_with_error!(env, ErrorCode::CacheExpired);
+        }
+        cached.toml
     }
 
     fn soroban_string_to_rust_string(env: &Env, value: &String) -> RustString {
@@ -5912,7 +6035,7 @@ impl AnchorKitContract {
     /// and per-service availability. Does not mutate any contract state.
     pub fn get_anchor_readiness(env: Env, anchor: Address) -> AnchorReadinessReport {
         let now = env.ledger().timestamp();
-        let is_registered = Self::is_attestor(env.clone(), anchor.clone());
+        let is_registered = Self::is_attestor_internal(&env, &anchor);
 
         let xdr = anchor.clone().to_xdr(&env);
         let raw = xdr_to_vec(&xdr);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -113,6 +113,12 @@ pub enum ErrorCode {
     InvalidSessionMetadata    = 52,
     /// Asset code is empty, too long, or contains invalid characters.
     InvalidAssetCode          = 53,
+
+    // URL-not-set errors (56–57)
+    /// Attestor has no endpoint URL set (profile exists but field is empty).
+    EndpointNotSet            = 56,
+    /// Attestor has no webhook URL set (profile exists but field is empty).
+    WebhookUrlNotSet          = 57,
 }
 
 impl ErrorCode {
@@ -174,6 +180,8 @@ impl ErrorCode {
             ErrorCode::InvalidSessionMetadata    => "Session metadata is invalid",
             ErrorCode::InvalidAssetCode          => "Asset code is invalid",
             ErrorCode::QuoteNotFound             => "Quote not found",
+            ErrorCode::EndpointNotSet            => "Attestor endpoint URL has not been set",
+            ErrorCode::WebhookUrlNotSet          => "Attestor webhook URL has not been set",
         }
     }
 }
@@ -348,6 +356,8 @@ impl AnchorKitError {
     pub fn invalid_request_context() -> Self { Self::from_code(ErrorCode::InvalidRequestContext) }
     pub fn invalid_session_metadata() -> Self { Self::from_code(ErrorCode::InvalidSessionMetadata) }
     pub fn quote_not_found() -> Self { Self::from_code(ErrorCode::QuoteNotFound) }
+    pub fn endpoint_not_set() -> Self { Self::from_code(ErrorCode::EndpointNotSet) }
+    pub fn webhook_url_not_set() -> Self { Self::from_code(ErrorCode::WebhookUrlNotSet) }
     pub fn invalid_asset_code(code: &str) -> Self {
         Self::with_context(
             ErrorCode::InvalidAssetCode,

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -632,6 +632,123 @@ mod tests {
     /// If the stored window_start_ledger is somehow *ahead* of the current ledger
     /// (sequence anomaly), the window must be treated as NOT expired so that the
     /// existing submission count is preserved and the rate-limit cannot be bypassed.
+    /// count == max_submissions is the exact rejection threshold: max-1 succeeds,
+    /// max is rejected.  Isolates the off-by-one boundary in the >= check.
+    #[test]
+    fn test_at_limit_exact_last_allowed_then_rejected() {
+        let env = Env::default();
+        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let config = RateLimitConfig { max_submissions: 3, window_length: 100 };
+        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_id = env.register_contract(&contract_address, crate::contract::AnchorKitContract);
+
+        // Submissions 1 through max_submissions-1 must all succeed.
+        for _ in 0..2 {
+            assert!(env.as_contract(&contract_id, &|| {
+                RateLimiter::check_and_increment(&env, &attestor, &config)
+            }).is_ok());
+        }
+
+        // The max_submissions-th call is the LAST allowed — must succeed.
+        assert!(env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        }).is_ok(), "submission at count == max_submissions-1 must succeed");
+
+        // Now count == max_submissions; the next call must be rejected.
+        let result = env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        });
+        assert!(result.is_err(), "submission at count == max_submissions must be rejected");
+        assert_eq!(result.unwrap_err().code, ErrorCode::RateLimitExceeded);
+
+        // State must be capped — no overflow past max.
+        let state = env.as_contract(&contract_id, &|| RateLimiter::get_state(&env, &attestor));
+        assert_eq!(state.submission_count, 3, "count must not exceed max_submissions");
+    }
+
+    /// Every call after the limit (count > max_submissions) must still return
+    /// RateLimitExceeded and must not mutate the stored count.
+    #[test]
+    fn test_one_over_limit_state_stays_capped() {
+        let env = Env::default();
+        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let config = RateLimitConfig { max_submissions: 2, window_length: 100 };
+        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_id = env.register_contract(&contract_address, crate::contract::AnchorKitContract);
+
+        // Fill the window.
+        env.as_contract(&contract_id, &|| { RateLimiter::check_and_increment(&env, &attestor, &config).unwrap(); });
+        env.as_contract(&contract_id, &|| { RateLimiter::check_and_increment(&env, &attestor, &config).unwrap(); });
+
+        // count == max: first rejection (one-over).
+        let err1 = env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        }).unwrap_err();
+        assert_eq!(err1.code, ErrorCode::RateLimitExceeded);
+
+        // count still == max: second rejection (two-over) — state must not have changed.
+        let err2 = env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        }).unwrap_err();
+        assert_eq!(err2.code, ErrorCode::RateLimitExceeded);
+
+        let state = env.as_contract(&contract_id, &|| RateLimiter::get_state(&env, &attestor));
+        assert_eq!(state.submission_count, 2, "count must remain at max after over-limit calls");
+    }
+
+    /// A submission at ledger window_start + window_length - 1 (one before expiry)
+    /// must still be rejected, while one at window_start + window_length is in the
+    /// new window and must succeed.  Pins the exact >=/> boundary in is_window_expired.
+    #[test]
+    fn test_window_one_before_expiry_still_restricted() {
+        let env = Env::default();
+        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let config = RateLimitConfig { max_submissions: 1, window_length: 10 };
+        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_id = env.register_contract(&contract_address, crate::contract::AnchorKitContract);
+
+        // Consume the sole slot at ledger 0.
+        assert!(env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        }).is_ok());
+
+        // Advance to one ledger BEFORE the window expires (delta = window_length - 1 = 9).
+        env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+            sequence_number: 9,
+            timestamp: 900,
+            protocol_version: 21,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+
+        // delta = 9 < window_length = 10 → still in old window → must be rejected.
+        let result = env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        });
+        assert!(result.is_err(), "submission at window_start + window_length - 1 must be rejected");
+        assert_eq!(result.unwrap_err().code, ErrorCode::RateLimitExceeded);
+
+        // Advance to exactly window_start + window_length (delta = 10 = window_length → expired).
+        env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+            sequence_number: 10,
+            timestamp: 1000,
+            protocol_version: 21,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+
+        // New window → must succeed.
+        assert!(env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        }).is_ok(), "submission at window_start + window_length must start a new window");
+    }
+
     #[test]
     fn test_window_not_expired_when_current_less_than_start() {
         // current < window_start → checked_sub underflows → None → false


### PR DESCRIPTION
Addresses four low-severity issues in a single cohesive change.

## Changes

### #425 — Remove unnecessary `env.clone()` throughout `contract.rs`
Added ten private `_internal` helpers (`get_version_internal`, `get_admin_internal`, `get_capacity_config_internal`, `get_attestor_count_internal`, `get_cache_count_internal`, `get_cache_config_internal`, `is_attestor_internal`, `get_supported_services_internal`, `get_kyc_status_internal`, `is_anchor_blacklisted_internal`, `get_anchor_toml_internal`) that accept `&Env` instead of an owned `Env`. Migrated all ~40 internal call sites to use them, eliminating every unnecessary clone.

### #422 — Expose `state_history` via `get_txn_state_history`
Added `get_txn_state_history(env, transaction_id) -> Vec<(TransactionState, u64)>` so callers can actually read the state-transition history stored inside every `TransactionStateRecord`. Previously the data was written to persistent storage on every transaction but was completely unreachable from outside the contract.

### #428 — Fix misleading `AttestorNotRegistered` errors in `get_endpoint` / `get_webhook_url`
When an attestor exists but has never configured a URL, both functions panicked with `AttestorNotRegistered` — making it impossible for callers to tell the difference from a truly missing attestor. Introduced two new error codes (`EndpointNotSet = 56`, `WebhookUrlNotSet = 57`) and wired them in. Also extracted a `check_attestor` private helper to consolidate the repeated is-registered guard.

### #429 — Add rate-limiter off-by-one boundary tests
Three new tests pin the exact boundaries most likely to hide off-by-one errors:
- `test_at_limit_exact_last_allowed_then_rejected` — submission `max_submissions - 1` succeeds; submission `max_submissions` is rejected; stored count stays capped.
- `test_one_over_limit_state_stays_capped` — repeated calls past the limit all return `RateLimitExceeded` without mutating the stored count.
- `test_window_one_before_expiry_still_restricted` — ledger at `window_start + window_length - 1` is still in the old window (rejected); ledger at `window_start + window_length` starts a new window (accepted).

## Test plan
- [ ] `cargo test` passes with all three new rate-limiter tests green
- [ ] `get_txn_state_history` returns chronological history for a known transaction ID
- [ ] Calling `get_endpoint` on a registered attestor with no URL set returns `EndpointNotSet` (not `AttestorNotRegistered`)
- [ ] Calling `get_webhook_url` on a registered attestor with no URL set returns `WebhookUrlNotSet`
- [ ] No `env.clone()` calls remain at internal call sites in `contract.rs`

closes #425 closes #422  closes #428 closes #429 