### PR TITLE
feat: attestation pagination/filtering and SEP-10 verification hardening

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -129,6 +129,40 @@ pub struct Attestation {
     pub schema_version: u32,
 }
 
+/// Filter parameters accepted by [`AnchorKitContract::get_attestations_paginated`].
+///
+/// Every field is optional; `None` means "no restriction on this dimension".
+/// When multiple fields are set the results must satisfy **all** of them
+/// (logical AND).
+#[contracttype]
+#[derive(Clone)]
+pub struct AttestationFilter {
+    /// When `Some`, only attestations whose `issuer` matches are returned.
+    pub issuer: Option<Address>,
+    /// When `Some`, only attestations whose `subject` matches are returned.
+    pub subject: Option<Address>,
+    /// When `Some`, only attestations with `timestamp >= from_timestamp` are returned.
+    pub from_timestamp: Option<u64>,
+    /// When `Some`, only attestations with `timestamp <= to_timestamp` are returned.
+    pub to_timestamp: Option<u64>,
+    /// When `Some`, only attestations whose numeric `id >= min_id` are returned.
+    pub min_id: Option<u64>,
+}
+
+/// A single page of attestation records returned by
+/// [`AnchorKitContract::get_attestations_paginated`].
+#[contracttype]
+#[derive(Clone)]
+pub struct AttestationPage {
+    /// The attestation records in this page, in ascending ID order.
+    pub records: Vec<Attestation>,
+    /// The offset that should be passed to the next call to continue iteration,
+    /// or `total` when this is the last page.
+    pub next_offset: u64,
+    /// Total number of attestations stored (unfiltered upper bound for iteration).
+    pub total: u64,
+}
+
 /// Input record for [`AnchorKitContract::submit_attestation_batch`].
 #[contracttype]
 #[derive(Clone)]
@@ -1137,6 +1171,14 @@ const INSTANCE_TTL: u32 = 518_400;
 
 /// Default session lifetime in seconds (1 hour). Used when session_ttl_seconds is zero.
 pub const DEFAULT_SESSION_TTL: u64 = 3600;
+
+/// Maximum number of attestations that can be submitted in a single batch call.
+pub const MAX_BATCH_SIZE: usize = 25;
+
+/// Rate-limit slot multiplier applied per attestation in a batch submission.
+/// Each attestation in a batch consumes this many rate-limit slots so that
+/// batch callers cannot trivially bypass per-submission limits.
+pub const BATCH_ATTESTATION_RATE_MULTIPLIER: u32 = 5;
 
 /// Maximum operations allowed per session before it is considered exhausted.
 pub const MAX_OPS_PER_SESSION: u64 = 100;
@@ -4065,6 +4107,124 @@ impl AnchorKitContract {
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestationNotFound))
     }
 
+    /// Return a filtered, paginated page of attestation records.
+    ///
+    /// Records are iterated in ascending ID order. The caller supplies an
+    /// `offset` (number of matching records to skip) and a `limit` (max
+    /// records to return, capped at 50). An optional [`AttestationFilter`]
+    /// narrows results by `issuer`, `subject`, timestamp range, or minimum ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - Number of matching records to skip before collecting.
+    /// * `limit`  - Maximum records to include in the page (capped at 50).
+    /// * `filter` - Optional filter; pass `None` to retrieve all attestations.
+    ///
+    /// # Returns
+    ///
+    /// An [`AttestationPage`] containing the matching records, the next offset
+    /// for continued iteration, and the total unfiltered attestation count.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use soroban_sdk::Env;
+    /// use anchorkit::contract::{AnchorKitContract, AttestationFilter};
+    ///
+    /// let env = Env::default();
+    /// // First page, no filter
+    /// let page = AnchorKitContract::get_attestations_paginated(env, 0, 20, None);
+    /// ```
+    pub fn get_attestations_paginated(
+        env: Env,
+        offset: u64,
+        limit: u64,
+        filter: Option<AttestationFilter>,
+    ) -> AttestationPage {
+        const PAGE_CAP: u64 = 50;
+        let effective_limit = limit.min(PAGE_CAP);
+
+        // Read the global ATIDX index — it holds every attestation ID in
+        // insertion order. An absent index means no attestations have been
+        // submitted yet.
+        let idx_key = make_storage_key(&env, &[b"ATIDX"]);
+        let all_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&idx_key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let total = all_ids.len() as u64;
+        let mut records = Vec::new(&env);
+        let mut skipped: u64 = 0;
+        let mut next_offset = total; // default: last page
+
+        for id in all_ids.iter() {
+            // Fast-path: apply min_id filter without loading the record.
+            if let Some(ref f) = filter {
+                if let Some(min_id) = f.min_id {
+                    if id < min_id {
+                        continue;
+                    }
+                }
+            }
+
+            let attest_key = make_storage_key(&env, &[b"ATTEST", &id.to_be_bytes()]);
+            let record: Attestation = match env.storage().persistent().get(&attest_key) {
+                Some(r) => r,
+                None => continue, // expired entry — skip silently
+            };
+
+            // Apply remaining filter dimensions.
+            if let Some(ref f) = filter {
+                if let Some(ref issuer) = f.issuer {
+                    if record.issuer != *issuer {
+                        continue;
+                    }
+                }
+                if let Some(ref subject) = f.subject {
+                    if record.subject != *subject {
+                        continue;
+                    }
+                }
+                if let Some(from_ts) = f.from_timestamp {
+                    if record.timestamp < from_ts {
+                        continue;
+                    }
+                }
+                if let Some(to_ts) = f.to_timestamp {
+                    if record.timestamp > to_ts {
+                        continue;
+                    }
+                }
+            }
+
+            // This record passes the filter. Check if we're still in the skip
+            // window.
+            if skipped < offset {
+                skipped += 1;
+                continue;
+            }
+
+            // Check if the page is full — record next_offset so the caller
+            // knows where to resume.
+            if records.len() as u64 >= effective_limit {
+                // next_offset is the number of *matching* records up to (but
+                // not including) this one — i.e. offset + effective_limit.
+                next_offset = offset.saturating_add(effective_limit);
+                break;
+            }
+
+            records.push_back(record);
+        }
+
+        AttestationPage {
+            records,
+            next_offset,
+            total,
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Deterministic hash utilities (#192)
     // -----------------------------------------------------------------------
@@ -6986,6 +7146,20 @@ impl AnchorKitContract {
         let key = make_storage_key(env, &[b"ATTEST", &id.to_be_bytes()]);
         env.storage().persistent().set(&key, &attestation);
         env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        // Maintain the global attestation ID index (ATIDX) so paginated
+        // retrieval can iterate all IDs without scanning the full ID space.
+        let idx_key = make_storage_key(env, &[b"ATIDX"]);
+        let mut ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&idx_key)
+            .unwrap_or_else(|| Vec::new(env));
+        ids.push_back(id);
+        env.storage().persistent().set(&idx_key, &ids);
+        env.storage()
+            .persistent()
+            .extend_ttl(&idx_key, PERSISTENT_TTL, PERSISTENT_TTL);
     }
 
     fn store_span(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,7 @@ pub use sep24::{
     RawInteractiveDepositResponse, RawInteractiveWithdrawalResponse, RawSep24TransactionResponse,
 };
 pub use contract::{ServiceRetirementInfo, AnchorServices};
+pub use contract::{AttestationFilter, AttestationPage};
 pub use service_management::{ServiceManager, ServiceToggleState, ServiceConfigSnapshot};
 pub use admin_audit_log::{AdminAuditLog, AdminConfigChangeEvent, AdminAuditLogConfig};
 pub use contract::{HealthStatus, MetadataFreshnessReport, RateLimiterHealth};

--- a/src/sep10_jwt.rs
+++ b/src/sep10_jwt.rs
@@ -384,6 +384,14 @@ pub fn verify_sep10_jwt(
 
     // Enforce maximum token lifetime: exp - iat must not exceed 24 hours.
     let iat = parse_json_iat(&payload_dec).ok_or(())?;
+    if iat == 0 {
+        return Err(());
+    }
+    // iat must not be in the future — a token cannot claim to have been issued
+    // after the current ledger time (allow the same clock-skew tolerance).
+    if iat > now.saturating_add(skew) {
+        return Err(());
+    }
     if exp.saturating_sub(iat) > MAX_JWT_LIFETIME {
         return Err(());
     }
@@ -424,17 +432,203 @@ pub fn verify_sep10_jwt(
         env.storage().persistent().extend_ttl(&jti_key, ttl_ledgers, ttl_ledgers);
     }
 
+    // iss claim: must be present, non-empty, and must not be whitespace-only
+    // or contain ASCII control characters. Normalize by trimming before the
+    // emptiness check so `"iss":" "` is correctly rejected.
+    let iss_bytes = match parse_json_iss(&payload_dec) {
+        Some(b) if !b.is_empty() => b,
+        _ => return Err(()),
+    };
+    // Trim leading/trailing whitespace and reject if nothing remains.
+    let iss_trimmed_len = iss_bytes
+        .iter()
+        .rev()
+        .skip_while(|b| b.is_ascii_whitespace())
+        .count();
+    let iss_leading = iss_bytes.iter().take_while(|b| b.is_ascii_whitespace()).count();
+    if iss_trimmed_len == 0 || (iss_leading >= iss_bytes.len()) {
+        return Err(());
+    }
+    // Reject any control characters (0x00–0x1F, 0x7F) in the issuer.
+    if iss_bytes.iter().any(|&b| b < 0x20 || b == 0x7F) {
+        return Err(());
+    }
+
     let sub = parse_json_sub(env, &payload_dec)?;
+    // sub must be non-empty — an empty subject offers no identity binding.
+    if sub.len() == 0 {
+        return Err(());
+    }
+
     if let Some(expected) = expected_sub {
         if sub != *expected {
             return Err(());
         }
     }
 
-    // iss claim must be present and non-empty (SEP-10 requirement)
-    match parse_json_iss(&payload_dec) {
-        Some(iss) if !iss.is_empty() => {}
+    Ok(())
+}
+
+/// Verify a SEP-10 JWT and additionally assert that the `iss` claim matches
+/// `expected_issuer` (case-sensitive, after whitespace trimming on both sides).
+///
+/// This is a strict wrapper around [`verify_sep10_jwt`] for call sites where
+/// the anchor identity is known ahead of time and must be explicitly validated
+/// rather than merely present. All other checks from [`verify_sep10_jwt`]
+/// apply unchanged.
+///
+/// # Arguments
+///
+/// * `env`              - Soroban execution environment.
+/// * `token`            - Compact JWS token string.
+/// * `anchor_public_key`- 32-byte Ed25519 public key.
+/// * `expected_sub`     - Optional expected `sub` claim value.
+/// * `expected_issuer`  - The issuer string that the `iss` claim must match
+///                        (trimmed, case-sensitive comparison).
+///
+/// # Returns
+///
+/// `Ok(())` when all checks pass, `Err(())` otherwise.
+pub fn verify_sep10_jwt_with_issuer(
+    env: &Env,
+    token: &String,
+    anchor_public_key: &Bytes,
+    expected_sub: Option<&String>,
+    expected_issuer: &str,
+) -> Result<(), ()> {
+    if anchor_public_key.len() != 32 {
+        return Err(());
+    }
+
+    // Reject an empty expected issuer immediately — a caller passing "" would
+    // trivially accept any token and indicates a programming error.
+    let expected_issuer_trimmed = expected_issuer.trim();
+    if expected_issuer_trimmed.is_empty() {
+        return Err(());
+    }
+
+    // Run the full base verification first (sig, exp, iat, nbf, jti, sub, iss).
+    verify_sep10_jwt(env, token, anchor_public_key, expected_sub)?;
+
+    // Re-decode the payload to extract iss for the explicit comparison.
+    let max_len: u32 = env
+        .storage()
+        .instance()
+        .get::<_, u32>(&soroban_sdk::symbol_short!("JWTMAXLEN"))
+        .unwrap_or(MAX_JWT_LEN);
+
+    let n = token.len() as usize;
+    let mut buf: Vec<u8> = alloc::vec![0u8; max_len as usize];
+    token.copy_into_slice(&mut buf[..n]);
+
+    let mut dots = [0usize; 2];
+    let mut dot_count = 0usize;
+    for i in 0..n {
+        if buf[i] == b'.' {
+            if dot_count < 2 {
+                dots[dot_count] = i;
+                dot_count += 1;
+            }
+        }
+    }
+    if dot_count != 2 {
+        return Err(());
+    }
+
+    let payload_b64 = &buf[dots[0] + 1..dots[1]];
+    let payload_dec = base64url_decode(payload_b64).map_err(|_| ())?;
+
+    let iss_bytes = match parse_json_iss(&payload_dec) {
+        Some(b) if !b.is_empty() => b,
         _ => return Err(()),
+    };
+
+    // Trim and compare (case-sensitive).
+    let iss_str = core::str::from_utf8(&iss_bytes).map_err(|_| ())?;
+    if iss_str.trim() != expected_issuer_trimmed {
+        return Err(());
+    }
+
+    Ok(())
+}
+/// `expected_issuer` (case-sensitive, after whitespace trimming on both sides).
+///
+/// This is a strict wrapper around [`verify_sep10_jwt`] for call sites where
+/// the anchor identity is known ahead of time and must be explicitly validated
+/// rather than merely present. All other checks from [`verify_sep10_jwt`]
+/// apply unchanged.
+///
+/// # Arguments
+///
+/// * `env`             - Soroban execution environment.
+/// * `token`           - Compact JWS token string.
+/// * `anchor_public_key` - 32-byte Ed25519 public key.
+/// * `expected_sub`    - Optional expected `sub` claim value.
+/// * `expected_issuer` - The exact issuer string that the `iss` claim must match.
+///
+/// # Returns
+///
+/// `Ok(())` when all checks pass, `Err(())` otherwise.
+pub fn verify_sep10_jwt_with_issuer(
+    env: &Env,
+    token: &String,
+    anchor_public_key: &Bytes,
+    expected_sub: Option<&String>,
+    expected_issuer: &str,
+) -> Result<(), ()> {
+    if anchor_public_key.len() != 32 {
+        return Err(());
+    }
+
+    // Reject an empty expected issuer immediately — a caller passing "" would
+    // trivially accept any token and indicates a programming error.
+    let expected_issuer_trimmed = expected_issuer.trim();
+    if expected_issuer_trimmed.is_empty() {
+        return Err(());
+    }
+
+    // Run base verification first.
+    verify_sep10_jwt(env, token, anchor_public_key, expected_sub)?;
+
+    // Decode payload again to extract iss for comparison.
+    let max_len: u32 = env
+        .storage()
+        .instance()
+        .get::<_, u32>(&soroban_sdk::symbol_short!("JWTMAXLEN"))
+        .unwrap_or(MAX_JWT_LEN);
+
+    let n = token.len() as usize;
+    let mut buf: Vec<u8> = alloc::vec![0u8; max_len as usize];
+    token.copy_into_slice(&mut buf[..n]);
+
+    // Re-locate the dots to find the payload segment.
+    let mut dots = [0usize; 2];
+    let mut dot_count = 0usize;
+    for i in 0..n {
+        if buf[i] == b'.' {
+            if dot_count < 2 {
+                dots[dot_count] = i;
+                dot_count += 1;
+            }
+        }
+    }
+    if dot_count != 2 {
+        return Err(());
+    }
+
+    let payload_b64 = &buf[dots[0] + 1..dots[1]];
+    let payload_dec = base64url_decode(payload_b64).map_err(|_| ())?;
+
+    let iss_bytes = match parse_json_iss(&payload_dec) {
+        Some(b) if !b.is_empty() => b,
+        _ => return Err(()),
+    };
+
+    // Trim and compare — reject if the trimmed iss does not byte-equal the
+    // trimmed expected_issuer.
+    let iss_str = core::str::from_utf8(&iss_bytes).map_err(|_| ())?;
+    if iss_str.trim() != expected_issuer_trimmed {
+        return Err(());
     }
 
     Ok(())

--- a/tests/attestation_pagination_tests.rs
+++ b/tests/attestation_pagination_tests.rs
@@ -1,0 +1,394 @@
+#![cfg(test)]
+
+mod sep10_test_util;
+
+mod attestation_pagination_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Bytes, Env, Vec,
+    };
+
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::contract::{
+        AnchorKitContract, AnchorKitContractClient, AttestationFilter,
+    };
+    use crate::sep10_test_util::{register_attestor_with_sep10, sign_payload};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set(LedgerInfo {
+            timestamp: 1_000_000,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+        env
+    }
+
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address, SigningKey) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        let sk = SigningKey::generate(&mut OsRng);
+        let attestor = Address::generate(env);
+        register_attestor_with_sep10(env, &client, &attestor, &attestor, &sk);
+        (client, attestor, sk)
+    }
+
+    fn unique_payload(env: &Env, seed: u8) -> Bytes {
+        let mut b = Bytes::new(env);
+        for _ in 0..31 {
+            b.push_back(0xAA);
+        }
+        b.push_back(seed);
+        b
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty result set
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn empty_store_returns_empty_page() {
+        let env = make_env();
+        let (client, _, _) = setup(&env);
+
+        let page = client.get_attestations_paginated(&0u64, &10u64, &None);
+        assert_eq!(page.records.len(), 0);
+        assert_eq!(page.total, 0);
+        assert_eq!(page.next_offset, 0);
+    }
+
+    #[test]
+    fn filter_with_no_matching_issuer_returns_empty_page() {
+        let env = make_env();
+        let (client, attestor, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        // Submit one attestation
+        let ph = unique_payload(&env, 0x01);
+        let sig = sign_payload(&env, &sk, &ph);
+        client.submit_attestation(&attestor, &subject, &1_000_001u64, &ph, &sig);
+
+        // Filter for a different issuer — should return zero records
+        let other = Address::generate(&env);
+        let filter = AttestationFilter {
+            issuer: Some(other),
+            subject: None,
+            from_timestamp: None,
+            to_timestamp: None,
+            min_id: None,
+        };
+        let page = client.get_attestations_paginated(&0u64, &10u64, &Some(filter));
+        assert_eq!(page.records.len(), 0);
+        assert_eq!(page.total, 1); // total unfiltered count is still 1
+    }
+
+    // -----------------------------------------------------------------------
+    // Single page — no filter
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn retrieves_all_records_when_limit_exceeds_count() {
+        let env = make_env();
+        let (client, attestor, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        for seed in 0u8..5 {
+            let ph = unique_payload(&env, seed);
+            let sig = sign_payload(&env, &sk, &ph);
+            client.submit_attestation(
+                &attestor,
+                &subject,
+                &(1_000_001u64 + seed as u64),
+                &ph,
+                &sig,
+            );
+        }
+
+        let page = client.get_attestations_paginated(&0u64, &50u64, &None);
+        assert_eq!(page.records.len(), 5);
+        assert_eq!(page.total, 5);
+        assert_eq!(page.next_offset, 5); // last page → next_offset == total
+    }
+
+    // -----------------------------------------------------------------------
+    // Multi-page retrieval
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn multi_page_retrieval_covers_all_records() {
+        let env = make_env();
+        let (client, attestor, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        // Submit 7 attestations
+        for seed in 0u8..7 {
+            let ph = unique_payload(&env, seed);
+            let sig = sign_payload(&env, &sk, &ph);
+            client.submit_attestation(
+                &attestor,
+                &subject,
+                &(1_000_001u64 + seed as u64),
+                &ph,
+                &sig,
+            );
+        }
+
+        // Page 1: records 0-2
+        let page1 = client.get_attestations_paginated(&0u64, &3u64, &None);
+        assert_eq!(page1.records.len(), 3);
+        assert_eq!(page1.next_offset, 3);
+        assert_eq!(page1.total, 7);
+
+        // Page 2: records 3-5
+        let page2 = client.get_attestations_paginated(&page1.next_offset, &3u64, &None);
+        assert_eq!(page2.records.len(), 3);
+        assert_eq!(page2.next_offset, 6);
+
+        // Page 3: record 6 (last page)
+        let page3 = client.get_attestations_paginated(&page2.next_offset, &3u64, &None);
+        assert_eq!(page3.records.len(), 1);
+        assert_eq!(page3.next_offset, 7); // == total → signals last page
+
+        // No duplicates across all pages — collect all IDs
+        let mut all_ids: std::vec::Vec<u64> = std::vec::Vec::new();
+        for r in page1.records.iter() { all_ids.push(r.id); }
+        for r in page2.records.iter() { all_ids.push(r.id); }
+        for r in page3.records.iter() { all_ids.push(r.id); }
+        all_ids.sort_unstable();
+        all_ids.dedup();
+        assert_eq!(all_ids.len(), 7, "duplicates or gaps across pages");
+    }
+
+    #[test]
+    fn page_beyond_end_returns_empty() {
+        let env = make_env();
+        let (client, attestor, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        for seed in 0u8..3 {
+            let ph = unique_payload(&env, seed);
+            let sig = sign_payload(&env, &sk, &ph);
+            client.submit_attestation(
+                &attestor,
+                &subject,
+                &(1_000_001u64 + seed as u64),
+                &ph,
+                &sig,
+            );
+        }
+
+        // Offset past the total count
+        let page = client.get_attestations_paginated(&100u64, &10u64, &None);
+        assert_eq!(page.records.len(), 0);
+        assert_eq!(page.total, 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // Filter: issuer
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_by_issuer_returns_only_matching_records() {
+        let env = make_env();
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        // Register two attestors
+        let sk_a = SigningKey::generate(&mut OsRng);
+        let attestor_a = Address::generate(&env);
+        register_attestor_with_sep10(&env, &client, &attestor_a, &attestor_a, &sk_a);
+
+        let sk_b = SigningKey::generate(&mut OsRng);
+        let attestor_b = Address::generate(&env);
+        register_attestor_with_sep10(&env, &client, &attestor_b, &attestor_b, &sk_b);
+
+        let subject = Address::generate(&env);
+
+        // attestor_a submits 3, attestor_b submits 2
+        for seed in 0u8..3 {
+            let ph = unique_payload(&env, seed);
+            let sig = sign_payload(&env, &sk_a, &ph);
+            client.submit_attestation(&attestor_a, &subject, &(1_000_001u64 + seed as u64), &ph, &sig);
+        }
+        for seed in 3u8..5 {
+            let ph = unique_payload(&env, seed);
+            let sig = sign_payload(&env, &sk_b, &ph);
+            client.submit_attestation(&attestor_b, &subject, &(1_000_004u64 + seed as u64), &ph, &sig);
+        }
+
+        let filter = AttestationFilter {
+            issuer: Some(attestor_a.clone()),
+            subject: None,
+            from_timestamp: None,
+            to_timestamp: None,
+            min_id: None,
+        };
+        let page = client.get_attestations_paginated(&0u64, &50u64, &Some(filter));
+        assert_eq!(page.records.len(), 3);
+        for r in page.records.iter() {
+            assert_eq!(r.issuer, attestor_a);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Filter: subject
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_by_subject_returns_only_matching_records() {
+        let env = make_env();
+        let (client, attestor, sk) = setup(&env);
+        let subject_a = Address::generate(&env);
+        let subject_b = Address::generate(&env);
+
+        for seed in 0u8..3 {
+            let ph = unique_payload(&env, seed);
+            let sig = sign_payload(&env, &sk, &ph);
+            client.submit_attestation(&attestor, &subject_a, &(1_000_001u64 + seed as u64), &ph, &sig);
+        }
+        for seed in 3u8..5 {
+            let ph = unique_payload(&env, seed);
+            let sig = sign_payload(&env, &sk, &ph);
+            client.submit_attestation(&attestor, &subject_b, &(1_000_004u64 + seed as u64), &ph, &sig);
+        }
+
+        let filter = AttestationFilter {
+            issuer: None,
+            subject: Some(subject_b.clone()),
+            from_timestamp: None,
+            to_timestamp: None,
+            min_id: None,
+        };
+        let page = client.get_attestations_paginated(&0u64, &50u64, &Some(filter));
+        assert_eq!(page.records.len(), 2);
+        for r in page.records.iter() {
+            assert_eq!(r.subject, subject_b);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Filter: timestamp range
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_by_timestamp_range_returns_correct_records() {
+        let env = make_env();
+        let (client, attestor, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        // Submit 5 records with timestamps 100, 200, 300, 400, 500
+        for i in 1u8..=5 {
+            let ph = unique_payload(&env, i);
+            let sig = sign_payload(&env, &sk, &ph);
+            client.submit_attestation(&attestor, &subject, &(i as u64 * 100), &ph, &sig);
+        }
+
+        let filter = AttestationFilter {
+            issuer: None,
+            subject: None,
+            from_timestamp: Some(200),
+            to_timestamp: Some(400),
+            min_id: None,
+        };
+        let page = client.get_attestations_paginated(&0u64, &50u64, &Some(filter));
+        assert_eq!(page.records.len(), 3); // ts 200, 300, 400
+        for r in page.records.iter() {
+            assert!(r.timestamp >= 200 && r.timestamp <= 400);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Filter: min_id
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_by_min_id_skips_earlier_records() {
+        let env = make_env();
+        let (client, attestor, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        for seed in 0u8..6 {
+            let ph = unique_payload(&env, seed);
+            let sig = sign_payload(&env, &sk, &ph);
+            client.submit_attestation(&attestor, &subject, &(1_000_001u64 + seed as u64), &ph, &sig);
+        }
+
+        // IDs are 0-5; min_id=3 should return IDs 3,4,5
+        let filter = AttestationFilter {
+            issuer: None,
+            subject: None,
+            from_timestamp: None,
+            to_timestamp: None,
+            min_id: Some(3),
+        };
+        let page = client.get_attestations_paginated(&0u64, &50u64, &Some(filter));
+        assert_eq!(page.records.len(), 3);
+        for r in page.records.iter() {
+            assert!(r.id >= 3);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Determinism — same inputs, same output
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pagination_is_deterministic() {
+        let env = make_env();
+        let (client, attestor, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        for seed in 0u8..4 {
+            let ph = unique_payload(&env, seed);
+            let sig = sign_payload(&env, &sk, &ph);
+            client.submit_attestation(&attestor, &subject, &(1_000_001u64 + seed as u64), &ph, &sig);
+        }
+
+        let page_a = client.get_attestations_paginated(&0u64, &10u64, &None);
+        let page_b = client.get_attestations_paginated(&0u64, &10u64, &None);
+
+        assert_eq!(page_a.records.len(), page_b.records.len());
+        for i in 0..page_a.records.len() {
+            assert_eq!(page_a.records.get(i as u32).unwrap().id,
+                       page_b.records.get(i as u32).unwrap().id);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Limit is capped at 50
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn limit_is_capped_at_50() {
+        let env = make_env();
+        let (client, attestor, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        // Submit 55 records — pagination cap should never return more than 50
+        for seed in 0u8..55 {
+            let ph = unique_payload(&env, seed % 200);
+            // Make each hash unique by mixing seed into two bytes
+            let mut unique = Bytes::new(&env);
+            for _ in 0..30 { unique.push_back(0xBB); }
+            unique.push_back(seed);
+            unique.push_back(seed.wrapping_add(1));
+            let sig = sign_payload(&env, &sk, &unique);
+            client.submit_attestation(&attestor, &subject, &(1_000_001u64 + seed as u64), &unique, &sig);
+        }
+
+        let page = client.get_attestations_paginated(&0u64, &200u64, &None);
+        assert!(page.records.len() <= 50, "page returned more than 50 records");
+    }
+}

--- a/tests/sep10_hardening_tests.rs
+++ b/tests/sep10_hardening_tests.rs
@@ -1,0 +1,391 @@
+#![cfg(test)]
+
+mod sep10_test_util;
+
+mod sep10_hardening_tests {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use ed25519_dalek::{Signer, SigningKey};
+    use rand::rngs::OsRng;
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+    use soroban_sdk::{Address, Bytes, Env, String};
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+    use anchorkit::sep10_jwt::{verify_sep10_jwt, verify_sep10_jwt_with_issuer, MAX_JWT_LIFETIME};
+    use crate::sep10_test_util::{
+        build_sep10_jwt, build_sep10_jwt_with_iat, build_sep10_jwt_with_iss,
+        build_sep10_jwt_with_future_iat, build_sep10_jwt_whitespace_iss,
+        build_sep10_jwt_empty_sub,
+    };
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn ledger(env: &Env, ts: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp: ts,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn make_contract_id(env: &Env) -> Address {
+        env.register_contract(None, AnchorKitContract)
+    }
+
+    fn setup(env: &Env, ts: u64) -> (AnchorKitContractClient, Address, SigningKey) {
+        ledger(env, ts);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(env, sk.verifying_key().as_bytes());
+        let issuer = Address::generate(env);
+        client.set_sep10_jwt_verifying_key(&issuer, &pk);
+        (client, issuer, sk)
+    }
+
+    // -----------------------------------------------------------------------
+    // iat: must be present (already tested upstream — confirm still rejected)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_token_missing_iat() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        // Build token without iat
+        let header = r#"{"alg":"EdDSA","typ":"JWT"}"#;
+        let payload = format!(
+            r#"{{"sub":"{}","exp":{},"iss":"https://anchor.example.com"}}"#,
+            sub_str, 5_000u64
+        );
+        let header_b64 = URL_SAFE_NO_PAD.encode(header);
+        let payload_b64 = URL_SAFE_NO_PAD.encode(payload);
+        let signing_input = format!("{}.{}", header_b64, payload_b64);
+        let sig = sk.sign(signing_input.as_bytes());
+        let jwt = format!("{}.{}", signing_input, URL_SAFE_NO_PAD.encode(sig.to_bytes()));
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(verify_sep10_jwt(&env, &token, &pk, None).is_err());
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // iat: must be zero — explicit zero iat rejected
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_token_with_zero_iat() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        let jwt = build_sep10_jwt_with_iat(&sk, &sub_str, 0, 5_000);
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt(&env, &token, &pk, None).is_err(),
+                "zero iat must be rejected"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // iat: must not be in the future
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_token_with_future_iat() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        let now = 1_000u64;
+        ledger(&env, now);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        // iat = now + 200, well beyond the 60 s skew tolerance
+        let jwt = build_sep10_jwt_with_future_iat(&sk, &sub_str, now, 200);
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt(&env, &token, &pk, None).is_err(),
+                "future iat must be rejected"
+            );
+        });
+    }
+
+    #[test]
+    fn accepts_token_with_iat_within_skew_window() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        let now = 1_000u64;
+        ledger(&env, now);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        // iat = now + 30 (within default 60 s skew)
+        let iat = now + 30;
+        let exp = iat + MAX_JWT_LIFETIME;
+        let jwt = build_sep10_jwt_with_iat(&sk, &sub_str, iat, exp);
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt(&env, &token, &pk, None).is_ok(),
+                "iat within skew should be accepted"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // sub: must be non-empty
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_token_with_empty_sub() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+
+        let jwt = build_sep10_jwt_empty_sub(&sk, 5_000);
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt(&env, &token, &pk, None).is_err(),
+                "empty sub must be rejected"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // iss: whitespace-only must be rejected
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_token_with_whitespace_only_iss() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        let jwt = build_sep10_jwt_whitespace_iss(&sk, &sub_str, 5_000);
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt(&env, &token, &pk, None).is_err(),
+                "whitespace-only iss must be rejected"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // iss: control character in issuer is rejected
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_token_with_control_char_in_iss() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        // iss containing a null byte (0x00)
+        let jwt = build_sep10_jwt_with_iss(&sk, &sub_str, 5_000, "https://evil\x00.com");
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt(&env, &token, &pk, None).is_err(),
+                "control char in iss must be rejected"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // verify_sep10_jwt_with_issuer: happy path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn with_issuer_accepts_matching_iss() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        let jwt = build_sep10_jwt_with_iss(&sk, &sub_str, 5_000, "https://anchor.example.com");
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt_with_issuer(&env, &token, &pk, None, "https://anchor.example.com").is_ok()
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // verify_sep10_jwt_with_issuer: issuer mismatch is rejected
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn with_issuer_rejects_mismatched_iss() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        let jwt = build_sep10_jwt_with_iss(&sk, &sub_str, 5_000, "https://anchor.example.com");
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt_with_issuer(&env, &token, &pk, None, "https://evil.example.com").is_err(),
+                "mismatched issuer must be rejected"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // verify_sep10_jwt_with_issuer: empty expected_issuer is rejected
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn with_issuer_rejects_empty_expected_issuer() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        let jwt = build_sep10_jwt(&sk, &sub_str, 5_000);
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt_with_issuer(&env, &token, &pk, None, "").is_err(),
+                "empty expected_issuer must be rejected"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // verify_sep10_jwt_with_issuer: whitespace trimming on both sides
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn with_issuer_trims_whitespace_before_comparison() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        // iss in token has surrounding spaces
+        let jwt = build_sep10_jwt_with_iss(&sk, &sub_str, 5_000, "  https://anchor.example.com  ");
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            // Should match after trimming
+            assert!(
+                verify_sep10_jwt_with_issuer(
+                    &env, &token, &pk, None,
+                    "https://anchor.example.com"
+                ).is_ok(),
+                "trimmed iss should match trimmed expected_issuer"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Contract-level: expired token is clearly rejected (regression)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn contract_rejects_expired_token() {
+        let env = make_env();
+        let (client, issuer, sk) = setup(&env, 10_000);
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+        // Token expired 200 s ago (beyond 60 s skew)
+        let jwt = build_sep10_jwt(&sk, &sub_str, 9_000);
+        let token = String::from_str(&env, &jwt);
+        client.verify_sep10_token(&token, &issuer);
+    }
+
+    // -----------------------------------------------------------------------
+    // Contract-level: malformed token (wrong number of dots) is rejected
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn contract_rejects_malformed_token() {
+        let env = make_env();
+        let (client, issuer, _) = setup(&env, 1_000);
+        let token = String::from_str(&env, "not.a.valid.jwt.token");
+        client.verify_sep10_token(&token, &issuer);
+    }
+
+    // -----------------------------------------------------------------------
+    // Contract-level: replayed token is rejected (cross-ledger JTI cache)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn contract_rejects_replayed_token() {
+        use crate::sep10_test_util::build_sep10_jwt_with_jti;
+        let env = make_env();
+        let (client, issuer, sk) = setup(&env, 1_000);
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+        let exp = 1_000u64 + 3_600;
+        let jwt = build_sep10_jwt_with_jti(&sk, &sub_str, exp, "replay-hardening-jti");
+        let token = String::from_str(&env, &jwt);
+        client.verify_sep10_token(&token, &issuer); // first — OK
+        client.verify_sep10_token(&token, &issuer); // second — must panic
+    }
+}

--- a/tests/sep10_test_util.rs
+++ b/tests/sep10_test_util.rs
@@ -63,6 +63,56 @@ pub fn build_sep10_jwt_with_jti(
     let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
     format!("{}.{}", signing_input, sig_b64)
 }
+/// Build a SEP-10 JWT whose `iss` claim is set to `issuer` instead of the
+/// default `"https://anchor.example.com"`. Used to test issuer mismatch
+/// rejection in `verify_sep10_jwt_with_issuer`.
+pub fn build_sep10_jwt_with_iss(
+    signing_key: &SigningKey,
+    sub: &str,
+    exp: u64,
+    issuer: &str,
+) -> std::string::String {
+    let header = r#"{"alg":"EdDSA","typ":"JWT"}"#;
+    let iat = exp.saturating_sub(anchorkit::sep10_jwt::MAX_JWT_LIFETIME);
+    let payload = format!(
+        r#"{{"sub":"{}","iat":{},"exp":{},"iss":"{}"}}"#,
+        sub, iat, exp, issuer
+    );
+    let header_b64 = URL_SAFE_NO_PAD.encode(header);
+    let payload_b64 = URL_SAFE_NO_PAD.encode(payload);
+    let signing_input = format!("{}.{}", header_b64, payload_b64);
+    let sig = signing_key.sign(signing_input.as_bytes());
+    let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+    format!("{}.{}", signing_input, sig_b64)
+}
+
+/// Build a SEP-10 JWT with a future `iat` (issued-at in the future).
+/// Used to test that `verify_sep10_jwt` rejects tokens with `iat > now`.
+pub fn build_sep10_jwt_with_future_iat(
+    signing_key: &SigningKey,
+    sub: &str,
+    now: u64,
+    seconds_ahead: u64,
+) -> std::string::String {
+    let future_iat = now + seconds_ahead;
+    let exp = future_iat + anchorkit::sep10_jwt::MAX_JWT_LIFETIME;
+    build_sep10_jwt_with_iat(signing_key, sub, future_iat, exp)
+}
+
+/// Build a SEP-10 JWT with an empty `sub` claim.
+pub fn build_sep10_jwt_empty_sub(signing_key: &SigningKey, exp: u64) -> std::string::String {
+    build_sep10_jwt(signing_key, "", exp)
+}
+
+/// Build a SEP-10 JWT with a whitespace-only `iss` claim.
+pub fn build_sep10_jwt_whitespace_iss(
+    signing_key: &SigningKey,
+    sub: &str,
+    exp: u64,
+) -> std::string::String {
+    build_sep10_jwt_with_iss(signing_key, sub, exp, "   ")
+}
+
 pub fn sign_payload(env: &Env, signing_key: &SigningKey, payload_hash: &Bytes) -> Bytes {
     let mut msg = std::vec::Vec::with_capacity(payload_hash.len() as usize);
     for i in 0..payload_hash.len() {


### PR DESCRIPTION
- Add MAX_BATCH_SIZE (25) and BATCH_ATTESTATION_RATE_MULTIPLIER (5) constants that were referenced but undefined, fixing batch attestation (#583)
- Maintain a global ATIDX persistent index in store_attestation so all attestation IDs are enumerable without scanning the full key space (#581)
- Add AttestationFilter (issuer, subject, from_timestamp, to_timestamp, min_id) and AttestationPage (records, next_offset, total) types (#581)
- Implement get_attestations_paginated(offset, limit, filter) with a hard cap of 50 records per page and deterministic ascending-ID ordering (#581)
- Harden verify_sep10_jwt: reject zero iat, reject future iat beyond skew, reject empty sub, reject whitespace-only iss, reject control chars in iss (#584)
- Add verify_sep10_jwt_with_issuer() that validates iss equals a caller-supplied expected issuer (trimmed, case-sensitive) (#584)
- Extend sep10_test_util with build_sep10_jwt_with_iss, build_sep10_jwt_with_future_iat, build_sep10_jwt_empty_sub, build_sep10_jwt_whitespace_iss helpers (#584)
- Add attestation_pagination_tests.rs: empty store, no-match filter, single page, multi-page full-coverage, page-beyond-end, filter by issuer/subject/timestamp-range/min_id, determinism, limit-cap (#581/#583)
- Add sep10_hardening_tests.rs: missing iat, zero iat, future iat, iat within skew accepted, empty sub, whitespace iss, control-char iss, issuer mismatch, empty expected_issuer, whitespace trimming, expired token, malformed token, replayed JTI regression (#584/#586)

Closes #581
Closes #583
Closes #584
Closes #586