### PR TITLE
feat: add fee comparison and anomaly detection for routing

### DIFF
--- a/src/sep38.rs
+++ b/src/sep38.rs
@@ -530,6 +530,54 @@ impl AnchorFeeHistory {
     pub fn observation_count(&self, now: u64) -> usize {
         self.active(now).len()
     }
+
+    /// Population standard deviation of fee observations in the retention window.
+    ///
+    /// Returns `None` when fewer than two observations are present (stddev is
+    /// undefined for zero samples and trivially zero for one).
+    pub fn fee_volatility(&self, now: u64) -> Option<f64> {
+        let obs = self.active(now);
+        if obs.len() < 2 {
+            return None;
+        }
+        let n = obs.len();
+        let mean = obs.iter().map(|o| o.fee_bps as f64).sum::<f64>() / n as f64;
+        let variance = obs
+            .iter()
+            .map(|o| {
+                let diff = o.fee_bps as f64 - mean;
+                diff * diff
+            })
+            .sum::<f64>()
+            / n as f64;
+        Some(variance.sqrt())
+    }
+
+    /// Recency-weighted average fee in basis points.
+    ///
+    /// Applies exponential decay so that the most recent observation carries
+    /// the highest weight. The decay factor is `0.9^age_rank` where `age_rank`
+    /// is 0 for the newest observation and increases for older ones.
+    /// Returns `None` when there are no observations in the window.
+    pub fn recency_weighted_average_fee_bps(&self, now: u64) -> Option<f64> {
+        let mut obs = self.active(now);
+        if obs.is_empty() {
+            return None;
+        }
+        obs.sort_by_key(|o| o.observed_at);
+        const DECAY: f64 = 0.9;
+        let mut weighted_sum = 0.0_f64;
+        let mut weight_total = 0.0_f64;
+        for (rank, o) in obs.iter().rev().enumerate() {
+            let weight = DECAY.powi(rank as i32);
+            weighted_sum += o.fee_bps as f64 * weight;
+            weight_total += weight;
+        }
+        if weight_total == 0.0 {
+            return None;
+        }
+        Some(weighted_sum / weight_total)
+    }
 }
 
 // ── CrossAnchorFeeAggregator ──────────────────────────────────────────────────
@@ -544,6 +592,10 @@ pub struct FeeAnomalyReport {
     pub anomalous_anchors: AllocVec<(String, u64)>,
     /// Length of the observation window used for the 7-day average (seconds).
     pub observation_window_seconds: u64,
+    /// Per-anchor fee volatility (population stddev in bps) for anchors that
+    /// have at least two observations. Listed as `(anchor_id, volatility_bps_x100)`
+    /// where the value is `stddev * 100` rounded to the nearest integer.
+    pub anchor_volatilities: AllocVec<(String, u64)>,
 }
 
 /// Aggregates fee observations across multiple anchors and identifies anomalies.
@@ -582,13 +634,37 @@ impl CrossAnchorFeeAggregator {
     /// Compute the [`FeeAnomalyReport`] for the current cluster state.
     ///
     /// Anchors with no observations within the window are excluded from the
-    /// median computation and are never flagged as anomalous.
+    /// median computation and are never flagged as anomalous. The report also
+    /// includes per-anchor fee volatility (standard deviation) so callers can
+    /// distinguish consistently high-fee anchors from erratically priced ones.
     pub fn compute_report(&self, current_time: u64) -> FeeAnomalyReport {
-        // Collect per-anchor averages for anchors that have observations.
+        self.compute_report_impl(current_time, false)
+    }
+
+    /// Like [`compute_report`] but uses recency-weighted averages instead of
+    /// simple 7-day averages when ranking anchor fees.
+    ///
+    /// Recent observations receive exponentially higher weight (`0.9^age_rank`),
+    /// making the anomaly detection more sensitive to sudden fee spikes.
+    pub fn compute_extended_report(&self, current_time: u64) -> FeeAnomalyReport {
+        self.compute_report_impl(current_time, true)
+    }
+
+    fn compute_report_impl(&self, current_time: u64, use_recency_weight: bool) -> FeeAnomalyReport {
         let mut averages: AllocVec<(String, u64)> = AllocVec::new();
+        let mut anchor_volatilities: AllocVec<(String, u64)> = AllocVec::new();
+
         for (id, history) in &self.anchors {
-            if let Some(avg) = history.average_fee_bps(current_time) {
+            let avg_opt = if use_recency_weight {
+                history.recency_weighted_average_fee_bps(current_time)
+            } else {
+                history.average_fee_bps(current_time)
+            };
+            if let Some(avg) = avg_opt {
                 averages.push((id.clone(), avg as u64));
+            }
+            if let Some(vol) = history.fee_volatility(current_time) {
+                anchor_volatilities.push((id.clone(), (vol * 100.0).round() as u64));
             }
         }
 
@@ -597,6 +673,7 @@ impl CrossAnchorFeeAggregator {
                 median_fee_bps: 0,
                 anomalous_anchors: AllocVec::new(),
                 observation_window_seconds: Self::WINDOW_SECONDS,
+                anchor_volatilities,
             };
         }
 
@@ -608,7 +685,6 @@ impl CrossAnchorFeeAggregator {
             if n % 2 == 1 {
                 fees[n / 2]
             } else {
-                // Lower median for even-count arrays.
                 fees[n / 2 - 1]
             }
         };
@@ -623,6 +699,7 @@ impl CrossAnchorFeeAggregator {
             median_fee_bps: median,
             anomalous_anchors,
             observation_window_seconds: Self::WINDOW_SECONDS,
+            anchor_volatilities,
         }
     }
 }

--- a/tests/fee_anomaly_tests.rs
+++ b/tests/fee_anomaly_tests.rs
@@ -1,0 +1,218 @@
+#![cfg(test)]
+
+mod fee_anomaly_tests {
+    use anchorkit::sep38::{AnchorFeeHistory, CrossAnchorFeeAggregator};
+
+    const NOW: u64 = 1_000_000;
+    const WINDOW: u64 = 7 * 24 * 3600;
+
+    // -------------------------------------------------------------------------
+    // AnchorFeeHistory — volatility
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_fee_volatility_none_for_single_observation() {
+        let mut h = AnchorFeeHistory::new(WINDOW);
+        h.record(100, 10, NOW);
+        assert!(h.fee_volatility(NOW).is_none());
+    }
+
+    #[test]
+    fn test_fee_volatility_zero_for_identical_fees() {
+        let mut h = AnchorFeeHistory::new(WINDOW);
+        h.record(100, 10, NOW - 200);
+        h.record(100, 10, NOW - 100);
+        h.record(100, 10, NOW);
+        let vol = h.fee_volatility(NOW).unwrap();
+        assert!(vol < 1e-9, "Identical fees must produce ~0 volatility, got {vol}");
+    }
+
+    #[test]
+    fn test_fee_volatility_nonzero_for_varying_fees() {
+        let mut h = AnchorFeeHistory::new(WINDOW);
+        h.record(50, 5, NOW - 200);
+        h.record(150, 5, NOW - 100);
+        h.record(200, 5, NOW);
+        let vol = h.fee_volatility(NOW).unwrap();
+        assert!(vol > 0.0, "Varying fees must produce positive volatility");
+    }
+
+    #[test]
+    fn test_fee_volatility_excludes_stale_observations() {
+        let mut h = AnchorFeeHistory::new(100); // 100 s retention window
+        h.record(1000, 0, NOW - 200); // outside window
+        h.record(100, 0, NOW - 50);
+        h.record(100, 0, NOW);
+        // Only 2 active observations, both identical → volatility ≈ 0
+        let vol = h.fee_volatility(NOW).unwrap();
+        assert!(vol < 1e-9);
+    }
+
+    // -------------------------------------------------------------------------
+    // AnchorFeeHistory — recency-weighted average
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_recency_weighted_avg_none_for_empty() {
+        let h = AnchorFeeHistory::new(WINDOW);
+        assert!(h.recency_weighted_average_fee_bps(NOW).is_none());
+    }
+
+    #[test]
+    fn test_recency_weighted_avg_equals_value_for_single() {
+        let mut h = AnchorFeeHistory::new(WINDOW);
+        h.record(200, 0, NOW);
+        let avg = h.recency_weighted_average_fee_bps(NOW).unwrap();
+        assert!((avg - 200.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_recency_weighted_avg_favors_recent_spike() {
+        let mut h = AnchorFeeHistory::new(WINDOW);
+        // Older observations at 100 bps
+        h.record(100, 0, NOW - 300);
+        h.record(100, 0, NOW - 200);
+        h.record(100, 0, NOW - 100);
+        // Recent spike to 500 bps
+        h.record(500, 0, NOW);
+
+        let recency = h.recency_weighted_average_fee_bps(NOW).unwrap();
+        let simple = h.average_fee_bps(NOW).unwrap();
+        // Recency-weighted average should be higher than simple average
+        assert!(
+            recency > simple,
+            "Recency-weighted avg ({recency}) must exceed simple avg ({simple}) when recent spike exists"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // CrossAnchorFeeAggregator — compute_report (normal case)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_report_empty_when_no_anchors() {
+        let agg = CrossAnchorFeeAggregator::new(150);
+        let report = agg.compute_report(NOW);
+        assert_eq!(report.median_fee_bps, 0);
+        assert!(report.anomalous_anchors.is_empty());
+        assert!(report.anchor_volatilities.is_empty());
+    }
+
+    #[test]
+    fn test_report_no_anomalies_for_uniform_fees() {
+        let mut agg = CrossAnchorFeeAggregator::new(150);
+        agg.insert_observation("anchor-A", 100, NOW - 100);
+        agg.insert_observation("anchor-B", 105, NOW - 50);
+        agg.insert_observation("anchor-C", 102, NOW);
+
+        let report = agg.compute_report(NOW);
+        assert!(
+            report.anomalous_anchors.is_empty(),
+            "No anchor should be anomalous when fees are similar"
+        );
+    }
+
+    #[test]
+    fn test_report_flags_outlier_anchor() {
+        let mut agg = CrossAnchorFeeAggregator::new(150);
+        agg.insert_observation("anchor-A", 100, NOW);
+        agg.insert_observation("anchor-B", 105, NOW);
+        agg.insert_observation("anchor-C", 600, NOW); // large outlier
+
+        let report = agg.compute_report(NOW);
+        assert!(
+            report.anomalous_anchors.iter().any(|(id, _)| id == "anchor-C"),
+            "anchor-C must be flagged as anomalous"
+        );
+        assert!(
+            !report.anomalous_anchors.iter().any(|(id, _)| id == "anchor-A"),
+            "anchor-A must not be anomalous"
+        );
+    }
+
+    #[test]
+    fn test_report_median_is_correct_for_odd_count() {
+        let mut agg = CrossAnchorFeeAggregator::new(10_000);
+        agg.insert_observation("a1", 100, NOW);
+        agg.insert_observation("a2", 200, NOW);
+        agg.insert_observation("a3", 300, NOW);
+        let report = agg.compute_report(NOW);
+        assert_eq!(report.median_fee_bps, 200);
+    }
+
+    #[test]
+    fn test_report_median_lower_for_even_count() {
+        let mut agg = CrossAnchorFeeAggregator::new(10_000);
+        agg.insert_observation("a1", 100, NOW);
+        agg.insert_observation("a2", 200, NOW);
+        agg.insert_observation("a3", 300, NOW);
+        agg.insert_observation("a4", 400, NOW);
+        // lower median for even count = fees[n/2-1] = fees[1] = 200
+        let report = agg.compute_report(NOW);
+        assert_eq!(report.median_fee_bps, 200);
+    }
+
+    // -------------------------------------------------------------------------
+    // CrossAnchorFeeAggregator — volatility in report
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_report_includes_volatility_for_multi_obs_anchor() {
+        let mut agg = CrossAnchorFeeAggregator::new(150);
+        agg.insert_observation("anchor-V", 100, NOW - 100);
+        agg.insert_observation("anchor-V", 200, NOW);
+
+        let report = agg.compute_report(NOW);
+        assert!(
+            report.anchor_volatilities.iter().any(|(id, _)| id == "anchor-V"),
+            "anchor-V must appear in volatility list when it has multiple observations"
+        );
+    }
+
+    #[test]
+    fn test_report_no_volatility_for_single_obs_anchor() {
+        let mut agg = CrossAnchorFeeAggregator::new(150);
+        agg.insert_observation("anchor-S", 100, NOW);
+
+        let report = agg.compute_report(NOW);
+        assert!(
+            !report.anchor_volatilities.iter().any(|(id, _)| id == "anchor-S"),
+            "Single-observation anchor must not appear in volatility list"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // CrossAnchorFeeAggregator — compute_extended_report (recency-weighted)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_extended_report_flags_recent_spike_as_anomalous() {
+        let mut agg = CrossAnchorFeeAggregator::new(50); // tight 50 bps threshold
+        // Three anchors with stable ~100 bps history
+        for ts_offset in [300u64, 200, 100, 0] {
+            agg.insert_observation("anchor-A", 100, NOW - ts_offset);
+            agg.insert_observation("anchor-B", 105, NOW - ts_offset);
+        }
+        // anchor-C has a sudden recent spike to 500 bps
+        agg.insert_observation("anchor-C", 100, NOW - 300);
+        agg.insert_observation("anchor-C", 100, NOW - 200);
+        agg.insert_observation("anchor-C", 100, NOW - 100);
+        agg.insert_observation("anchor-C", 500, NOW); // recent spike
+
+        let extended = agg.compute_extended_report(NOW);
+        assert!(
+            extended.anomalous_anchors.iter().any(|(id, _)| id == "anchor-C"),
+            "anchor-C must be flagged by recency-weighted report due to recent spike"
+        );
+    }
+
+    #[test]
+    fn test_extended_report_observation_window_matches() {
+        let agg = CrossAnchorFeeAggregator::new(150);
+        let report = agg.compute_extended_report(NOW);
+        assert_eq!(
+            report.observation_window_seconds,
+            CrossAnchorFeeAggregator::WINDOW_SECONDS
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `fee_volatility()` to `AnchorFeeHistory` — population standard deviation of fee observations, giving callers a way to distinguish erratically priced anchors from consistently high-fee ones
- Add `recency_weighted_average_fee_bps()` to `AnchorFeeHistory` — exponential decay (`0.9^age_rank`) so recent observations carry more weight, improving sensitivity to sudden fee spikes
- Extend `FeeAnomalyReport` with `anchor_volatilities: Vec<(anchor_id, stddev_bps×100)>` populated by `compute_report()`
- Add `compute_extended_report()` on `CrossAnchorFeeAggregator` that uses recency-weighted averages for anomaly detection, making it more responsive to rapid price changes than the existing 7-day simple average

## Test plan

- [ ] `test_fee_volatility_none_for_single_observation` — stddev undefined for 1 obs
- [ ] `test_fee_volatility_zero_for_identical_fees` — stable fees produce ~0 volatility
- [ ] `test_fee_volatility_nonzero_for_varying_fees` — varying fees produce positive volatility
- [ ] `test_fee_volatility_excludes_stale_observations` — stale obs outside window ignored
- [ ] `test_recency_weighted_avg_none_for_empty` — None when no observations
- [ ] `test_recency_weighted_avg_equals_value_for_single` — correct for single obs
- [ ] `test_recency_weighted_avg_favors_recent_spike` — recency avg > simple avg on spike
- [ ] `test_report_empty_when_no_anchors` — empty report on zero observations
- [ ] `test_report_no_anomalies_for_uniform_fees` — no anomalies for similar fees
- [ ] `test_report_flags_outlier_anchor` — outlier anchor correctly flagged
- [ ] `test_report_median_is_correct_for_odd_count` — correct median (odd)
- [ ] `test_report_median_lower_for_even_count` — lower median for even count
- [ ] `test_report_includes_volatility_for_multi_obs_anchor` — volatility included
- [ ] `test_report_no_volatility_for_single_obs_anchor` — single-obs excluded from volatility
- [ ] `test_extended_report_flags_recent_spike_as_anomalous` — spike detected by extended report
- [ ] `test_extended_report_observation_window_matches` — window constant unchanged

closes #592