### PR TITLE
feat(SorobanAnchor): add-sep-31-direct-payment-support-to-the-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ anchorkit doctor
 The contract explicitly exposes which Stellar Ecosystem Proposals (SEPs) it supports via two on-chain methods:
 
 ```rust
-// Returns [6, 10, 24, 38]
+// Returns [6, 10, 24, 31, 38]
 let seps: Vec<u32> = AnchorKitContract::supported_seps(env);
 
 // Returns per-SEP boolean flags
@@ -170,9 +170,10 @@ assert!(flags.sep10); // SEP-10 JWT authentication is supported
 | [SEP-6](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) | Non-interactive deposit and withdrawal | ✓ |
 | [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) | Stellar Web Authentication (JWT) | ✓ |
 | [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md) | Interactive deposit and withdrawal | ✓ |
+| [SEP-31](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md) | Direct payment | ✓ |
 | [SEP-38](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md) | Anchor RFQ / firm quotes | ✓ |
 
-Constants are also exported from the `contract` module: `SEP_6`, `SEP_10`, `SEP_24`, `SEP_38`.
+Constants are also exported from the `contract` module: `SEP_6`, `SEP_10`, `SEP_24`, `SEP_31`, `SEP_38`.
 
 ## Key APIs
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -175,6 +175,7 @@ pub const SERVICE_DEPOSITS: u32 = 1;
 pub const SERVICE_WITHDRAWALS: u32 = 2;
 pub const SERVICE_QUOTES: u32 = 3;
 pub const SERVICE_KYC: u32 = 4;
+pub const SERVICE_SEP31: u32 = 5;
 
 // ---------------------------------------------------------------------------
 // #344 — Admin permission model
@@ -237,7 +238,7 @@ pub const SERVICE_CAPABILITY_VERSION: u32 = 1;
 /// outside `SERVICE_DEPOSITS..=MAX_KNOWN_SERVICE_CODE` are rejected by
 /// [`configure_services_versioned`]. Extend this (and bump the version) to
 /// introduce new service identifiers.
-const MAX_KNOWN_SERVICE_CODE: u32 = SERVICE_KYC;
+const MAX_KNOWN_SERVICE_CODE: u32 = SERVICE_SEP31;
 
 /// Typed representation of a service capability an anchor can support.
 ///
@@ -249,6 +250,7 @@ pub enum ServiceType {
     Withdrawals,
     Quotes,
     KYC,
+    Sep31,
 }
 
 impl ServiceType {
@@ -258,6 +260,7 @@ impl ServiceType {
             ServiceType::Withdrawals => SERVICE_WITHDRAWALS,
             ServiceType::Quotes => SERVICE_QUOTES,
             ServiceType::KYC => SERVICE_KYC,
+            ServiceType::Sep31 => SERVICE_SEP31,
         }
     }
 }
@@ -576,6 +579,7 @@ pub struct StellarToml {
     pub transfer_server_sep0024: String,
     pub kyc_server: String,
     pub web_auth_endpoint: String,
+    pub direct_payment_server: String,
 }
 
 #[contracttype]
@@ -852,6 +856,8 @@ pub const SEP_6: u32 = 6;
 pub const SEP_10: u32 = 10;
 /// SEP-24: Interactive deposit and withdrawal
 pub const SEP_24: u32 = 24;
+/// SEP-31: Direct payment
+pub const SEP_31: u32 = 31;
 /// SEP-38: Anchor Request for Quote (RFQ)
 pub const SEP_38: u32 = 38;
 
@@ -865,6 +871,8 @@ pub struct SepFeatureFlags {
     pub sep10: bool,
     /// SEP-24 interactive deposit/withdrawal support.
     pub sep24: bool,
+    /// SEP-31 direct payment support.
+    pub sep31: bool,
     /// SEP-38 RFQ / firm quote support.
     pub sep38: bool,
 }
@@ -5851,6 +5859,21 @@ impl AnchorKitContract {
         }
     }
 
+    /// Return `true` when the anchor's cached stellar.toml advertises a
+    /// `DIRECT_PAYMENT_SERVER` endpoint (SEP-31).
+    pub fn supports_sep31(env: Env, anchor: Address) -> bool {
+        let key = (symbol_short!("TOMLCACHE"), anchor);
+        if !env.storage().temporary().has(&key) {
+            return false;
+        }
+        let cached: CachedToml = env.storage().temporary().get(&key).unwrap();
+        let now = env.ledger().timestamp();
+        if cached.cached_at + cached.ttl_seconds <= now {
+            return false;
+        }
+        !cached.toml.direct_payment_server.is_empty()
+    }
+
     // -----------------------------------------------------------------------
     // Transaction state
     // -----------------------------------------------------------------------
@@ -7038,7 +7061,7 @@ impl AnchorKitContract {
     ///
     /// # Returns
     ///
-    /// A [`Vec<u32>`] containing the SEP numbers: `[6, 10, 24, 38]`.
+    /// A [`Vec<u32>`] containing the SEP numbers: `[6, 10, 24, 31, 38]`.
     ///
     /// # Examples
     ///
@@ -7055,6 +7078,7 @@ impl AnchorKitContract {
         v.push_back(SEP_6);
         v.push_back(SEP_10);
         v.push_back(SEP_24);
+        v.push_back(SEP_31);
         v.push_back(SEP_38);
         v
     }
@@ -7082,6 +7106,7 @@ impl AnchorKitContract {
             sep6: true,
             sep10: true,
             sep24: true,
+            sep31: true,
             sep38: true,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,14 @@
 //! - Anchor discovery via `stellar.toml`
 //!
 //! ### Off-chain service layer (SEP modules)
-//! Three thin normalisation modules translate raw anchor HTTP responses into
+//! Four thin normalisation modules translate raw anchor HTTP responses into
 //! typed Rust structs so callers never have to parse raw JSON themselves:
 //!
 //! | Module | SEP | Purpose |
 //! |--------|-----|---------|
 //! | [`sep6`] | SEP-6 | Non-interactive deposit / withdrawal |
 //! | [`sep24`] | SEP-24 | Interactive deposit / withdrawal |
+//! | [`sep31`] | SEP-31 | Direct payment |
 //! | [`sep38`] | SEP-38 | Anchor RFQ / firm quotes |
 //!
 //! ### Cross-cutting utilities
@@ -151,6 +152,8 @@ pub mod sep6;
 #[cfg(not(feature = "wasm"))]
 pub mod sep24;
 #[cfg(not(feature = "wasm"))]
+pub mod sep31;
+#[cfg(not(feature = "wasm"))]
 pub mod sep38;
 #[cfg(not(feature = "wasm"))]
 pub mod stellar_toml;
@@ -200,6 +203,10 @@ pub use sep6::{
     RawDepositResponse, RawTransactionResponse, RawWithdrawalResponse, TransactionKind,
     TransactionStatus, TransactionStatusResponse, WithdrawalResponse,
     poll_transaction_status, PollConfig, PollResult,
+};
+#[cfg(not(feature = "wasm"))]
+pub use sep31::{
+    initiate_sep31_payment, RawSep31PaymentResponse, Sep31PaymentResponse,
 };
 #[cfg(not(feature = "wasm"))]
 pub use sep24::{

--- a/src/sep31.rs
+++ b/src/sep31.rs
@@ -1,0 +1,133 @@
+//! SEP-31 Direct Payment Service Layer
+//!
+//! Provides normalized service functions for initiating direct payments
+//! across anchors implementing SEP-31.
+
+extern crate alloc;
+use alloc::string::String;
+
+use crate::errors::Error;
+use crate::response_validator::validate_stellar_account_id;
+
+/// Raw fields from an anchor's direct payment initiation response.
+pub struct RawSep31PaymentResponse {
+    pub id: String,
+    pub stellar_account_id: String,
+    pub stellar_memo: Option<String>,
+    pub stellar_memo_type: Option<String>,
+}
+
+/// Validated direct payment response from a SEP-31 anchor.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Sep31PaymentResponse {
+    pub id: String,
+    pub stellar_account_id: String,
+    pub stellar_memo: Option<String>,
+    pub stellar_memo_type: Option<String>,
+}
+
+/// Valid SEP-31 memo type strings.
+const VALID_MEMO_TYPES: &[&str] = &["text", "id", "hash"];
+
+/// Validate that whenever a memo value is present, a valid memo type is also present.
+fn validate_memo_pair(memo: Option<&str>, memo_type: Option<&str>) -> Result<(), Error> {
+    if memo.is_some() {
+        match memo_type {
+            None => return Err(Error::invalid_transaction_intent()),
+            Some(mt) if !VALID_MEMO_TYPES.contains(&mt) => {
+                return Err(Error::invalid_transaction_intent());
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Normalize a raw SEP-31 direct payment response into a canonical
+/// [`Sep31PaymentResponse`].
+///
+/// Validates that `id` is non-empty, `stellar_account_id` is a valid Stellar
+/// account, and memo fields are consistent when present.
+pub fn initiate_sep31_payment(
+    raw: RawSep31PaymentResponse,
+) -> Result<Sep31PaymentResponse, Error> {
+    if raw.id.is_empty() {
+        return Err(Error::invalid_transaction_intent());
+    }
+    validate_stellar_account_id(&raw.stellar_account_id)?;
+    validate_memo_pair(
+        raw.stellar_memo.as_deref(),
+        raw.stellar_memo_type.as_deref(),
+    )?;
+
+    Ok(Sep31PaymentResponse {
+        id: raw.id,
+        stellar_account_id: raw.stellar_account_id,
+        stellar_memo: raw.stellar_memo,
+        stellar_memo_type: raw.stellar_memo_type,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    const VALID_ACCOUNT: &str =
+        "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+    fn raw_payment() -> RawSep31PaymentResponse {
+        RawSep31PaymentResponse {
+            id: "pay-001".to_string(),
+            stellar_account_id: VALID_ACCOUNT.to_string(),
+            stellar_memo: None,
+            stellar_memo_type: None,
+        }
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_accepts_valid_response() {
+        let resp = initiate_sep31_payment(raw_payment()).unwrap();
+        assert_eq!(resp.id, "pay-001");
+        assert_eq!(resp.stellar_account_id, VALID_ACCOUNT);
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_empty_id() {
+        let mut raw = raw_payment();
+        raw.id = String::new();
+        assert_eq!(
+            initiate_sep31_payment(raw),
+            Err(Error::invalid_transaction_intent())
+        );
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_invalid_account_id() {
+        let mut raw = raw_payment();
+        raw.stellar_account_id = "not-a-valid-account".to_string();
+        assert!(initiate_sep31_payment(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_memo_without_type() {
+        let mut raw = raw_payment();
+        raw.stellar_memo = Some("12345".to_string());
+        raw.stellar_memo_type = None;
+        assert_eq!(
+            initiate_sep31_payment(raw),
+            Err(Error::invalid_transaction_intent())
+        );
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_invalid_memo_type() {
+        let mut raw = raw_payment();
+        raw.stellar_memo = Some("12345".to_string());
+        raw.stellar_memo_type = Some("fax".to_string());
+        assert_eq!(
+            initiate_sep31_payment(raw),
+            Err(Error::invalid_transaction_intent())
+        );
+    }
+}

--- a/tests/anchor_info_discovery_tests.rs
+++ b/tests/anchor_info_discovery_tests.rs
@@ -92,6 +92,7 @@ mod anchor_info_discovery_tests {
             ),
             kyc_server: String::from_str(env, "https://kyc.example.com"),
             web_auth_endpoint: String::from_str(env, "https://auth.example.com"),
+            direct_payment_server: String::from_str(env, ""),
         }
     }
 
@@ -116,6 +117,7 @@ mod anchor_info_discovery_tests {
             ),
             kyc_server: String::from_str(env, "https://kyc.example.com"),
             web_auth_endpoint: String::from_str(env, "https://auth.example.com"),
+            direct_payment_server: String::from_str(env, ""),
         }
     }
 
@@ -485,6 +487,7 @@ mod anchor_info_discovery_tests {
             ),
             kyc_server: String::from_str(&env, "https://kyc2.example.com"),
             web_auth_endpoint: String::from_str(&env, "https://auth2.example.com"),
+            direct_payment_server: String::from_str(&env, ""),
         };
 
         client.fetch_anchor_info(&anchor1, &sample_toml(&env), &3600u64, &no_uri(&env));

--- a/tests/sep31_tests.rs
+++ b/tests/sep31_tests.rs
@@ -1,0 +1,95 @@
+//! Tests for SEP-31 direct payment support (#558).
+
+use anchorkit::contract::{
+    AnchorKitContract, AnchorKitContractClient, ServiceType, SERVICE_SEP31,
+};
+use anchorkit::sep31::{initiate_sep31_payment, RawSep31PaymentResponse};
+use anchorkit::Error;
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+#[path = "sep10_test_util.rs"]
+mod sep10_test_util;
+
+use sep10_test_util::register_attestor_with_sep10;
+
+const VALID_ACCOUNT: &str = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+fn raw_payment() -> RawSep31PaymentResponse {
+    RawSep31PaymentResponse {
+        id: "pay-001".into(),
+        stellar_account_id: VALID_ACCOUNT.into(),
+        stellar_memo: None,
+        stellar_memo_type: None,
+    }
+}
+
+#[test]
+fn valid_payment_response_accepted() {
+    let resp = initiate_sep31_payment(raw_payment()).unwrap();
+    assert_eq!(resp.id, "pay-001");
+    assert_eq!(resp.stellar_account_id, VALID_ACCOUNT);
+}
+
+#[test]
+fn empty_id_rejected() {
+    let mut raw = raw_payment();
+    raw.id.clear();
+    assert_eq!(
+        initiate_sep31_payment(raw),
+        Err(Error::invalid_transaction_intent())
+    );
+}
+
+#[test]
+fn invalid_stellar_account_id_rejected() {
+    let mut raw = raw_payment();
+    raw.stellar_account_id = "invalid-account".into();
+    assert!(initiate_sep31_payment(raw).is_err());
+}
+
+#[test]
+fn memo_without_memo_type_rejected() {
+    let mut raw = raw_payment();
+    raw.stellar_memo = Some("12345".into());
+    raw.stellar_memo_type = None;
+    assert_eq!(
+        initiate_sep31_payment(raw),
+        Err(Error::invalid_transaction_intent())
+    );
+}
+
+#[test]
+fn memo_with_invalid_type_rejected() {
+    let mut raw = raw_payment();
+    raw.stellar_memo = Some("12345".into());
+    raw.stellar_memo_type = Some("fax".into());
+    assert_eq!(
+        initiate_sep31_payment(raw),
+        Err(Error::invalid_transaction_intent())
+    );
+}
+
+#[test]
+fn service_type_sep31_detected_in_capability_check() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AnchorKitContract);
+    let client = AnchorKitContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let anchor = Address::generate(&env);
+    let sk = SigningKey::generate(&mut OsRng);
+    register_attestor_with_sep10(&env, &client, &anchor, &anchor, &sk);
+
+    let mut services = Vec::new(&env);
+    services.push_back(ServiceType::Sep31.as_u32());
+
+    client.configure_services(&anchor, &services);
+
+    assert_eq!(ServiceType::Sep31.as_u32(), SERVICE_SEP31);
+    assert!(client.supports_service(&anchor, &SERVICE_SEP31));
+}

--- a/tests/supported_seps_tests.rs
+++ b/tests/supported_seps_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for issue #353: contract-level supported SEP list and feature flags.
 
 use anchorkit::contract::{
-    AnchorKitContract, SepFeatureFlags, SEP_10, SEP_24, SEP_38, SEP_6,
+    AnchorKitContract, SepFeatureFlags, SEP_10, SEP_24, SEP_31, SEP_38, SEP_6,
 };
 use soroban_sdk::Env;
 
@@ -9,10 +9,11 @@ use soroban_sdk::Env;
 fn supported_seps_returns_expected_list() {
     let env = Env::default();
     let seps = AnchorKitContract::supported_seps(env);
-    assert_eq!(seps.len(), 4);
+    assert_eq!(seps.len(), 5);
     assert!(seps.contains(&SEP_6));
     assert!(seps.contains(&SEP_10));
     assert!(seps.contains(&SEP_24));
+    assert!(seps.contains(&SEP_31));
     assert!(seps.contains(&SEP_38));
 }
 
@@ -21,6 +22,7 @@ fn supported_seps_constants_have_correct_values() {
     assert_eq!(SEP_6, 6);
     assert_eq!(SEP_10, 10);
     assert_eq!(SEP_24, 24);
+    assert_eq!(SEP_31, 31);
     assert_eq!(SEP_38, 38);
 }
 
@@ -31,5 +33,6 @@ fn supported_sep_feature_flags_all_enabled() {
     assert!(flags.sep6);
     assert!(flags.sep10);
     assert!(flags.sep24);
+    assert!(flags.sep31);
     assert!(flags.sep38);
 }


### PR DESCRIPTION
Closes #558

## Summary
- Add SEP-31 Direct Payment Support to the Service Layer and Contract

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths