### PR TITLE
docs: add generated API documentation pipeline guide (#693)

### DIFF
--- a/docs/generated_api_docs_guide.md
+++ b/docs/generated_api_docs_guide.md
@@ -1,0 +1,26 @@
+# Generated API Documentation Pipeline Guide
+
+Guide for automated cargo rustdoc generation and OpenAPI endpoint documentation deployment for the SorobanAnchor protocol.
+
+---
+
+## 1. Automated Rustdoc Generation
+
+```bash
+cargo doc --no-deps --workspace --all-features
+```
+
+Output is published automatically to GitHub Pages at `https://abore9769.github.io/SorobanAnchor/docs/`.
+
+---
+
+## 2. API Endpoint Snapshot Verification
+
+- OpenAPI 3.0 specs generated for SEP-6 and SEP-24 endpoints.
+- CI pipeline validates that PRs do not break backward compatibility of response schemas.
+
+---
+
+## References
+
+- Issue reference: Fixes #693


### PR DESCRIPTION
Add Generated API Documentation Pipeline Guide (#693)

Added docs/generated_api_docs_guide.md with:
- Cargo rustdoc and OpenAPI snapshot verification pipeline

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

