### PR TITLE
Wire admin audit log & service manager into contract; dedupe webhook retry config (#448, #449, #450)

### DIFF
--- a/src/admin_audit_log.rs
+++ b/src/admin_audit_log.rs
@@ -88,13 +88,60 @@ impl AdminAuditLog {
         status: &str,
         error_message: &str,
     ) {
+        Self::write_event(
+            env,
+            admin,
+            String::from_str(env, change_type),
+            String::from_str(env, target),
+            String::from_str(env, old_value),
+            String::from_str(env, new_value),
+            String::from_str(env, status),
+            String::from_str(env, error_message),
+        );
+    }
+
+    /// Log an admin configuration change where `target` is an on-chain value
+    /// already rendered as a Soroban [`String`] (for example `addr.to_string()`).
+    ///
+    /// This mirrors [`Self::log_change`] but avoids forcing callers inside the
+    /// `no_std` contract to materialise a `&str` for an [`Address`] target. It
+    /// is the entry point used by `contract.rs` to record admin operations.
+    pub fn log_action(
+        env: &Env,
+        admin: &Address,
+        change_type: &str,
+        target: String,
+        old_value: &str,
+        new_value: &str,
+    ) {
+        Self::write_event(
+            env,
+            admin,
+            String::from_str(env, change_type),
+            target,
+            String::from_str(env, old_value),
+            String::from_str(env, new_value),
+            String::from_str(env, "success"),
+            String::from_str(env, ""),
+        );
+    }
+
+    /// Core audit-entry writer shared by the public logging helpers.
+    ///
+    /// All string fields are already materialised as Soroban [`String`]s so this
+    /// function never has to assume the target is a `&str`.
+    fn write_event(
+        env: &Env,
+        admin: &Address,
+        change_type: String,
+        target: String,
+        old_value: String,
+        new_value: String,
+        status: String,
+        error_message: String,
+    ) {
         // Check if audit logging is enabled
-        let config_key = soroban_sdk::Symbol::new(env, "ADMIN_AUDIT_CFG");
-        let config: AdminAuditLogConfig = env
-            .storage()
-            .instance()
-            .get(&config_key)
-            .unwrap_or_else(|| AdminAuditLogConfig::default());
+        let config = Self::get_config(env);
 
         if !config.enabled {
             return;
@@ -118,13 +165,13 @@ impl AdminAuditLog {
         let event = AdminConfigChangeEvent {
             entry_id,
             admin: admin.clone(),
-            change_type: String::from_str(env, change_type),
-            target: String::from_str(env, target),
-            old_value: String::from_str(env, old_value),
-            new_value: String::from_str(env, new_value),
+            change_type,
+            target,
+            old_value,
+            new_value,
             timestamp: env.ledger().timestamp(),
-            status: String::from_str(env, status),
-            error_message: String::from_str(env, error_message),
+            status,
+            error_message,
         };
 
         // Store the event using entry_id as part of the key

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -12,6 +12,8 @@ use crate::rate_limiter::RateLimiter;
 use crate::sep10_jwt;
 use crate::transaction_state_tracker::{OptRecovery, TransactionState, TransactionStateRecord};
 use crate::replay_detection;
+use crate::admin_audit_log::AdminAuditLog;
+use crate::service_management::ServiceManager;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1330,6 +1332,14 @@ impl AnchorKitContract {
         let key = role_key(&env, role, &grantee);
         env.storage().persistent().set(&key, &true);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        AdminAuditLog::log_action(
+            &env,
+            &Self::get_admin_internal(&env),
+            "grant_role",
+            grantee.to_string(),
+            "",
+            Self::role_name(role),
+        );
         env.events().publish(
             (symbol_short!("role"), symbol_short!("granted"), grantee),
             role as u32,
@@ -1345,6 +1355,14 @@ impl AnchorKitContract {
         if env.storage().persistent().has(&key) {
             env.storage().persistent().remove(&key);
         }
+        AdminAuditLog::log_action(
+            &env,
+            &Self::get_admin_internal(&env),
+            "revoke_role",
+            grantee.to_string(),
+            Self::role_name(role),
+            "",
+        );
         env.events().publish(
             (symbol_short!("role"), symbol_short!("revoked"), grantee),
             role as u32,
@@ -2097,7 +2115,16 @@ impl AnchorKitContract {
         // Increment count
         env.storage().instance().set(&Self::attestor_count_key(&env), &(current_count + 1));
         env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
-        
+
+        AdminAuditLog::log_action(
+            &env,
+            &Self::get_admin_internal(&env),
+            "register_attestor",
+            attestor.to_string(),
+            "",
+            "registered",
+        );
+
         env.events().publish(
             (symbol_short!("attestor"), symbol_short!("added"), attestor),
             (),
@@ -2157,7 +2184,16 @@ impl AnchorKitContract {
             env.storage().instance().set(&Self::attestor_count_key(&env), &(current_count - 1));
             env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
         }
-        
+
+        AdminAuditLog::log_action(
+            &env,
+            &Self::get_admin_internal(&env),
+            "revoke_attestor",
+            attestor.to_string(),
+            "registered",
+            "revoked",
+        );
+
         env.events().publish(
             (symbol_short!("attestor"), symbol_short!("removed"), attestor),
             (),
@@ -2315,6 +2351,14 @@ impl AnchorKitContract {
         profile.endpoint = endpoint.clone();
         profile.updated_at = now;
         Self::save_profile(&env, &profile);
+        AdminAuditLog::log_action(
+            &env,
+            &attestor,
+            "set_endpoint",
+            attestor.to_string(),
+            "",
+            "updated",
+        );
         env.events().publish(
             (symbol_short!("endpoint"), symbol_short!("updated")),
             EndpointUpdated { attestor, endpoint },
@@ -2904,6 +2948,109 @@ impl AnchorKitContract {
         env.storage().persistent().set(&key, &record);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
         env.events().publish((symbol_short!("services"), symbol_short!("unretire")), (anchor, service));
+    }
+
+    // -----------------------------------------------------------------------
+    // Service enable/disable toggles & rollback (#449)
+    //
+    // These entry points expose the [`ServiceManager`] toggle/snapshot store
+    // on-chain. They complement `configure_services` (which records an anchor's
+    // declared capability set) by letting admins flip individual services on or
+    // off at runtime and roll back to a prior snapshot without re-declaring the
+    // whole set.
+    // -----------------------------------------------------------------------
+
+    /// Enable a single service for `anchor`. Returns `false` if it was already
+    /// enabled. Requires the primary admin.
+    pub fn enable_service(env: Env, anchor: Address, service_code: u32) -> bool {
+        Self::require_admin(&env);
+        let changed = ServiceManager::enable_service(&env, &anchor, service_code);
+        AdminAuditLog::log_action(
+            &env,
+            &Self::get_admin_internal(&env),
+            "enable_service",
+            anchor.to_string(),
+            "disabled",
+            "enabled",
+        );
+        changed
+    }
+
+    /// Disable a single service for `anchor`. Returns `false` if it was already
+    /// disabled. Requires the primary admin.
+    pub fn disable_service(env: Env, anchor: Address, service_code: u32) -> bool {
+        Self::require_admin(&env);
+        let changed = ServiceManager::disable_service(&env, &anchor, service_code);
+        AdminAuditLog::log_action(
+            &env,
+            &Self::get_admin_internal(&env),
+            "disable_service",
+            anchor.to_string(),
+            "enabled",
+            "disabled",
+        );
+        changed
+    }
+
+    /// Returns `true` if `service_code` is currently enabled for `anchor` in the
+    /// [`ServiceManager`] toggle store.
+    pub fn is_service_enabled(env: Env, anchor: Address, service_code: u32) -> bool {
+        ServiceManager::is_service_enabled(&env, &anchor, service_code)
+    }
+
+    /// Read the full toggle state (enabled + disabled services) for `anchor`.
+    pub fn get_service_toggle_state(
+        env: Env,
+        anchor: Address,
+    ) -> crate::service_management::ServiceToggleState {
+        ServiceManager::get_service_state(&env, &anchor)
+    }
+
+    /// Take a snapshot of `services` for `anchor` so it can later be restored
+    /// via [`Self::rollback_services`]. Returns the new snapshot id. Requires
+    /// the primary admin.
+    pub fn snapshot_services(
+        env: Env,
+        anchor: Address,
+        services: Vec<u32>,
+        description: String,
+    ) -> u64 {
+        Self::require_admin(&env);
+        let desc = Self::soroban_string_to_rust_string(&env, &description);
+        let snapshot_id = ServiceManager::create_snapshot(&env, &anchor, &services, desc.as_str());
+        AdminAuditLog::log_action(
+            &env,
+            &Self::get_admin_internal(&env),
+            "snapshot_services",
+            anchor.to_string(),
+            "",
+            "snapshot_taken",
+        );
+        snapshot_id
+    }
+
+    /// Restore the service toggle state captured in `snapshot_id`. Returns
+    /// `false` if no such snapshot exists. Requires the primary admin.
+    pub fn rollback_services(env: Env, snapshot_id: u64) -> bool {
+        Self::require_admin(&env);
+        let restored = ServiceManager::rollback_to_snapshot(&env, snapshot_id);
+        AdminAuditLog::log_action(
+            &env,
+            &Self::get_admin_internal(&env),
+            "rollback_services",
+            String::from_str(&env, "service_snapshot"),
+            "",
+            "rolled_back",
+        );
+        restored
+    }
+
+    /// Fetch a previously taken service snapshot by id, if it exists.
+    pub fn get_service_snapshot(
+        env: Env,
+        snapshot_id: u64,
+    ) -> Option<crate::service_management::ServiceConfigSnapshot> {
+        ServiceManager::get_snapshot(&env, snapshot_id)
     }
 
     // -----------------------------------------------------------------------
@@ -3502,6 +3649,14 @@ impl AnchorKitContract {
         record.expiry = Some(now + KYC_EXPIRY_SECONDS);
         env.storage().persistent().set(&key, &record);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        AdminAuditLog::log_action(
+            &env,
+            &operator,
+            "approve_kyc",
+            subject.to_string(),
+            "Pending",
+            "Approved",
+        );
         env.events().publish(
             (symbol_short!("kyc"), symbol_short!("approved"), subject),
             WebhookEvent {
@@ -3530,6 +3685,14 @@ impl AnchorKitContract {
         record.rejection_reason_hash = Some(reason_hash.clone());
         env.storage().persistent().set(&key, &record);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        AdminAuditLog::log_action(
+            &env,
+            &operator,
+            "reject_kyc",
+            subject.to_string(),
+            "Pending",
+            "Rejected",
+        );
         env.events().publish(
             (symbol_short!("kyc"), symbol_short!("rejected"), subject),
             WebhookEvent {
@@ -4858,6 +5021,14 @@ impl AnchorKitContract {
         env.storage()
             .persistent()
             .extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        AdminAuditLog::log_action(
+            &env,
+            &Self::get_admin_internal(&env),
+            "blacklist_anchor",
+            anchor.to_string(),
+            "active",
+            "blacklisted",
+        );
         env.events().publish(
             (symbol_short!("anchor"), symbol_short!("blacklist")),
             anchor,
@@ -4878,6 +5049,14 @@ impl AnchorKitContract {
         Self::require_admin(&env);
         let key = anchor_blacklist_key(&env, &anchor);
         env.storage().persistent().remove(&key);
+        AdminAuditLog::log_action(
+            &env,
+            &Self::get_admin_internal(&env),
+            "remove_from_blacklist",
+            anchor.to_string(),
+            "blacklisted",
+            "active",
+        );
         env.events().publish(
             (symbol_short!("anchor"), symbol_short!("unblklist")),
             anchor,
@@ -5616,8 +5795,17 @@ impl AnchorKitContract {
     pub fn set_rate_limit_config(env: Env, max_submissions: u32, window_length: u32) {
         Self::require_admin(&env);
         let config = crate::rate_limiter::RateLimitConfig { max_submissions, window_length };
-        RateLimiter::update_config(&env, &Self::get_admin_internal(&env), &config)
+        let admin = Self::get_admin_internal(&env);
+        RateLimiter::update_config(&env, &admin, &config)
             .unwrap_or_else(|_| panic_with_error!(&env, ErrorCode::ValidationError));
+        AdminAuditLog::log_action(
+            &env,
+            &admin,
+            "set_rate_limit_config",
+            String::from_str(&env, "rate_limiter"),
+            "",
+            "updated",
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -5656,6 +5844,15 @@ impl AnchorKitContract {
             .get::<_, Address>(&admin_key(env))
             .unwrap_or_else(|| panic_with_error!(env, ErrorCode::NotInitialized));
         admin.require_auth();
+    }
+
+    /// Stable human-readable name for an [`AdminRole`], used in audit entries.
+    fn role_name(role: AdminRole) -> &'static str {
+        match role {
+            AdminRole::KycAdmin => "KycAdmin",
+            AdminRole::AttestorAdmin => "AttestorAdmin",
+            AdminRole::CacheAdmin => "CacheAdmin",
+        }
     }
 
     /// Returns `true` if `address` holds `role` OR is the primary admin.

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -3890,6 +3890,12 @@ impl AnchorKitContract {
             .persistent()
             .get(&sess_key)
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::SessionNotFound));
+        // #447: only the address that created the session may close it.
+        // `initiator.require_auth()` alone proves the *supplied* address signed,
+        // not that it owns this session, so verify ownership explicitly.
+        if initiator != session.initiator {
+            panic_with_error!(&env, ErrorCode::UnauthorizedAttestor);
+        }
         Self::validate_session(&env, &session);
         session.closed = true;
         env.storage().persistent().set(&sess_key, &session);

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -221,8 +221,6 @@ pub fn fetch_stellar_toml_with_proxy(
 ///
 /// let config = WebhookDeliveryConfig {
 ///     endpoint_url: "https://hooks.example.com/anchor".to_string(),
-///     max_retries: 3,
-///     retry_delay_ms: 100,
 ///     timeout_ms: 5000,
 ///     retry_config: RetryConfig::default(),
 ///     dead_letter_storage_key: "anchor-hook".to_string(),
@@ -413,8 +411,6 @@ mod tests {
         // avoid real network calls in unit tests.
         let config = WebhookDeliveryConfig {
             endpoint_url: "https://hooks.example.com/anchor".to_string(),
-            max_retries: 3,
-            retry_delay_ms: 0,
             timeout_ms: 1000,
             retry_config: RetryConfig {
                 max_attempts: 3,
@@ -453,8 +449,6 @@ mod tests {
 
         let config = WebhookDeliveryConfig {
             endpoint_url: "https://hooks.example.com/anchor".to_string(),
-            max_retries: 2,
-            retry_delay_ms: 0,
             timeout_ms: 1000,
             retry_config: RetryConfig {
                 max_attempts: 2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,8 @@ pub use sep24::{
     RawInteractiveDepositResponse, RawInteractiveWithdrawalResponse, RawSep24TransactionResponse,
 };
 pub use contract::{ServiceRetirementInfo, AnchorServices};
+pub use service_management::{ServiceManager, ServiceToggleState, ServiceConfigSnapshot};
+pub use admin_audit_log::{AdminAuditLog, AdminConfigChangeEvent, AdminAuditLogConfig};
 pub use contract::{HealthStatus, MetadataFreshnessReport, RateLimiterHealth};
 pub use contract::{AnchorHealthMetrics, AnchorProofRecord};
 pub use transaction_state_tracker::{BudgetStatus, BudgetAlert};

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -29,17 +29,19 @@ use crate::{
 // ---------------------------------------------------------------------------
 
 /// Configuration for a single webhook endpoint.
+///
+/// Retry behaviour is fully described by [`RetryConfig`]: `retry_config.max_attempts`
+/// is the single source of truth for how many delivery attempts are made, and
+/// `retry_config.base_delay_ms` (with the multiplier/cap) controls the backoff
+/// delay. There are intentionally no separate `max_retries` / `retry_delay_ms`
+/// fields — they previously duplicated `RetryConfig` and could silently disagree.
 #[derive(Clone, Debug)]
 pub struct WebhookDeliveryConfig {
     /// Target URL for the HTTP POST.
     pub endpoint_url: String,
-    /// Maximum delivery attempts (passed straight to `RetryConfig::max_attempts`).
-    pub max_retries: u32,
-    /// Base delay between retries in milliseconds.
-    pub retry_delay_ms: u64,
     /// Per-attempt timeout in milliseconds (informational; enforced by `http_post`).
     pub timeout_ms: u64,
-    /// Backoff parameters (base delay, multiplier, cap).
+    /// Backoff parameters: max attempts, base delay, multiplier, cap.
     pub retry_config: RetryConfig,
     /// Key under which failed entries are stored in the DLQ map.
     pub dead_letter_storage_key: String,
@@ -92,8 +94,7 @@ where
     S: FnMut(u64),
     T: Fn() -> u64,
 {
-    let mut retry_cfg = config.retry_config.clone();
-    retry_cfg.max_attempts = config.max_retries;
+    let retry_cfg = config.retry_config.clone();
 
     let last_error_msg: RefCell<String> = RefCell::new(String::new());
     let last_status: RefCell<u16> = RefCell::new(0);
@@ -128,11 +129,12 @@ where
         Err(e) => {
             let last = last_error_msg.into_inner();
             let status = last_status.into_inner();
+            let attempts_made = config.retry_config.max_attempts;
             let entry = DlqEntry {
                 payload: payload.to_string(),
                 failed_at_timestamp: now_fn(),
                 last_status_code: status,
-                attempts_made: config.max_retries,
+                attempts_made,
                 last_error: last.clone(),
             };
             dlq.entry(config.dead_letter_storage_key.clone())
@@ -143,9 +145,9 @@ where
                 ErrorCode::WebhookDeliveryFailed,
                 &format!(
                     "Webhook delivery failed after {} attempt(s): {}",
-                    config.max_retries, e
+                    attempts_made, e
                 ),
-                &format!("attempts_made={} last_status={} last_error={}", config.max_retries, status, last),
+                &format!("attempts_made={} last_status={} last_error={}", attempts_made, status, last),
             ))
         }
     }
@@ -202,8 +204,6 @@ mod tests {
     fn make_config(max_retries: u32) -> WebhookDeliveryConfig {
         WebhookDeliveryConfig {
             endpoint_url: "https://example.com/hook".to_string(),
-            max_retries,
-            retry_delay_ms: 10,
             timeout_ms: 1000,
             retry_config: RetryConfig {
                 max_attempts: max_retries,

--- a/tests/webhook_middleware_tests.rs
+++ b/tests/webhook_middleware_tests.rs
@@ -13,8 +13,6 @@ mod webhook_middleware_tests {
     fn config(max_retries: u32) -> WebhookDeliveryConfig {
         WebhookDeliveryConfig {
             endpoint_url: "https://example.com/hook".into(),
-            max_retries,
-            retry_delay_ms: 0,
             timeout_ms: 1000,
             retry_config: RetryConfig::new(max_retries, 0, 0, 1),
             dead_letter_storage_key: "test_dlq".into(),


### PR DESCRIPTION
## Summary

Three related defects where utility modules existed but were never connected to the contract surface (or carried duplicated config). Each is now wired in and consistent.

### #448 — Admin audit log was never called from `contract.rs`
`AdminAuditLog::log_change` existed but no admin operation invoked it, so there was no actual audit trail. Admin operations now write an audit entry:

- `grant_role`, `revoke_role`
- `register_attestor`, `revoke_attestor`
- `set_endpoint`
- `approve_kyc`, `reject_kyc`
- `blacklist_anchor`, `remove_from_blacklist`
- `set_rate_limit_config`

Added `AdminAuditLog::log_action`, which accepts a Soroban `String` target so on-chain addresses (`addr.to_string()`) can be logged directly without materialising a `&str`. The existing `&str` helpers (`log_change` / `log_change_with_status`) were refactored onto a shared private `write_event` core — public behaviour and storage layout are unchanged, so existing tests keep passing.

### #449 — `ServiceManager` toggle/rollback features were orphaned
None of the `ServiceManager` methods were reachable on-chain. Added contract entry points that wire them in (all admin-gated and audited):

- `enable_service`, `disable_service`
- `is_service_enabled`, `get_service_toggle_state`
- `snapshot_services`, `rollback_services`, `get_service_snapshot`

These complement the existing `configure_services` capability declaration by letting admins flip individual services at runtime and roll back to a prior snapshot.

### #450 — Redundant webhook retry fields
Removed `max_retries` and `retry_delay_ms` from `WebhookDeliveryConfig`. They duplicated `RetryConfig` — `max_retries` silently overrode `retry_config.max_attempts`, and `retry_delay_ms` was never read. `RetryConfig` (`max_attempts` / `base_delay_ms`) is now the single source of truth. Updated all constructors and docs.

Closes #448
Closes #449
Closes #450
Closes #447 