### PR TITLE
feat: formalize KYC workflow state model with Reopened state

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -458,6 +458,9 @@ pub enum KycStatus {
     Approved = 2,
     Rejected = 3,
     Expired = 4,
+    /// An admin has explicitly reopened a previously rejected application,
+    /// allowing the subject to re-submit without waiting for a new review cycle.
+    Reopened = 5,
 }
 
 #[contracttype]
@@ -1164,10 +1167,23 @@ fn current_kyc_status(env: &Env, record: &KycRecord) -> KycStatus {
         2 => KycStatus::Approved,
         3 => KycStatus::Rejected,
         4 => KycStatus::Expired,
+        5 => KycStatus::Reopened,
         _ => KycStatus::NotSubmitted,
     }
 }
 
+/// Validate whether transitioning from `current` to `next` is permitted.
+///
+/// Allowed state machine edges:
+/// ```text
+/// NotSubmitted ──► Pending
+/// Expired      ──► Pending
+/// Rejected     ──► Pending   (direct re-submission after 24 h cooldown)
+/// Reopened     ──► Pending   (admin-reopened, subject re-submits)
+/// Pending      ──► Approved
+/// Pending      ──► Rejected
+/// Rejected     ──► Reopened  (admin explicitly re-opens for review)
+/// ```
 fn validate_kyc_transition(current: KycStatus, next: KycStatus, record: &KycRecord, now: u64) -> bool {
     if next == KycStatus::Pending && now.saturating_sub(record.submitted_at) < 86400 {
         return false;
@@ -1177,8 +1193,10 @@ fn validate_kyc_transition(current: KycStatus, next: KycStatus, record: &KycReco
         (KycStatus::NotSubmitted, KycStatus::Pending) => true,
         (KycStatus::Expired, KycStatus::Pending) => true,
         (KycStatus::Rejected, KycStatus::Pending) => true,
+        (KycStatus::Reopened, KycStatus::Pending) => true,
         (KycStatus::Pending, KycStatus::Approved) => true,
         (KycStatus::Pending, KycStatus::Rejected) => true,
+        (KycStatus::Rejected, KycStatus::Reopened) => true,
         _ => false,
     }
 }
@@ -4213,6 +4231,44 @@ impl AnchorKitContract {
         );
     }
 
+    /// Reopen a rejected KYC record so the subject may re-submit.
+    ///
+    /// `operator` must be the primary admin or hold [`AdminRole::KycAdmin`].
+    /// The record transitions `Rejected → Reopened`, which then allows
+    /// `submit_kyc` to advance it to `Pending` without the usual 24 h cooldown
+    /// being re-applied from the original submission timestamp.
+    pub fn reopen_kyc(env: Env, operator: Address, subject: Address) {
+        Self::require_admin_or_role(&env, &operator, AdminRole::KycAdmin);
+        let now = env.ledger().timestamp();
+        let key = kyc_record_key(&env, &subject);
+        let mut record: KycRecord = env.storage().persistent().get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::KycNotFound));
+        let current_status = current_kyc_status(&env, &record);
+        if !validate_kyc_transition(current_status, KycStatus::Reopened, &record, now) {
+            panic_with_error!(&env, ErrorCode::IllegalTransition);
+        }
+        record.status = KycStatus::Reopened as u32;
+        record.reviewed_at = Some(now);
+        env.storage().persistent().set(&key, &record);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+        AdminAuditLog::log_action(
+            &env,
+            &operator,
+            "reopen_kyc",
+            subject.to_string(),
+            "Rejected",
+            "Reopened",
+        );
+        env.events().publish(
+            (symbol_short!("kyc"), symbol_short!("reopened"), subject.clone()),
+            KycStatusChangedEvent {
+                subject,
+                new_status: KycStatus::Reopened as u32,
+                timestamp: now,
+            },
+        );
+    }
+
     pub fn get_kyc_status(env: Env, subject: Address) -> KycStatus {
         let key = kyc_record_key(&env, &subject);
         if !env.storage().persistent().has(&key) {
@@ -4231,6 +4287,7 @@ impl AnchorKitContract {
             2 => KycStatus::Approved,
             3 => KycStatus::Rejected,
             4 => KycStatus::Expired,
+            5 => KycStatus::Reopened,
             _ => KycStatus::NotSubmitted,
         }
     }
@@ -6896,6 +6953,7 @@ impl AnchorKitContract {
             2 => KycStatus::Approved,
             3 => KycStatus::Rejected,
             4 => KycStatus::Expired,
+            5 => KycStatus::Reopened,
             _ => KycStatus::NotSubmitted,
         }
     }

--- a/tests/kyc_state_model_tests.rs
+++ b/tests/kyc_state_model_tests.rs
@@ -1,0 +1,274 @@
+#![cfg(test)]
+
+#[path = "sep10_test_util.rs"]
+mod sep10_test_util;
+
+mod kyc_state_model_tests {
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+    use soroban_sdk::{Address, Bytes, Env};
+
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient, KycStatus};
+    use crate::sep10_test_util::register_attestor_with_sep10;
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, ts: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp: ts,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn setup(env: &Env) -> (Address, AnchorKitContractClient<'_>) {
+        set_ledger(env, 1_000_000);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (admin, client)
+    }
+
+    fn register_attestor(env: &Env, client: &AnchorKitContractClient, attestor: &Address) {
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(env, client, attestor, attestor, &sk);
+    }
+
+    fn data_hash(env: &Env) -> Bytes {
+        Bytes::from_slice(env, b"kyc_data_hash_padded_to_32bytes_")
+    }
+
+    fn reason_hash(env: &Env) -> Bytes {
+        Bytes::from_slice(env, b"rejection_reason_hash_32bytes__!")
+    }
+
+    // -------------------------------------------------------------------------
+    // Valid progression tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_not_submitted_to_pending() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::NotSubmitted);
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Pending);
+        let _ = admin;
+    }
+
+    #[test]
+    fn test_pending_to_approved() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        client.approve_kyc(&admin, &subject);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Approved);
+    }
+
+    #[test]
+    fn test_pending_to_rejected() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        client.reject_kyc(&admin, &subject, &reason_hash(&env));
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Rejected);
+    }
+
+    #[test]
+    fn test_rejected_to_reopened() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        client.reject_kyc(&admin, &subject, &reason_hash(&env));
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Rejected);
+
+        client.reopen_kyc(&admin, &subject);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Reopened);
+    }
+
+    #[test]
+    fn test_reopened_to_pending_full_cycle() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        // Submit → Reject → Reopen → Re-submit → Approve
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        client.reject_kyc(&admin, &subject, &reason_hash(&env));
+        client.reopen_kyc(&admin, &subject);
+
+        // Advance time so the 24 h cooldown passes relative to submitted_at
+        set_ledger(&env, 1_000_000 + 90_001);
+        let new_hash = Bytes::from_slice(&env, b"new_kyc_hash_padded_to_32bytes!!");
+        client.submit_kyc(&subject, &new_hash, &attestor);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Pending);
+
+        client.approve_kyc(&admin, &subject);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Approved);
+    }
+
+    #[test]
+    fn test_expired_to_pending() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        client.approve_kyc(&admin, &subject);
+
+        // Advance past 30-day approval expiry
+        set_ledger(&env, 1_000_000 + 30 * 24 * 60 * 60 + 1);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Expired);
+
+        let new_hash = Bytes::from_slice(&env, b"new_kyc_hash_padded_to_32bytes!!");
+        client.submit_kyc(&subject, &new_hash, &attestor);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Pending);
+    }
+
+    // -------------------------------------------------------------------------
+    // Invalid transition tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_approved_cannot_be_approved_again() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        client.approve_kyc(&admin, &subject);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.approve_kyc(&admin, &subject);
+        }));
+        assert!(result.is_err(), "Approved → Approved must be rejected");
+    }
+
+    #[test]
+    fn test_approved_cannot_be_rejected() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        client.approve_kyc(&admin, &subject);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.reject_kyc(&admin, &subject, &reason_hash(&env));
+        }));
+        assert!(result.is_err(), "Approved → Rejected must be rejected");
+    }
+
+    #[test]
+    fn test_pending_cannot_be_reopened() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Pending);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.reopen_kyc(&admin, &subject);
+        }));
+        assert!(result.is_err(), "Pending → Reopened must be rejected");
+    }
+
+    #[test]
+    fn test_not_submitted_cannot_be_reopened() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let subject = Address::generate(&env);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.reopen_kyc(&admin, &subject);
+        }));
+        assert!(result.is_err(), "NotSubmitted → Reopened must be rejected");
+    }
+
+    #[test]
+    fn test_resubmit_blocked_within_cooldown() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        client.reject_kyc(&admin, &subject, &reason_hash(&env));
+        client.reopen_kyc(&admin, &subject);
+
+        // Do NOT advance time — 24 h cooldown still active
+        let new_hash = Bytes::from_slice(&env, b"new_kyc_hash_padded_to_32bytes!!");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.submit_kyc(&subject, &new_hash, &attestor);
+        }));
+        assert!(result.is_err(), "Re-submission within cooldown must be rejected");
+    }
+
+    // -------------------------------------------------------------------------
+    // Recovery after rejection
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_recovery_after_rejection_via_reopen() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let attestor = Address::generate(&env);
+        let subject = Address::generate(&env);
+        register_attestor(&env, &client, &attestor);
+
+        client.submit_kyc(&subject, &data_hash(&env), &attestor);
+        client.reject_kyc(&admin, &subject, &reason_hash(&env));
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Rejected);
+
+        client.reopen_kyc(&admin, &subject);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Reopened);
+
+        set_ledger(&env, 1_000_000 + 90_001);
+        let new_hash = Bytes::from_slice(&env, b"recovery_hash_padded_to_32bytes!");
+        client.submit_kyc(&subject, &new_hash, &attestor);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Pending);
+
+        client.approve_kyc(&admin, &subject);
+        assert_eq!(client.get_kyc_status(&subject), KycStatus::Approved);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Reopened = 5` variant to `KycStatus` enum as an explicit admin-controlled gate between rejection and re-submission
- Add `reopen_kyc()` contract function allowing KYC admins to transition `Rejected → Reopened`
- Update `validate_kyc_transition()` with fully documented state machine edges including `Reopened → Pending`
- Update all `KycStatus` match arms (`current_kyc_status`, `get_kyc_status`, `get_kyc_status_internal`) to handle the new state

## Test plan

- [ ] `test_not_submitted_to_pending` — baseline NotSubmitted → Pending
- [ ] `test_pending_to_approved` — happy path approval
- [ ] `test_pending_to_rejected` — rejection path
- [ ] `test_rejected_to_reopened` — new Reopened state reachable from Rejected
- [ ] `test_reopened_to_pending_full_cycle` — full Rejected → Reopened → Pending → Approved cycle
- [ ] `test_expired_to_pending` — expired approval allows re-submission
- [ ] `test_approved_cannot_be_approved_again` — invalid transition rejected
- [ ] `test_approved_cannot_be_rejected` — invalid transition rejected
- [ ] `test_pending_cannot_be_reopened` — invalid transition rejected
- [ ] `test_not_submitted_cannot_be_reopened` — invalid transition rejected
- [ ] `test_resubmit_blocked_within_cooldown` — 24 h cooldown still enforced after reopen
- [ ] `test_recovery_after_rejection_via_reopen` — full recovery scenario

closes #594