### PR TITLE
fix: SEP-6 status, retry rate-limit/zero-attempts, redundant session nonce (#451 #452 #453 #454)

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -3708,10 +3708,6 @@ impl AnchorKitContract {
         env.storage().persistent().set(&sess_key, &session);
         env.storage().persistent().extend_ttl(&sess_key, PERSISTENT_TTL, PERSISTENT_TTL);
 
-        let snonce_key = make_storage_key(&env, &[b"SNONCE", &session_id.to_be_bytes()]);
-        env.storage().persistent().set(&snonce_key, &0u64);
-        env.storage().persistent().extend_ttl(&snonce_key, PERSISTENT_TTL, PERSISTENT_TTL);
-
         env.events().publish(
             (symbol_short!("session"), symbol_short!("created"), session_id),
             SessionCreatedEvent { session_id, initiator, timestamp: now },

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -193,8 +193,13 @@ impl JitterSource for MockJitterSource {
 
 /// Classify whether an error code is retryable.
 ///
-/// Retryable: transient network/server errors (availability, rate limits, stale data).
-/// Non-retryable: auth failures, bad input, protocol violations.
+/// Retryable: transient network/server errors (availability, stale data).
+/// Non-retryable: auth failures, bad input, protocol violations, rate limits.
+///
+/// `RateLimitExceeded` is intentionally NOT retryable: retrying immediately (or
+/// with a backoff shorter than the rate window) reproduces the same error and
+/// wastes all attempts. Callers that want to respect a rate limit should
+/// implement their own wait-and-retry loop keyed to the window length.
 pub fn is_retryable(code: crate::errors::ErrorCode) -> bool {
     use crate::errors::ErrorCode;
     match code {
@@ -203,8 +208,7 @@ pub fn is_retryable(code: crate::errors::ErrorCode) -> bool {
         | ErrorCode::StaleQuote
         | ErrorCode::NoQuotesAvailable
         | ErrorCode::CacheExpired
-        | ErrorCode::CacheNotFound
-        | ErrorCode::RateLimitExceeded => true,
+        | ErrorCode::CacheNotFound => true,
         _ => false,
     }
 }
@@ -270,6 +274,15 @@ where
     S: FnMut(u64),
     J: JitterSource,
 {
+    // Guard against `max_attempts == 0`: the loop below would never execute,
+    // leaving `last_err` as `None` and hitting the `unreachable!()` at the end
+    // (a panic in debug, UB-adjacent in release). Treat 0 as a single attempt
+    // so the operation still runs exactly once and its result is returned.
+    debug_assert!(config.max_attempts >= 1, "max_attempts must be at least 1");
+    if config.max_attempts == 0 {
+        return f(0);
+    }
+
     let mut last_err: Option<E> = None;
 
     for attempt in 0..config.max_attempts {

--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -75,7 +75,9 @@ impl TransactionStatus {
             "pending_external" => Self::PendingExternal,
             "pending_anchor" => Self::PendingAnchor,
             "pending_trust" => Self::PendingTrust,
-            "pending_user" | "pending_user_transfer_start" => Self::PendingUser,
+            "pending_user"
+            | "pending_user_transfer_start"
+            | "pending_user_transfer_complete" => Self::PendingUser,
             "completed" => Self::Completed,
             "refunded" => Self::Refunded,
             "expired" => Self::Expired,


### PR DESCRIPTION
## Summary

Implements four fixes from reported issues.

### #454 — SEP-6 `pending_user_transfer_complete` status (`src/sep6.rs`)
`TransactionStatus::from_str` didn't handle the SEP-6 `pending_user_transfer_complete` status, silently mapping it to `Error`. Now mapped to `PendingUser` alongside `pending_user_transfer_start`.

### #451 — `RateLimitExceeded` no longer retryable (`src/retry.rs`)
`is_retryable` classified `RateLimitExceeded` as retryable, causing the backoff loop to hammer a rate-limited endpoint and waste every attempt. Removed it from the retryable set (rate limits require waiting for the next window, not a short backoff).

### #452 — `retry_with_backoff` guards `max_attempts == 0` (`src/retry.rs`)
With `max_attempts == 0` the loop never ran, `last_err` stayed `None`, and the code hit `unreachable!()` (panic in debug). Added a `debug_assert!` plus an early `return f(0)` so the operation runs exactly once instead of panicking.

### #453 — Removed redundant SNONCE storage entry (`src/contract.rs`)
`create_session` wrote a separate `SNONCE/` persistent entry that was never incremented or read — replay protection uses the `Session.nonce` field. Removed the redundant write to save a persistent storage slot per session.

Closes #454
Closes #451
Closes #452
Closes #453
