### PR TITLE
feat: add fallback quote selection for degraded anchors

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -58,6 +58,15 @@ pub struct Quote {
     pub routing_reason: Option<String>,
 }
 
+/// Explicit lifecycle state for a quote (#591, also used by fallback routing).
+#[contracttype]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum QuoteLifecycleState {
+    Active = 0,
+    Invalidated = 1,
+}
+
 /// Pre-v2 quote layout without `routing_reason`. Used when reading legacy records
 /// that were persisted before the field was added to the schema.
 #[contracttype]
@@ -1204,6 +1213,12 @@ fn kyc_record_key(env: &Env, subject: &Address) -> BytesN<32> {
     let xdr = subject.clone().to_xdr(env);
     let raw = xdr_to_vec(&xdr);
     make_storage_key(env, &[b"KYC", &raw])
+}
+
+fn quote_lifecycle_key(env: &Env, anchor: &Address, quote_id: u64) -> BytesN<32> {
+    let xdr = anchor.clone().to_xdr(env);
+    let raw = xdr_to_vec(&xdr);
+    make_storage_key(env, &[b"QLIFE", &raw, &quote_id.to_be_bytes()])
 }
 
 fn compliance_check_key(env: &Env, subject: &Address, check_type: &String) -> BytesN<32> {
@@ -6107,6 +6122,74 @@ impl AnchorKitContract {
         );
 
         best
+    }
+
+    // -----------------------------------------------------------------------
+    // Fallback quote selection (#593)
+    // -----------------------------------------------------------------------
+
+    /// Route a transaction with explicit fallback anchor support.
+    ///
+    /// Behaves identically to [`route_transaction`] but first attempts to use
+    /// the quote from `preferred_anchor`. If that anchor is unavailable,
+    /// blacklisted, or has no valid non-invalidated quote for the requested
+    /// asset pair, the function falls back to the normal scoring strategy over
+    /// all remaining candidates and emits a `quote/fallback` event so the
+    /// selection is auditable.
+    pub fn route_with_fallback(
+        env: Env,
+        options: RoutingOptions,
+        preferred_anchor: Address,
+    ) -> Quote {
+        validate_currency_code(&env, &options.request.base_asset);
+        validate_currency_code(&env, &options.request.quote_asset);
+        let now = env.ledger().timestamp();
+
+        // Try the preferred anchor first.
+        let preferred_quote: Option<Quote> = (|| {
+            if Self::is_anchor_blacklisted_internal(&env, &preferred_anchor) {
+                return None;
+            }
+            let meta: RoutingAnchorMeta = anchor_meta_opt(&env, &preferred_anchor)?;
+            if !meta.is_active { return None; }
+            let anchor_xdr = preferred_anchor.clone().to_xdr(&env);
+            let anchor_raw = xdr_to_vec(&anchor_xdr);
+            let lq_key = make_storage_key(&env, &[b"LATESTQ", &anchor_raw]);
+            let quote_id: u64 = env.storage().persistent().get(&lq_key)?;
+            let q_key = make_storage_key(&env, &[b"QUOTE", &anchor_raw, &quote_id.to_be_bytes()]);
+            let quote: Quote = env.storage().persistent().get(&q_key)?;
+            if quote.base_asset != options.request.base_asset
+                || quote.quote_asset != options.request.quote_asset
+            {
+                return None;
+            }
+            if quote.valid_until <= now { return None; }
+            let lc_key = quote_lifecycle_key(&env, &preferred_anchor, quote_id);
+            let lc: u32 = env.storage().persistent().get(&lc_key).unwrap_or(0u32);
+            if lc == QuoteLifecycleState::Invalidated as u32 { return None; }
+            if options.request.amount < quote.minimum_amount
+                || (quote.maximum_amount != 0 && options.request.amount > quote.maximum_amount)
+            {
+                return None;
+            }
+            Some(quote)
+        })();
+
+        if let Some(q) = preferred_quote {
+            env.events().publish(
+                (symbol_short!("quote"), symbol_short!("routed"), q.quote_id),
+                q.quote_id,
+            );
+            return q;
+        }
+
+        // Preferred anchor unavailable — fall back to standard routing and
+        // emit a fallback event so the decision is auditable.
+        env.events().publish(
+            (symbol_short!("quote"), symbol_short!("fallback"), 0u64),
+            0u64,
+        );
+        Self::route_transaction(env, options)
     }
 
     /// Return up to `max_results` quotes sorted by descending weighted composite score.

--- a/tests/fallback_quote_tests.rs
+++ b/tests/fallback_quote_tests.rs
@@ -1,0 +1,268 @@
+#![cfg(test)]
+
+#[path = "sep10_test_util.rs"]
+mod sep10_test_util;
+
+mod fallback_quote_tests {
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+    use soroban_sdk::{Address, Env, String, Symbol, Vec};
+
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::contract::{
+        AnchorKitContract, AnchorKitContractClient, RoutingOptions, RoutingRequest,
+    };
+    use crate::sep10_test_util::register_attestor_with_sep10;
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, ts: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp: ts,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn setup(env: &Env) -> (Address, AnchorKitContractClient<'_>) {
+        set_ledger(env, 1_000_000);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (admin, client)
+    }
+
+    fn register_anchor(env: &Env, client: &AnchorKitContractClient, anchor: &Address) {
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(env, client, anchor, anchor, &sk);
+        let mut services = Vec::new(env);
+        services.push_back(1u32);
+        services.push_back(3u32);
+        client.configure_services(anchor, &services);
+    }
+
+    fn base_options(env: &Env, admin: &Address) -> RoutingOptions {
+        let mut strategy = Vec::new(env);
+        strategy.push_back(Symbol::new(env, "LowestFee"));
+        RoutingOptions {
+            request: RoutingRequest {
+                base_asset: String::from_str(env, "USD"),
+                quote_asset: String::from_str(env, "USDC"),
+                amount: 5_000,
+                operation_type: 1,
+            },
+            strategy,
+            min_reputation: 0,
+            max_anchors: 10,
+            require_kyc: false,
+            require_compliance: false,
+            subject: admin.clone(),
+            fee_weight: 333,
+            speed_weight: 333,
+            reputation_weight: 334,
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Preferred anchor is available — should be selected directly
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_preferred_anchor_used_when_available() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+
+        let preferred = Address::generate(&env);
+        let other = Address::generate(&env);
+        register_anchor(&env, &client, &preferred);
+        register_anchor(&env, &client, &other);
+
+        client.set_anchor_metadata(&preferred, &80u32, &60u64, &80u32, &99u32, &1_000u64);
+        client.set_anchor_metadata(&other, &90u32, &60u64, &90u32, &99u32, &1_000u64);
+
+        // preferred has a higher fee but is still valid
+        client.submit_quote(
+            &preferred,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10_000u64,
+            &100u32,
+            &100u64,
+            &100_000u64,
+            &1_003_600u64,
+        );
+        client.submit_quote(
+            &other,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10_000u64,
+            &20u32,
+            &100u64,
+            &100_000u64,
+            &1_003_600u64,
+        );
+
+        let result = client.route_with_fallback(&base_options(&env, &admin), &preferred);
+        assert_eq!(result.anchor, preferred, "Preferred anchor must be selected when available");
+    }
+
+    // -------------------------------------------------------------------------
+    // Preferred anchor has no quote — fallback to best alternative
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_fallback_used_when_preferred_has_no_quote() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+
+        let preferred = Address::generate(&env);
+        let fallback = Address::generate(&env);
+        register_anchor(&env, &client, &preferred);
+        register_anchor(&env, &client, &fallback);
+
+        client.set_anchor_metadata(&preferred, &80u32, &60u64, &80u32, &99u32, &1_000u64);
+        client.set_anchor_metadata(&fallback, &90u32, &60u64, &90u32, &99u32, &1_000u64);
+
+        // Only the fallback anchor has a quote
+        client.submit_quote(
+            &fallback,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10_000u64,
+            &20u32,
+            &100u64,
+            &100_000u64,
+            &1_003_600u64,
+        );
+
+        let result = client.route_with_fallback(&base_options(&env, &admin), &preferred);
+        assert_eq!(result.anchor, fallback, "Fallback anchor must be used when preferred has no quote");
+    }
+
+    // -------------------------------------------------------------------------
+    // Preferred anchor quote is expired — fallback triggered
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_fallback_used_when_preferred_quote_expired() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+
+        let preferred = Address::generate(&env);
+        let fallback = Address::generate(&env);
+        register_anchor(&env, &client, &preferred);
+        register_anchor(&env, &client, &fallback);
+
+        client.set_anchor_metadata(&preferred, &80u32, &60u64, &80u32, &99u32, &1_000u64);
+        client.set_anchor_metadata(&fallback, &90u32, &60u64, &90u32, &99u32, &1_000u64);
+
+        // Preferred quote expires at t=1_000_500 (500 s from now)
+        client.submit_quote(
+            &preferred,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10_000u64,
+            &50u32,
+            &100u64,
+            &100_000u64,
+            &1_000_500u64,
+        );
+        // Fallback quote valid for 1 hour
+        client.submit_quote(
+            &fallback,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10_000u64,
+            &30u32,
+            &100u64,
+            &100_000u64,
+            &1_003_600u64,
+        );
+
+        // Advance time past preferred's expiry
+        set_ledger(&env, 1_001_000);
+
+        let result = client.route_with_fallback(&base_options(&env, &admin), &preferred);
+        assert_eq!(result.anchor, fallback, "Fallback anchor must be used when preferred quote is expired");
+    }
+
+    // -------------------------------------------------------------------------
+    // Preferred anchor is blacklisted — fallback triggered
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_fallback_used_when_preferred_is_blacklisted() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+
+        let preferred = Address::generate(&env);
+        let fallback = Address::generate(&env);
+        register_anchor(&env, &client, &preferred);
+        register_anchor(&env, &client, &fallback);
+
+        client.set_anchor_metadata(&preferred, &80u32, &60u64, &80u32, &99u32, &1_000u64);
+        client.set_anchor_metadata(&fallback, &90u32, &60u64, &90u32, &99u32, &1_000u64);
+
+        client.submit_quote(
+            &preferred,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10_000u64,
+            &50u32,
+            &100u64,
+            &100_000u64,
+            &1_003_600u64,
+        );
+        client.submit_quote(
+            &fallback,
+            &String::from_str(&env, "USD"),
+            &String::from_str(&env, "USDC"),
+            &10_000u64,
+            &30u32,
+            &100u64,
+            &100_000u64,
+            &1_003_600u64,
+        );
+
+        // Blacklist the preferred anchor
+        client.blacklist_anchor(
+            &preferred,
+            &String::from_str(&env, "test_blacklist"),
+        );
+
+        let result = client.route_with_fallback(&base_options(&env, &admin), &preferred);
+        assert_eq!(result.anchor, fallback, "Fallback anchor must be used when preferred is blacklisted");
+        let _ = admin;
+    }
+
+    // -------------------------------------------------------------------------
+    // No fallback available — must panic with NoQuotesAvailable
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_no_fallback_panics_when_no_quotes() {
+        let env = make_env();
+        let (admin, client) = setup(&env);
+
+        let preferred = Address::generate(&env);
+        register_anchor(&env, &client, &preferred);
+        client.set_anchor_metadata(&preferred, &80u32, &60u64, &80u32, &99u32, &1_000u64);
+        // No quotes submitted at all
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.route_with_fallback(&base_options(&env, &admin), &preferred);
+        }));
+        assert!(result.is_err(), "Must panic when no quotes are available");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `route_with_fallback(env, options, preferred_anchor)` contract function that first attempts the preferred anchor's quote before falling back to normal weighted-score routing
- The preferred path is skipped when the anchor is blacklisted, inactive, has no valid quote, quote is expired, quote is invalidated, or the request amount is outside the quote's limits
- A `quote/fallback` event is emitted whenever the primary path is bypassed, making every fallback decision deterministic and auditable
- Falls back to `route_transaction()` internally, so all existing strategy modes (LowestFee, FastestSettlement, WeightedScore) continue to apply on the fallback path

## Test plan

- [ ] `test_preferred_anchor_used_when_available` — preferred anchor selected when its quote is valid
- [ ] `test_fallback_used_when_preferred_has_no_quote` — fallback anchor selected when preferred has no quote
- [ ] `test_fallback_used_when_preferred_quote_expired` — fallback triggered when preferred quote is expired
- [ ] `test_fallback_used_when_preferred_is_blacklisted` — fallback triggered when preferred is blacklisted
- [ ] `test_no_fallback_panics_when_no_quotes` — NoQuotesAvailable when nothing available

closes #593