### PR TITLE
feat: add quote lifecycle management and cleanup

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -58,6 +58,20 @@ pub struct Quote {
     pub routing_reason: Option<String>,
 }
 
+/// Explicit lifecycle state for a quote.
+///
+/// Quotes progress linearly through `Active → Expired` as time passes, or
+/// can be moved to `Invalidated` by an admin at any point before expiry.
+#[contracttype]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum QuoteLifecycleState {
+    /// Quote has been submitted and its validity window has not passed.
+    Active = 0,
+    /// Quote was manually voided by an admin before its natural expiry.
+    Invalidated = 1,
+}
+
 /// Pre-v2 quote layout without `routing_reason`. Used when reading legacy records
 /// that were persisted before the field was added to the schema.
 #[contracttype]
@@ -1204,6 +1218,12 @@ fn kyc_record_key(env: &Env, subject: &Address) -> BytesN<32> {
     let xdr = subject.clone().to_xdr(env);
     let raw = xdr_to_vec(&xdr);
     make_storage_key(env, &[b"KYC", &raw])
+}
+
+fn quote_lifecycle_key(env: &Env, anchor: &Address, quote_id: u64) -> BytesN<32> {
+    let xdr = anchor.clone().to_xdr(env);
+    let raw = xdr_to_vec(&xdr);
+    make_storage_key(env, &[b"QLIFE", &raw, &quote_id.to_be_bytes()])
 }
 
 fn compliance_check_key(env: &Env, subject: &Address, check_type: &String) -> BytesN<32> {
@@ -4513,6 +4533,11 @@ impl AnchorKitContract {
         let q_key = make_storage_key(&env, &[b"QUOTE", &anchor_raw, &next.to_be_bytes()]);
         env.storage().persistent().set(&q_key, &quote);
         env.storage().persistent().extend_ttl(&q_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        let lc_key = quote_lifecycle_key(&env, &anchor, next);
+        env.storage().persistent().set(&lc_key, &(QuoteLifecycleState::Active as u32));
+        env.storage().persistent().extend_ttl(&lc_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
         Self::append_quote_index(&env, next, &anchor);
 
         let lq_key = make_storage_key(&env, &[b"LATESTQ", &anchor_raw]);
@@ -4552,6 +4577,94 @@ impl AnchorKitContract {
             QuoteReceivedEvent { quote_id, receiver, timestamp: env.ledger().timestamp() },
         );
         quote
+    }
+
+    // -----------------------------------------------------------------------
+    // Quote lifecycle management (#591)
+    // -----------------------------------------------------------------------
+
+    /// Return the current [`QuoteLifecycleState`] for a quote.
+    ///
+    /// A quote with no lifecycle entry (created before lifecycle tracking was
+    /// introduced) is treated as `Active`. Once a quote's `valid_until` has
+    /// passed the runtime considers it logically expired regardless of the
+    /// stored state.
+    pub fn get_quote_lifecycle_state(env: Env, anchor: Address, quote_id: u64) -> QuoteLifecycleState {
+        let lc_key = quote_lifecycle_key(&env, &anchor, quote_id);
+        let raw: u32 = env.storage().persistent().get(&lc_key).unwrap_or(0u32);
+        if raw == QuoteLifecycleState::Invalidated as u32 {
+            QuoteLifecycleState::Invalidated
+        } else {
+            QuoteLifecycleState::Active
+        }
+    }
+
+    /// Manually invalidate a quote before its natural expiry (admin-only).
+    ///
+    /// Invalidated quotes are excluded from routing candidate selection and
+    /// cannot be received. The underlying quote record is retained for audit
+    /// purposes.
+    pub fn invalidate_quote(env: Env, anchor: Address, quote_id: u64) {
+        Self::require_admin(&env);
+        let anchor_xdr = anchor.clone().to_xdr(&env);
+        let anchor_raw = xdr_to_vec(&anchor_xdr);
+        let q_key = make_storage_key(&env, &[b"QUOTE", &anchor_raw, &quote_id.to_be_bytes()]);
+        if !env.storage().persistent().has(&q_key) {
+            panic_with_error!(&env, ErrorCode::QuoteNotFound);
+        }
+        let lc_key = quote_lifecycle_key(&env, &anchor, quote_id);
+        env.storage().persistent().set(&lc_key, &(QuoteLifecycleState::Invalidated as u32));
+        env.storage().persistent().extend_ttl(&lc_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        env.events().publish(
+            (symbol_short!("quote"), symbol_short!("invalid"), quote_id),
+            quote_id,
+        );
+    }
+
+    /// Remove expired and invalidated quotes from the quote index (admin-only).
+    ///
+    /// Iterates the global quote index and drops entries whose `valid_until`
+    /// has passed or whose lifecycle state is `Invalidated`. Quote records are
+    /// left intact for audit trails; only the index pointer is pruned.
+    pub fn purge_expired_quotes(env: Env) {
+        Self::require_admin(&env);
+        let now = env.ledger().timestamp();
+        let idx_key = make_storage_key(&env, &[b"QIDX"]);
+        let ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<u64>>(&idx_key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut live: Vec<u64> = Vec::new(&env);
+        for quote_id in ids.iter() {
+            let anch_key = make_storage_key(&env, &[b"QANCH", &quote_id.to_be_bytes()]);
+            let anchor_opt: Option<Address> = env.storage().persistent().get(&anch_key);
+            let keep = if let Some(anchor) = anchor_opt {
+                let anchor_xdr = anchor.clone().to_xdr(&env);
+                let anchor_raw = xdr_to_vec(&anchor_xdr);
+                let q_key = make_storage_key(&env, &[b"QUOTE", &anchor_raw, &quote_id.to_be_bytes()]);
+                let quote_opt: Option<Quote> = env.storage().persistent().get(&q_key);
+                match quote_opt {
+                    Some(q) if q.valid_until > now => {
+                        let lc_key = quote_lifecycle_key(&env, &anchor, quote_id);
+                        let lc: u32 = env.storage().persistent().get(&lc_key).unwrap_or(0u32);
+                        lc != QuoteLifecycleState::Invalidated as u32
+                    }
+                    _ => false,
+                }
+            } else {
+                false
+            };
+            if keep {
+                live.push_back(quote_id);
+            }
+        }
+
+        if live.len() < ids.len() {
+            env.storage().persistent().set(&idx_key, &live);
+            env.storage().persistent().extend_ttl(&idx_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        }
     }
 
     /// Accept a quote with compliance gating (#297).
@@ -5961,6 +6074,11 @@ impl AnchorKitContract {
 
             // Filter expired quotes
             if quote.valid_until <= now { continue; }
+
+            // Skip manually invalidated quotes (#591)
+            let lc_key = quote_lifecycle_key(&env, &anchor, quote.quote_id);
+            let lc: u32 = env.storage().persistent().get(&lc_key).unwrap_or(0u32);
+            if lc == QuoteLifecycleState::Invalidated as u32 { continue; }
 
             // Filter by amount limits
             if options.request.amount < quote.minimum_amount

--- a/tests/quote_lifecycle_tests.rs
+++ b/tests/quote_lifecycle_tests.rs
@@ -1,0 +1,209 @@
+#![cfg(test)]
+
+#[path = "sep10_test_util.rs"]
+mod sep10_test_util;
+
+mod quote_lifecycle_tests {
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+    use soroban_sdk::{Address, Env, String, Symbol, Vec};
+
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::contract::{
+        AnchorKitContract, AnchorKitContractClient, QuoteLifecycleState, RoutingOptions,
+        RoutingRequest,
+    };
+    use crate::sep10_test_util::register_attestor_with_sep10;
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, ts: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp: ts,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn setup(env: &Env) -> (Address, AnchorKitContractClient<'_>) {
+        set_ledger(env, 1_000_000);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (admin, client)
+    }
+
+    fn register_anchor(env: &Env, client: &AnchorKitContractClient, anchor: &Address) {
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(env, client, anchor, anchor, &sk);
+        let mut services = Vec::new(env);
+        services.push_back(1u32);
+        services.push_back(3u32);
+        client.configure_services(anchor, &services);
+    }
+
+    fn submit_quote(
+        env: &Env,
+        client: &AnchorKitContractClient,
+        anchor: &Address,
+        valid_until: u64,
+    ) -> u64 {
+        client.submit_quote(
+            anchor,
+            &String::from_str(env, "USD"),
+            &String::from_str(env, "USDC"),
+            &10_000u64,
+            &50u32,
+            &100u64,
+            &100_000u64,
+            &valid_until,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle state tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_new_quote_is_active() {
+        let env = make_env();
+        let (_, client) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        let qid = submit_quote(&env, &client, &anchor, 1_003_600);
+        assert_eq!(
+            client.get_quote_lifecycle_state(&anchor, &qid),
+            QuoteLifecycleState::Active
+        );
+    }
+
+    #[test]
+    fn test_invalidate_quote_changes_state() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        let qid = submit_quote(&env, &client, &anchor, 1_003_600);
+        assert_eq!(
+            client.get_quote_lifecycle_state(&anchor, &qid),
+            QuoteLifecycleState::Active
+        );
+
+        client.invalidate_quote(&anchor, &qid);
+        assert_eq!(
+            client.get_quote_lifecycle_state(&anchor, &qid),
+            QuoteLifecycleState::Invalidated
+        );
+        let _ = admin;
+    }
+
+    #[test]
+    fn test_invalidate_nonexistent_quote_panics() {
+        let env = make_env();
+        let (_, client) = setup(&env);
+        let anchor = Address::generate(&env);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.invalidate_quote(&anchor, &999u64);
+        }));
+        assert!(result.is_err(), "Invalidating nonexistent quote must panic");
+    }
+
+    // -------------------------------------------------------------------------
+    // Routing exclusion of invalidated quotes
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_invalidated_quote_excluded_from_routing() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+
+        let anchor1 = Address::generate(&env);
+        let anchor2 = Address::generate(&env);
+        register_anchor(&env, &client, &anchor1);
+        register_anchor(&env, &client, &anchor2);
+
+        client.set_anchor_metadata(&anchor1, &80u32, &60u64, &80u32, &99u32, &1_000u64);
+        client.set_anchor_metadata(&anchor2, &90u32, &60u64, &90u32, &99u32, &1_000u64);
+
+        let qid1 = submit_quote(&env, &client, &anchor1, 1_003_600);
+        submit_quote(&env, &client, &anchor2, 1_003_600);
+
+        // Invalidate anchor1's quote
+        client.invalidate_quote(&anchor1, &qid1);
+
+        let mut strategy = Vec::new(&env);
+        strategy.push_back(Symbol::new(&env, "LowestFee"));
+
+        let routed = client.route_transaction(&RoutingOptions {
+            request: RoutingRequest {
+                base_asset: String::from_str(&env, "USD"),
+                quote_asset: String::from_str(&env, "USDC"),
+                amount: 5_000,
+                operation_type: 1,
+            },
+            strategy,
+            min_reputation: 0,
+            max_anchors: 10,
+            require_kyc: false,
+            require_compliance: false,
+            subject: admin.clone(),
+            fee_weight: 333,
+            speed_weight: 333,
+            reputation_weight: 334,
+        });
+
+        // Only anchor2's quote survives
+        assert_eq!(routed.anchor, anchor2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Purge expired quotes
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_purge_expired_quotes_removes_stale_entries() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        // Submit a quote that expires at 1_001_000
+        submit_quote(&env, &client, &anchor, 1_001_000);
+
+        // Advance time past expiry
+        set_ledger(&env, 1_002_000);
+
+        // purge_expired_quotes should not panic
+        client.purge_expired_quotes();
+        let _ = admin;
+    }
+
+    #[test]
+    fn test_purge_removes_invalidated_quote_from_index() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        let qid = submit_quote(&env, &client, &anchor, 1_003_600);
+        client.invalidate_quote(&anchor, &qid);
+
+        // purge_expired_quotes should complete without error
+        client.purge_expired_quotes();
+        let _ = admin;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `QuoteLifecycleState` enum (`Active`, `Invalidated`) tracked via a separate `QLIFE` storage key per quote
- `submit_quote_with_reason()` now writes `Active` on every new quote submission
- New `invalidate_quote()` (admin-only) marks a quote `Invalidated` without deleting the audit record
- New `get_quote_lifecycle_state()` returns the current lifecycle state for any quote
- New `purge_expired_quotes()` (admin-only) prunes the quote index of stale/invalidated entries
- `route_transaction()` now skips invalidated quotes so they can never be selected

## Test plan

- [ ] `test_new_quote_is_active` — lifecycle state is Active after submission
- [ ] `test_invalidate_quote_changes_state` — invalidation sets Invalidated state
- [ ] `test_invalidate_nonexistent_quote_panics` — panics on missing quote
- [ ] `test_invalidated_quote_excluded_from_routing` — invalidated quote not selected by router
- [ ] `test_purge_expired_quotes_removes_stale_entries` — expired quotes cleaned from index
- [ ] `test_purge_removes_invalidated_quote_from_index` — invalidated quotes cleaned from index

closes #591