### PR TITLE
fix: resolve issues #487 #488 #489 #490

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1078,6 +1078,10 @@ fn admin_key(env: &Env) -> BytesN<32> {
     make_storage_key(env, &[b"ADMIN"])
 }
 
+fn pending_admin_key(env: &Env) -> BytesN<32> {
+    make_storage_key(env, &[b"PENDADMIN"])
+}
+
 fn initialized_key(env: &Env) -> BytesN<32> {
     make_storage_key(env, &[b"INITIALIZED"])
 }
@@ -1314,6 +1318,46 @@ impl AnchorKitContract {
             .instance()
             .get::<_, Address>(&admin_key(&env))
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::NotInitialized))
+    }
+
+    /// Begin a two-step admin transfer by recording `new_admin` as the pending
+    /// admin. The transfer is not final until `new_admin` calls
+    /// [`accept_admin_transfer`](Self::accept_admin_transfer).
+    ///
+    /// Only the current admin may call this. Overwrites any previously pending
+    /// transfer without confirmation.
+    pub fn propose_admin_transfer(env: Env, new_admin: Address) {
+        Self::require_admin(&env);
+        env.storage().instance().set(&pending_admin_key(&env), &new_admin);
+        env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("proposed")),
+            new_admin,
+        );
+    }
+
+    /// Complete a pending admin transfer. Must be called by the address that
+    /// was nominated via [`propose_admin_transfer`](Self::propose_admin_transfer).
+    ///
+    /// After this call the caller becomes the new admin and the pending-admin
+    /// slot is cleared.
+    ///
+    /// Panics with [`ErrorCode::NotInitialized`] when no transfer has been
+    /// proposed.
+    pub fn accept_admin_transfer(env: Env) {
+        let new_admin: Address = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&pending_admin_key(&env))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::NotInitialized));
+        new_admin.require_auth();
+        env.storage().instance().set(&admin_key(&env), &new_admin);
+        env.storage().instance().remove(&pending_admin_key(&env));
+        env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("accepted")),
+            new_admin,
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1819,17 +1863,29 @@ impl AnchorKitContract {
     // Request ID generation
     // -----------------------------------------------------------------------
 
-    /// Generate a deterministic request ID: sha256(timestamp_u64_be || sequence_number_u32_be)[:16]
+    /// Generate a unique request ID: sha256(timestamp_u64_be || sequence_u32_be || counter_u64_be)[:16]
+    ///
+    /// A contract-level counter is included so that two calls within the same
+    /// ledger (same timestamp and sequence) always produce distinct IDs.
     pub fn generate_request_id(env: Env) -> RequestId {
         let ts = env.ledger().timestamp();
         let seq = env.ledger().sequence() as u32;
 
-        // Build input: 8-byte timestamp || 4-byte sequence number (big-endian)
+        // Increment a per-contract call counter to disambiguate same-ledger calls.
+        let counter_key = make_storage_key(&env, &[b"REQIDCNT"]);
+        let counter: u64 = env.storage().instance().get(&counter_key).unwrap_or(0u64);
+        env.storage().instance().set(&counter_key, &(counter + 1));
+        env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+
+        // Build input: 8-byte timestamp || 4-byte sequence || 8-byte counter (big-endian)
         let mut input = Bytes::new(&env);
         for b in ts.to_be_bytes().iter() {
             input.push_back(*b);
         }
         for b in seq.to_be_bytes().iter() {
+            input.push_back(*b);
+        }
+        for b in counter.to_be_bytes().iter() {
             input.push_back(*b);
         }
 
@@ -3263,7 +3319,9 @@ impl AnchorKitContract {
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ValidationError));
 
         let span_index = ctx.next_span_index;
-        ctx.next_span_index += 1;
+        ctx.next_span_index = ctx.next_span_index
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::SessionOperationLimitExceeded));
 
         let now = env.ledger().timestamp();
         env.storage().temporary().set(&ctx_key, &ctx);
@@ -6571,6 +6629,14 @@ impl AnchorKitContract {
 
     /// Return an aggregated health snapshot for the contract's key subsystems.
     /// Does not modify any contract state.
+    ///
+    /// Key consistency (issue #489):
+    ///   - COUNTER: written by `next_attestation_id` as `vec![env, symbol_short!("COUNTER")]`
+    ///              and read here with the identical key — consistent.
+    ///   - QCNT:    written by `submit_quote` via `make_storage_key(&env, &[b"QCNT"])`
+    ///              and read here with the identical call — consistent.
+    ///   - SCNT:    written by `create_session` via `make_storage_key(&env, &[b"SCNT"])`
+    ///              and read here with the identical call — consistent.
     pub fn get_contract_diagnostics(env: Env) -> ContractDiagnostics {
         let now = env.ledger().timestamp();
         let is_initialized = env.storage().persistent().has(&initialized_key(&env));


### PR DESCRIPTION
## Summary

Fixes four open issues in a single commit.

---

### #487 — `generate_request_id` produces duplicate IDs within the same ledger

**Root cause:** the hash input was only `timestamp || sequence`, both of which are fixed for an entire ledger.

**Fix:** added a per-contract call counter (`REQIDCNT` in instance storage) to the hash input. The counter is incremented on every call, so two invocations in the same ledger produce distinct IDs.

---

### #488 — `propagate_span` overflow panic on `next_span_index`

**Root cause:** `ctx.next_span_index += 1` will panic in release builds (overflow-checks = true) once `u32::MAX` spans exist.

**Fix:** replaced with `checked_add(1).unwrap_or_else(|| panic_with_error!(&env, ErrorCode::SessionOperationLimitExceeded))` which produces a controlled, meaningful error instead.

---

### #489 — COUNTER / QCNT / SCNT key consistency in `get_contract_diagnostics`

**Investigation result:** all three keys are written and read with identical key formats throughout the contract:
- `COUNTER` — `vec![env, symbol_short!("COUNTER")]` in both `next_attestation_id` and `get_contract_diagnostics`
- `QCNT` — `make_storage_key(&env, &[b"QCNT"])` in both `submit_quote` variants and `get_contract_diagnostics`
- `SCNT` — `make_storage_key(&env, &[b"SCNT"])` in both `create_session` and `get_contract_diagnostics`

**Fix:** no logic change needed. Added documentation comments to `get_contract_diagnostics` confirming key consistency for future auditors.

---

### #490 — No admin transfer mechanism

**Root cause:** the admin address set during `initialize` has no rotation path.

**Fix:** added a two-step commit-reveal transfer:
- `propose_admin_transfer(new_admin)` — current admin nominates a successor (stored under `PENDADMIN` in instance storage)
- `accept_admin_transfer()` — nominated address authorizes and finalizes the transfer; clears the pending slot

Closes #487
Closes #488
Closes #489
Closes #490