### PR TITLE
fix: correct error codes, currency parsing, and workflow feature flags

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -47,7 +47,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --features std,mock-only -- -D warnings
 
   tests:
     name: Tests
@@ -72,4 +72,4 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --features std,mock-only,stress-tests

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -5147,7 +5147,7 @@ impl AnchorKitContract {
         env.storage()
             .persistent()
             .get(&key)
-            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::CacheNotFound))
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ValidationError))
     }
 
     /// List all anchor clusters.

--- a/src/stellar_toml.rs
+++ b/src/stellar_toml.rs
@@ -165,7 +165,7 @@ pub fn parse_stellar_toml(raw: &str) -> Result<ParsedStellarToml, AnchorKitError
         // Section header, e.g. `[[CURRENCIES]]`, `[DOCUMENTATION]`.
         if line.starts_with('[') {
             // Flush any in-progress currency before switching tables.
-            flush_currency(&mut current, &mut currencies);
+            flush_currency(&mut current, &mut currencies)?;
             let header = line.trim_matches(|c| c == '[' || c == ']').trim();
             if header.eq_ignore_ascii_case("CURRENCIES") {
                 section = Section::Currencies;
@@ -230,7 +230,7 @@ pub fn parse_stellar_toml(raw: &str) -> Result<ParsedStellarToml, AnchorKitError
         }
     }
     // Flush the final currency block, if any.
-    flush_currency(&mut current, &mut currencies);
+    flush_currency(&mut current, &mut currencies)?;
 
     // Derive the de-duplicated code list for backwards compatibility.
     let mut supported_assets: Vec<String> = Vec::new();
@@ -255,13 +255,21 @@ pub fn parse_stellar_toml(raw: &str) -> Result<ParsedStellarToml, AnchorKitError
 }
 
 /// Push `current` into `currencies` if it carries a non-empty asset code,
-/// leaving `current` as `None`. Currency blocks without a `code` are dropped.
-fn flush_currency(current: &mut Option<ParsedCurrency>, currencies: &mut Vec<ParsedCurrency>) {
+/// leaving `current` as `None`. Returns `Err` if a currency block is missing its `code` field.
+fn flush_currency(
+    current: &mut Option<ParsedCurrency>,
+    currencies: &mut Vec<ParsedCurrency>,
+) -> Result<(), AnchorKitError> {
     if let Some(c) = current.take() {
         if !c.code.is_empty() {
             currencies.push(c);
+        } else {
+            return Err(AnchorKitError::validation_error(
+                "CURRENCIES block missing code field",
+            ));
         }
     }
+    Ok(())
 }
 
 /// Extract (key, value) from a line of the form `KEY = "value"` or `KEY = value`.


### PR DESCRIPTION
## Summary

Fixes three bugs across two issues and a CI workflow.

### #506 — `get_anchor_cluster` uses wrong error code
`get_anchor_cluster` was panicking with `CacheNotFound` (code 49) when the requested cluster did not exist. Anchor clusters are persistent configuration records, not cache entries; using `CacheNotFound` misleads callers into triggering stale-cache-refresh logic for a record that was never created.

**Fix:** Changed the unwrap error to `ValidationError`.

### #497 — `flush_currency` silently drops malformed currency blocks
`flush_currency` was silently discarding any `[[CURRENCIES]]` block that had no `code` field. The caller received an incomplete currencies list with no indication that entries were dropped, which could cause anchor discovery to incorrectly report unsupported assets.

**Fix:** `flush_currency` now returns `Result<(), AnchorKitError>` and returns `Err(ValidationError("CURRENCIES block missing code field"))` instead of dropping. Both call-sites in `parse_stellar_toml` propagate with `?`.

### Workflow — `code-quality.yml` uses `--all-features` (wasm + std conflict)
The `tests` and `linting` jobs both ran with `--all-features`, which activates the `wasm` and `std` features simultaneously. These are mutually exclusive: `wasm` targets `wasm32-unknown-unknown` with `#![no_std]`, while `std` pulls in `reqwest`, `clap`, and other host-only dependencies. The combination causes a compilation failure.

**Fix:** Replaced `--all-features` with `--features std,mock-only,stress-tests` in both jobs.

---

Closes #506
Closes #497