### PR TITLE
docs: add maintainer onboarding and module ownership guide (#691)

### DIFF
--- a/docs/maintainer_onboarding.md
+++ b/docs/maintainer_onboarding.md
@@ -1,0 +1,26 @@
+# Maintainer Onboarding & Module Ownership Guide
+
+Onboarding documentation for new maintainers of the SorobanAnchor protocol repository.
+
+---
+
+## 1. Module Ownership Matrix
+
+| Module | Primary Maintainer | Scope |
+| :--- | :--- | :--- |
+| `anchor-sep6` | Anchor Core Team | Programmatic deposit & withdrawal flows |
+| `anchor-sep10` | Security Guild | Web Authentication & JWT attestation |
+| `anchor-routing` | Protocol Engineering | Payment pathfinding & cross-chain bridge |
+
+---
+
+## 2. Release & Triage Responsibilities
+
+- **PR Review SLA:** All open community PRs reviewed within 48 hours.
+- **Security Triage:** Critical advisories handled via private disclosure.
+
+---
+
+## References
+
+- Issue reference: Fixes #691


### PR DESCRIPTION
Add Maintainer Onboarding and Module Ownership Guide (#691)

Added docs/maintainer_onboarding.md with:
- Module ownership matrix and triage SLAs

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

