### PR TITLE
 Fix routing and weighted score strategy issues (#467, #468, #469, #470)

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -297,6 +297,9 @@ pub struct RoutingOptions {
     pub require_kyc: bool,
     pub require_compliance: bool,
     pub subject: Address,
+    pub fee_weight: u32,       // Issue #469: scaled ×1000
+    pub speed_weight: u32,
+    pub reputation_weight: u32,
 }
 
 /// Composite weighted routing strategy.
@@ -5313,21 +5316,44 @@ impl AnchorKitContract {
                 }
             }
         } else if strategy_sym == Symbol::new(&env, "WeightedScore") {
-            // Issue #55: weighted score = reputation(40%) + liquidity(30%) + uptime(20%) - fee(10%)
-            let weighted_score = |meta: &RoutingAnchorMeta, fee_pct: u32| -> u64 {
-                let fee_factor = if fee_pct <= 100 { 100 - fee_pct } else { 0 };
-                (meta.reputation_score as u64) * 40
-                    + (meta.liquidity_score as u64) * 30
-                    + (meta.uptime_percentage as u64) * 20
-                    + (fee_factor as u64) * 10
-            };
-            let mut best_score: u64 = anchor_meta_opt(&env, &best.anchor)
-                .map(|m| weighted_score(&m, best.fee_percentage))
-                .unwrap_or(0);
+            // Issues #469, #470: use actual weights from options and properly scale fee to basis points
+            // Normalize scores similar to route_anchors
+            let mut max_fee: u32 = 1;
+            let mut max_settlement: u64 = 1;
+            let mut max_reputation: u32 = 1;
+            
             for q in candidates.iter() {
-                let score = anchor_meta_opt(&env, &q.anchor)
-                    .map(|m| weighted_score(&m, q.fee_percentage))
-                    .unwrap_or(0);
+                if q.fee_percentage > max_fee { max_fee = q.fee_percentage; }
+                let meta = anchor_meta_opt(&env, &q.anchor);
+                if let Some(m) = &meta {
+                    if m.average_settlement_time > max_settlement { max_settlement = m.average_settlement_time; }
+                    if m.reputation_score > max_reputation { max_reputation = m.reputation_score; }
+                }
+            }
+            
+            let fw = options.fee_weight as f32 / 1000.0_f32;
+            let sw = options.speed_weight as f32 / 1000.0_f32;
+            let rw = options.reputation_weight as f32 / 1000.0_f32;
+            
+            let weighted_score = |q: &Quote| -> f32 {
+                let meta = anchor_meta_opt(&env, &q.anchor).unwrap_or_else(|| RoutingAnchorMeta {
+                    anchor: q.anchor.clone(),
+                    is_active: false,
+                    reputation_score: 0,
+                    liquidity_score: 0,
+                    uptime_percentage: 0,
+                    average_settlement_time: u64::MAX,
+                    total_volume: 0,
+                });
+                let fee_score = 1.0_f32 - (q.fee_percentage as f32 / max_fee as f32);
+                let speed_score = 1.0_f32 - (meta.average_settlement_time as f32 / max_settlement as f32);
+                let rep_score = meta.reputation_score as f32 / max_reputation as f32;
+                fw * fee_score + sw * speed_score + rw * rep_score
+            };
+            
+            let mut best_score: f32 = weighted_score(&best);
+            for q in candidates.iter() {
+                let score = weighted_score(&q);
                 if score > best_score {
                     best_score = score;
                     best = q;
@@ -5336,7 +5362,7 @@ impl AnchorKitContract {
         }
 
         env.events().publish(
-            (symbol_short!("webhook"), symbol_short!("event")),
+            (symbol_short!("route"), symbol_short!("selected")),
             WebhookEvent {
                 event_type: String::from_str(&env, "transaction_routed"),
                 transaction_id: best.quote_id,
@@ -5448,8 +5474,8 @@ impl AnchorKitContract {
         // Sort descending by score
         scored.sort_unstable_by(|a, b| b.0.cmp(&a.0));
 
-        // Return top max_results quotes as a Soroban Vec
-        let limit = if max_results == 0 { 3u32 } else { max_results };
+        // Return top max_results quotes as a Soroban Vec (issue #467: 0 means no limit)
+        let limit = if max_results == 0 { u32::MAX } else { max_results };
         let mut result: Vec<Quote> = Vec::new(&env);
         for (_, quote) in scored.into_iter().take(limit as usize) {
             result.push_back(quote);

--- a/tests/cli_integration_harness.rs
+++ b/tests/cli_integration_harness.rs
@@ -379,6 +379,9 @@ fn harness_step6_quote_and_route() {
         require_kyc: false,
         require_compliance: false,
         subject: Address::generate(&env),
+        fee_weight: 333u32,
+        speed_weight: 333u32,
+        reputation_weight: 334u32,
     };
 
     let best = client.route_transaction(&options);

--- a/tests/routing_tests.rs
+++ b/tests/routing_tests.rs
@@ -130,6 +130,9 @@ mod routing_tests {
             require_kyc: false,
             require_compliance: false,
             subject: Address::generate(&env),
+            fee_weight: 333,
+            speed_weight: 333,
+            reputation_weight: 334,
         };
 
         // anchor2 has faster settlement time (200 < 600)
@@ -173,6 +176,9 @@ mod routing_tests {
             require_kyc: false,
             require_compliance: false,
             subject: Address::generate(&env),
+            fee_weight: 333,
+            speed_weight: 333,
+            reputation_weight: 334,
         };
 
         // anchor2 has higher reputation (8000 > 3000)
@@ -515,6 +521,9 @@ mod routing_tests {
             require_kyc: false,
             require_compliance: false,
             subject: Address::generate(env),
+            fee_weight: 333,
+            speed_weight: 333,
+            reputation_weight: 334,
         }
     }
 


### PR DESCRIPTION
 # Fix routing and weighted score strategy issues (#467, #468, #469, #470)

  Closes #467
  Closes #468
  Closes #469
  Closes #470
 
  
  ## Overview
  This PR addresses four critical bugs in the routing and scoring logic for anchor selection
  in the Soroban contract, improving consistency, transparency, and functionality of the
  weighted routing strategy.
  
  ## Changes
  
  ### Issue #467: Fix route_anchors max_results=0 handling
  **Problem**: When `max_results=0` was passed to `route_anchors`, it was silently converted
  to 3, which was undocumented and confusing for integrators.
  
  **Solution**: Changed `max_results=0` to mean "no limit" by using `u32::MAX`. This is now
  the expected behavior and clearly indicates unlimited results.
  
  **Files Changed**: `src/contract.rs`
  **Lines**: 5477
  
  ---
  
  ### Issue #468: Fix route_transaction event topic namespace
  **Problem**: The `route_transaction` function emitted routing events under the 'webhook'
  topic namespace, conflating two distinct event categories:
  - Webhook delivery events (off-chain event propagation)
  - Route selection events (contract-level anchor selection)
  
  This caused confusion for off-chain listeners filtering by event type.
  
  **Solution**: Changed the event topic from `(symbol_short!("webhook"),
  symbol_short!("event"))` to `(symbol_short!("route"), symbol_short!("selected"))` to
  properly distinguish routing events from webhook delivery events.
  
  **Files Changed**: `src/contract.rs`
  **Lines**: 5365
  
  ---
  
  ### Issue #469: Fix WeightedScore strategy using hardcoded weights instead of provided
  parameters
  **Problem**: The `WeightedScore` routing strategy in `route_transaction` ignored the
  `fee_weight`, `speed_weight`, and `reputation_weight` parameters and used hardcoded
  percentages (40/30/20/10). Callers could not customize the weighted scoring.
  
  **Solution**:
  1. Extended `RoutingOptions` struct with three new fields:
     - `fee_weight: u32` (scaled ×1000)
     - `speed_weight: u32` (scaled ×1000)
     - `reputation_weight: u32` (scaled ×1000)
  
  2. Rewrote the `WeightedScore` closure to:
     - Extract and normalize max values for fees, settlement times, and reputation
     - Calculate individual score components (fee_score, speed_score, rep_score) using
  normalization
     - Apply the provided weights to each component
     - Match the scoring approach used in `route_anchors` for consistency
  
  **Files Changed**: 
  - `src/contract.rs` (RoutingOptions struct, WeightedScore implementation)
  - `tests/routing_tests.rs` (3 RoutingOptions instantiations)
  - `tests/cli_integration_harness.rs` (1 RoutingOptions instantiation)
  
  **Lines**: 297-299, 5318-5354, plus test updates
  
  ---
  
  ### Issue #470: Fix WeightedScore fee_factor scaling (basis points vs percentage)
  **Problem**: The fee_factor calculation used `if fee_pct <= 100 { 100 - fee_pct } else { 0
  }`, treating fees as percentages. However, `fee_percentage` is stored as basis points (1% =
  100 bps, max = 10000 bps). This made the fee component of the weighted score ineffective for
  most real-world fee levels (1%-100%), all scoring 0.
  
  **Solution**: Implemented proper normalization using the maximum fee percentage found in
  candidates:
  ```rust
  let fee_score = 1.0_f32 - (q.fee_percentage as f32 / max_fee as f32);
  
  This correctly handles basis points through normalization, giving low-fee anchors higher
  scores relative to high-fee anchors.
  
  Files Changed: src/contract.rs
  Lines: 5341
  
  ────────────────────────────────────────────────────────────────────────────────────────────
  
  Test Updates
  
  Updated all test instantiations of RoutingOptions to provide the required weight parameters:
  
  - Default weights: fee_weight: 333, speed_weight: 333, reputation_weight: 334 (sum = 1000)
  - Files: tests/routing_tests.rs, tests/cli_integration_harness.rs
  
  Verification
  
  - All changes compile without errors
  - Existing tests pass with updated parameters
  - Route selection logic now respects caller-provided weights
  - Event topics properly distinguish routing from webhook events
  - max_results=0 now behaves intuitively (no limit)
  
  Closes
  
  Closes #467
  Closes #468
  Closes #469
  Closes #470
 