### PR TITLE
fix: correct domain min length check and add SEP-38 numeric validation

### DIFF
--- a/src/domain_validator.rs
+++ b/src/domain_validator.rs
@@ -82,8 +82,8 @@ pub fn validate_anchor_domain(domain: &str) -> Result<(), AnchorKitError> {
         return Err(AnchorKitError::invalid_endpoint_format());
     }
 
-    // Check minimum length for valid HTTPS URL ("https://a.b" = 11 chars)
-    if domain.len() < 10 {
+    // Check minimum length for valid HTTPS URL ("https://a.b" = 12 chars)
+    if domain.len() < 12 {
         return Err(AnchorKitError::invalid_endpoint_format());
     }
 

--- a/src/response_validator.rs
+++ b/src/response_validator.rs
@@ -316,6 +316,10 @@ fn crc16_xmodem(input: &[u8]) -> u16 {
 ///
 /// Returns [`Error`] with code [`ErrorCode::ValidationError`] if any string
 /// field is empty.
+fn is_valid_positive_decimal(s: &str) -> bool {
+    s.parse::<f64>().map(|v| v > 0.0).unwrap_or(false)
+}
+
 pub fn validate_sep38_quote_response(
     id: &str,
     expires_at: &str,
@@ -341,6 +345,18 @@ pub fn validate_sep38_quote_response(
     }
     if fee.is_empty() {
         return Err(Error::validation_error("fee is empty"));
+    }
+    if !is_valid_positive_decimal(price) {
+        return Err(Error::validation_error("price must be a positive number"));
+    }
+    if !is_valid_positive_decimal(sell_amount) {
+        return Err(Error::validation_error("sell_amount must be a positive number"));
+    }
+    if !is_valid_positive_decimal(buy_amount) {
+        return Err(Error::validation_error("buy_amount must be a positive number"));
+    }
+    if !is_valid_positive_decimal(fee) {
+        return Err(Error::validation_error("fee must be a positive number"));
     }
 
     Ok(Sep38QuoteResponse {


### PR DESCRIPTION
## Summary

Fixes two low-severity bugs reported in issues #495 and #496.

### #495 — validate_anchor_domain: wrong minimum length check and comment
- `'https://a.b'` is **12** characters, not 11
- Updated the comment to reflect the correct count
- Changed the guard from `< 10` to `< 12` so strings like `'https://x.'` (10 chars, empty TLD) are correctly rejected

### #496 — validate_sep38_quote_response: no numeric validation
- Added `is_valid_positive_decimal` helper using `str::parse::<f64>()`
- Applied it to `price`, `sell_amount`, `buy_amount`, and `fee` — invalid strings like `'abc'`, `'-1.5'`, or `'1.2.3'` now return a `ValidationError` instead of being silently accepted

Closes #495
Closes #496