### PR TITLE
feat: replay detection metrics, attestor recovery, precise errors, rich events

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -213,6 +213,37 @@ pub const SERVICE_KYC: u32 = 4;
 pub const SERVICE_SEP31: u32 = 5;
 
 // ---------------------------------------------------------------------------
+// Attestor revocation record — stored when an attestor is revoked so that
+// recovery can be performed without losing the original public key or audit
+// history.
+// ---------------------------------------------------------------------------
+
+/// Persisted metadata capturing the circumstances of an attestor revocation.
+///
+/// Written by `revoke_attestor` and read by `reactivate_attestor` and
+/// `get_attestor_revocation_info`.  The record is never deleted, which means
+/// the full revocation/reactivation history is always available for audit.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AttestorRevocationRecord {
+    /// Address of the attestor that was revoked.
+    pub attestor: Address,
+    /// Ledger timestamp when the revocation was executed.
+    pub revoked_at: u64,
+    /// Address of the admin that performed the revocation.
+    pub revoked_by: Address,
+    /// Human-readable reason supplied at revocation time (may be empty).
+    pub reason: String,
+    /// Copy of the attestor's public key preserved so that re-registration is
+    /// not required after reactivation.
+    pub public_key: BytesN<32>,
+    /// Whether this attestor has been reactivated after this revocation.
+    pub reactivated: bool,
+    /// Ledger timestamp when the attestor was reactivated (0 = not yet reactivated).
+    pub reactivated_at: u64,
+}
+
+// ---------------------------------------------------------------------------
 // #344 — Admin permission model
 //
 // Every admin-gated method maps to one of the categories below. The primary
@@ -1128,6 +1159,77 @@ struct UpgradeEvent {
     upgraded_at: u64,
 }
 
+/// Event emitted when `initialize` completes successfully.
+#[contracttype]
+#[derive(Clone)]
+pub struct ContractInitializedEvent {
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
+/// Rich event emitted when an attestor is registered.
+#[contracttype]
+#[derive(Clone)]
+pub struct AttestorRegisteredEvent {
+    pub attestor: Address,
+    pub timestamp: u64,
+}
+
+/// Rich event emitted when an attestor is revoked.
+#[contracttype]
+#[derive(Clone)]
+pub struct AttestorRevokedEvent {
+    pub attestor: Address,
+    pub revoked_by: Address,
+    pub timestamp: u64,
+}
+
+/// Rich event emitted when a previously revoked attestor is reactivated.
+#[contracttype]
+#[derive(Clone)]
+pub struct AttestorReactivatedEvent {
+    pub attestor: Address,
+    pub reactivated_by: Address,
+    pub timestamp: u64,
+}
+
+/// Event emitted when a rate limit is enforced (request dropped).
+#[contracttype]
+#[derive(Clone)]
+pub struct RateLimitHitEvent {
+    pub attestor: Address,
+    pub timestamp: u64,
+    pub ledger_sequence: u32,
+}
+
+/// Event emitted when a quote is rejected because its validity window has closed.
+#[contracttype]
+#[derive(Clone)]
+pub struct QuoteExpiredEvent {
+    pub quote_id: u64,
+    pub anchor: Address,
+    pub valid_until: u64,
+    pub expired_at: u64,
+}
+
+/// Event emitted when a webhook URL is registered for an attestor.
+#[contracttype]
+#[derive(Clone)]
+pub struct WebhookRegisteredEvent {
+    pub attestor: Address,
+    pub timestamp: u64,
+}
+
+/// Event emitted when an anchor's services are (re)configured.
+#[contracttype]
+#[derive(Clone)]
+pub struct ServicesConfiguredEvent {
+    pub anchor: Address,
+    pub service_count: u32,
+    pub capability_version: u32,
+    pub timestamp: u64,
+}
+
 // ---------------------------------------------------------------------------
 // TTLs (in ledgers)
 // ---------------------------------------------------------------------------
@@ -1143,6 +1245,13 @@ pub const MAX_OPS_PER_SESSION: u64 = 100;
 
 /// Minimum TTL for replay-protection entries (7 days in ledgers at ~5 s/ledger).
 pub const REPLAY_TTL: u32 = 120_960;
+
+/// Maximum number of attestations allowed in a single batch submission.
+pub const MAX_BATCH_SIZE: usize = 100;
+
+/// Rate-limit slot multiplier applied per attestation in a batch submission.
+/// Each attestation in a batch consumes this many slots from the rate-limit window.
+pub const BATCH_ATTESTATION_RATE_MULTIPLIER: u32 = 1;
 
 /// Inclusive lower bound for the configurable JWT max-length (set_jwt_max_len).
 const MIN_JWT_MAX_LEN: u32 = 2048;
@@ -1394,6 +1503,10 @@ impl AnchorKitContract {
         let schema_key = make_storage_key(&env, &[b"SCHEMAVER"]);
         env.storage().instance().set(&schema_key, &SCHEMA_V1);
         env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+        env.events().publish(
+            (symbol_short!("contract"), symbol_short!("init")),
+            ContractInitializedEvent { admin, timestamp: env.ledger().timestamp() },
+        );
     }
 
     /// Check if the contract has been initialized.
@@ -2517,8 +2630,8 @@ impl AnchorKitContract {
         );
 
         env.events().publish(
-            (symbol_short!("attestor"), symbol_short!("added"), attestor),
-            (),
+            (symbol_short!("attestor"), symbol_short!("added"), attestor.clone()),
+            AttestorRegisteredEvent { attestor, timestamp: env.ledger().timestamp() },
         );
     }
 
@@ -2565,27 +2678,56 @@ impl AnchorKitContract {
         if !env.storage().persistent().has(&key) {
             panic_with_error!(&env, ErrorCode::AttestorNotRegistered);
         }
-        env.storage().persistent().remove(&key);
+
+        // Read the public key before removing it so the revocation record can
+        // preserve it for a future reactivation.
         let pk_key = make_storage_key(&env, &[b"ATPUBKEY", &raw]);
+        let public_key: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&pk_key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestorNotRegistered));
+
+        // Remove the active registration keys so `check_attestor` / `is_attestor`
+        // start returning false immediately.
+        env.storage().persistent().remove(&key);
         env.storage().persistent().remove(&pk_key);
-        
+
+        // Persist a revocation record so the attestor can be safely reactivated
+        // later without needing to re-register from scratch.
+        let admin = Self::get_admin_internal(&env);
+        let revoc_record = AttestorRevocationRecord {
+            attestor: attestor.clone(),
+            revoked_at: env.ledger().timestamp(),
+            revoked_by: admin.clone(),
+            reason: String::from_str(&env, ""),
+            public_key,
+            reactivated: false,
+            reactivated_at: 0,
+        };
+        let revoc_key = (symbol_short!("ATREVOC"), attestor.clone());
+        env.storage().persistent().set(&revoc_key, &revoc_record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&revoc_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
         // Decrement count
         let current_count = Self::get_attestor_count_internal(&env);
         if current_count > 0 {
             env.storage().instance().set(&Self::attestor_count_key(&env), &(current_count - 1));
-            
+
             let mut attestors_list = env.storage().instance().get::<_, soroban_sdk::Vec<Address>>(&Self::attestor_list_key(&env)).unwrap_or_else(|| soroban_sdk::Vec::new(&env));
             if let Some(idx) = attestors_list.first_index_of(&attestor) {
                 attestors_list.remove(idx);
                 env.storage().instance().set(&Self::attestor_list_key(&env), &attestors_list);
             }
-            
+
             env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
         }
 
         AdminAuditLog::log_action(
             &env,
-            &Self::get_admin_internal(&env),
+            &admin,
             "revoke_attestor",
             attestor.to_string(),
             "registered",
@@ -2593,9 +2735,128 @@ impl AnchorKitContract {
         );
 
         env.events().publish(
-            (symbol_short!("attestor"), symbol_short!("removed"), attestor),
-            (),
+            (symbol_short!("attestor"), symbol_short!("removed"), attestor.clone()),
+            AttestorRevokedEvent { attestor, revoked_by: admin, timestamp: env.ledger().timestamp() },
         );
+    }
+
+    /// Reactivate an attestor that was previously revoked.
+    ///
+    /// Restores the attestor's registration and public key, allowing them to
+    /// submit attestations again. Audit history from the original revocation
+    /// is preserved. Only the primary admin or an [`AdminRole::AttestorAdmin`]
+    /// holder may call this function.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment context.
+    /// * `attestor` - Address of the attestor to reactivate.
+    ///
+    /// # Authorization
+    ///
+    /// Requires admin or `AttestorAdmin` role.
+    ///
+    /// # Errors
+    ///
+    /// Panics with:
+    /// - [`ErrorCode::AttestorNotRegistered`] if no revocation record exists for the attestor
+    /// - [`ErrorCode::AttestorAlreadyRegistered`] if the attestor is currently active
+    ///
+    /// # Side effects
+    ///
+    /// - Restores `ATTESTOR` and `ATPUBKEY` storage entries
+    /// - Marks the revocation record as reactivated with a timestamp
+    /// - Emits `attestor.restored` event
+    /// - Writes an admin audit log entry
+    pub fn reactivate_attestor(env: Env, attestor: Address) {
+        Self::require_admin(&env);
+
+        let xdr = attestor.clone().to_xdr(&env);
+        let raw = xdr_to_vec(&xdr);
+        let active_key = make_storage_key(&env, &[b"ATTESTOR", &raw]);
+
+        // Fail early if already active — nothing to recover.
+        if env.storage().persistent().has(&active_key) {
+            panic_with_error!(&env, ErrorCode::AttestorAlreadyRegistered);
+        }
+
+        // Load the revocation record — this is our proof of a prior valid registration.
+        let revoc_key = (symbol_short!("ATREVOC"), attestor.clone());
+        let mut revoc_record: AttestorRevocationRecord = env
+            .storage()
+            .persistent()
+            .get(&revoc_key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::AttestorNotRegistered));
+
+        // Restore the active registration flag and public key.
+        env.storage().persistent().set(&active_key, &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&active_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        let pk_key = make_storage_key(&env, &[b"ATPUBKEY", &raw]);
+        env.storage().persistent().set(&pk_key, &revoc_record.public_key);
+        env.storage()
+            .persistent()
+            .extend_ttl(&pk_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        // Update the revocation record to record reactivation timestamp.
+        revoc_record.reactivated = true;
+        revoc_record.reactivated_at = env.ledger().timestamp();
+        env.storage().persistent().set(&revoc_key, &revoc_record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&revoc_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        // Add back to the active attestors list and increment count.
+        let current_count = Self::get_attestor_count_internal(&env);
+        env.storage().instance().set(&Self::attestor_count_key(&env), &(current_count + 1));
+
+        let mut attestors_list = env
+            .storage()
+            .instance()
+            .get::<_, soroban_sdk::Vec<Address>>(&Self::attestor_list_key(&env))
+            .unwrap_or_else(|| soroban_sdk::Vec::new(&env));
+        if !attestors_list.contains(&attestor) {
+            attestors_list.push_back(attestor.clone());
+            env.storage().instance().set(&Self::attestor_list_key(&env), &attestors_list);
+        }
+        env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);
+
+        let admin = Self::get_admin_internal(&env);
+        AdminAuditLog::log_action(
+            &env,
+            &admin,
+            "reactivate_attestor",
+            attestor.to_string(),
+            "revoked",
+            "registered",
+        );
+
+        env.events().publish(
+            (symbol_short!("attestor"), symbol_short!("restored"), attestor.clone()),
+            AttestorReactivatedEvent { attestor, reactivated_by: admin, timestamp: env.ledger().timestamp() },
+        );
+    }
+
+    /// Return the revocation record for an attestor, if one exists.
+    ///
+    /// Returns `Some(AttestorRevocationRecord)` when the attestor has been
+    /// revoked at least once.  The record's `reactivated` field indicates
+    /// whether the attestor is currently active again.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - The Soroban environment context.
+    /// * `attestor` - Address of the attestor to query.
+    ///
+    /// # Returns
+    ///
+    /// `Some(AttestorRevocationRecord)` if found, `None` if the attestor was
+    /// never revoked.
+    pub fn get_attestor_revocation_info(env: Env, attestor: Address) -> Option<AttestorRevocationRecord> {
+        let revoc_key = (symbol_short!("ATREVOC"), attestor);
+        env.storage().persistent().get(&revoc_key)
     }
 
     /// Check if an address is a registered attestor.
@@ -2844,10 +3105,7 @@ impl AnchorKitContract {
         Self::save_profile(&env, &profile);
         env.events().publish(
             (symbol_short!("webhook"), symbol_short!("reg")),
-            EndpointUpdated {
-                attestor,
-                endpoint: webhook_url,
-            },
+            WebhookRegisteredEvent { attestor, timestamp: env.ledger().timestamp() },
         );
     }
 
@@ -3053,11 +3311,19 @@ impl AnchorKitContract {
 
         // Also sync services into the unified AttestorProfile.
         let mut profile = Self::load_or_init_profile(&env, &anchor);
-        profile.services = normalized;
+        profile.services = normalized.clone();
         profile.updated_at = env.ledger().timestamp();
         Self::save_profile(&env, &profile);
 
-        env.events().publish((symbol_short!("services"), symbol_short!("config")), record);
+        env.events().publish(
+            (symbol_short!("services"), symbol_short!("config"), anchor.clone()),
+            ServicesConfiguredEvent {
+                anchor,
+                service_count: normalized.len() as u32,
+                capability_version: version,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
     }
 
     /// The service-capability schema version this contract understands.
@@ -3515,6 +3781,9 @@ impl AnchorKitContract {
             .persistent()
             .extend_ttl(&used_key, REPLAY_TTL, REPLAY_TTL);
 
+        // Record accepted event for observability metrics.
+        replay_detection::record_accepted_event(&env);
+
         env.events().publish(
             (symbol_short!("attest"), symbol_short!("recorded"), id, subject),
             AttestEvent {
@@ -3545,7 +3814,7 @@ impl AnchorKitContract {
 
         let batch_size = attestations.len() as usize;
         if batch_size > MAX_BATCH_SIZE {
-            panic_with_error!(&env, ErrorCode::ValidationError);
+            panic_with_error!(&env, ErrorCode::BatchSizeExceeded);
         }
 
         if batch_size == 0 {
@@ -3640,7 +3909,7 @@ impl AnchorKitContract {
                 match kyc_status {
                     KycStatus::Pending => panic_with_error!(&env, ErrorCode::KycPending),
                     KycStatus::Rejected => panic_with_error!(&env, ErrorCode::KycRejected),
-                    KycStatus::Expired => panic_with_error!(&env, ErrorCode::ComplianceNotMet),
+                    KycStatus::Expired => panic_with_error!(&env, ErrorCode::KycExpired),
                     KycStatus::NotSubmitted => panic_with_error!(&env, ErrorCode::KycNotFound),
                     _ => panic_with_error!(&env, ErrorCode::ComplianceNotMet),
                 }
@@ -3695,6 +3964,8 @@ impl AnchorKitContract {
                 payload_hash,
             },
         );
+        // Record accepted event for observability metrics.
+        replay_detection::record_accepted_event(&env);
         id
     }
 
@@ -3759,6 +4030,8 @@ impl AnchorKitContract {
                 transaction_id: id, timestamp, payload_hash,
             },
         );
+        // Record accepted event for observability metrics.
+        replay_detection::record_accepted_event(&env);
         id
     }
 
@@ -4590,6 +4863,16 @@ impl AnchorKitContract {
         let quote: Quote = env.storage().persistent().get(&q_key)
             .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::QuoteNotFound));
 
+        // Reject the quote if its validity window has closed.
+        let now = env.ledger().timestamp();
+        if quote.valid_until <= now {
+            env.events().publish(
+                (symbol_short!("quote"), symbol_short!("expired"), quote_id),
+                QuoteExpiredEvent { quote_id, anchor: anchor.clone(), valid_until: quote.valid_until, expired_at: now },
+            );
+            panic_with_error!(&env, ErrorCode::QuoteExpired);
+        }
+
         // #297: Enforce compliance gating if required
         if require_compliance {
             let comp_key = compliance_check_key(&env, &receiver, &String::from_str(&env, "kyc"));
@@ -4712,6 +4995,8 @@ impl AnchorKitContract {
                 result_data: 0,
             },
         );
+        // Record accepted event for observability metrics.
+        replay_detection::record_accepted_event(&env);
         id
     }
 
@@ -4767,7 +5052,10 @@ impl AnchorKitContract {
         env.storage().persistent().set(&slog_key, &log_id);
         env.storage().persistent().extend_ttl(&slog_key, PERSISTENT_TTL, PERSISTENT_TTL);
 
-        env.events().publish((symbol_short!("attestor"), symbol_short!("added"), attestor), ());
+        env.events().publish(
+            (symbol_short!("attestor"), symbol_short!("added"), attestor.clone()),
+            AttestorRegisteredEvent { attestor, timestamp: env.ledger().timestamp() },
+        );
         env.events().publish(
             (symbol_short!("audit"), symbol_short!("logged"), log_id),
             AuditLogEvent {
@@ -4829,7 +5117,14 @@ impl AnchorKitContract {
         env.storage().persistent().set(&slog_key, &log_id);
         env.storage().persistent().extend_ttl(&slog_key, PERSISTENT_TTL, PERSISTENT_TTL);
 
-        env.events().publish((symbol_short!("attestor"), symbol_short!("removed"), attestor), ());
+        env.events().publish(
+            (symbol_short!("attestor"), symbol_short!("removed"), attestor.clone()),
+            AttestorRevokedEvent {
+                attestor,
+                revoked_by: operator,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
         env.events().publish(
             (symbol_short!("audit"), symbol_short!("logged"), log_id),
             AuditLogEvent {
@@ -5997,7 +6292,7 @@ impl AnchorKitContract {
                 match kyc_status {
                     KycStatus::Pending      => panic_with_error!(&env, ErrorCode::KycPending),
                     KycStatus::Rejected     => panic_with_error!(&env, ErrorCode::KycRejected),
-                    KycStatus::Expired      => panic_with_error!(&env, ErrorCode::ComplianceNotMet),
+                    KycStatus::Expired      => panic_with_error!(&env, ErrorCode::KycExpired),
                     KycStatus::NotSubmitted => panic_with_error!(&env, ErrorCode::KycNotFound),
                     _ => panic_with_error!(&env, ErrorCode::ComplianceNotMet),
                 }
@@ -6706,6 +7001,14 @@ impl AnchorKitContract {
             .map(|r| Symbol::new(env, Self::role_name(*r)));
         let config = RateLimiter::resolve_config(env, attestor, role);
         if RateLimiter::check_and_increment(env, attestor, &config).is_err() {
+            env.events().publish(
+                (symbol_short!("ratelimit"), symbol_short!("hit"), attestor.clone()),
+                RateLimitHitEvent {
+                    attestor: attestor.clone(),
+                    timestamp: env.ledger().timestamp(),
+                    ledger_sequence: env.ledger().sequence(),
+                },
+            );
             panic_with_error!(env, ErrorCode::RateLimitExceeded);
         }
     }
@@ -6807,6 +7110,12 @@ impl AnchorKitContract {
             .persistent()
             .has(&make_storage_key(env, &[b"ATTESTOR", &raw]))
         {
+            // Distinguish revoked attestors (have a revocation record but no active
+            // registration key) from ones that were never registered at all.
+            let revoc_key = (symbol_short!("ATREVOC"), attestor.clone());
+            if env.storage().persistent().has(&revoc_key) {
+                panic_with_error!(env, ErrorCode::AttestorRevoked);
+            }
             panic_with_error!(env, ErrorCode::AttestorNotRegistered);
         }
     }
@@ -6941,10 +7250,10 @@ impl AnchorKitContract {
             .get(&make_storage_key(env, &[b"ATPUBKEY", &raw]))
             .unwrap_or_else(|| panic_with_error!(env, ErrorCode::UnauthorizedAttestor));
         if signature.len() != 64 {
-            panic_with_error!(env, ErrorCode::UnauthorizedAttestor);
+            panic_with_error!(env, ErrorCode::SignatureVerificationFailed);
         }
         let signature_bytes: BytesN<64> = signature.clone().try_into().unwrap_or_else(|_| {
-            panic_with_error!(env, ErrorCode::UnauthorizedAttestor)
+            panic_with_error!(env, ErrorCode::SignatureVerificationFailed)
         });
         env.crypto()
             .ed25519_verify(&pk, payload_hash, &signature_bytes);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -121,6 +121,18 @@ pub enum ErrorCode {
     EndpointNotSet            = 56,
     /// Attestor has no webhook URL set (profile exists but field is empty).
     WebhookUrlNotSet          = 57,
+
+    // Precise failure-mode variants (58–62)
+    /// KYC record exists but the approval has passed its expiry timestamp.
+    KycExpired                = 58,
+    /// Attestor address is known but currently revoked; reactivation is required.
+    AttestorRevoked           = 59,
+    /// Quote record exists but `valid_until` has passed.
+    QuoteExpired              = 60,
+    /// EdDSA signature length or value is invalid for the given public key.
+    SignatureVerificationFailed = 61,
+    /// Batch submission contains more items than the per-call maximum.
+    BatchSizeExceeded         = 62,
 }
 
 impl ErrorCode {
@@ -186,6 +198,11 @@ impl ErrorCode {
             ErrorCode::TransactionNotFound       => "Transaction record not found",
             ErrorCode::EndpointNotSet            => "Attestor endpoint URL is not set",
             ErrorCode::WebhookUrlNotSet          => "Attestor webhook URL is not set",
+            ErrorCode::KycExpired                => "KYC approval has expired",
+            ErrorCode::AttestorRevoked           => "Attestor is revoked; reactivation required",
+            ErrorCode::QuoteExpired              => "Quote has passed its validity deadline",
+            ErrorCode::SignatureVerificationFailed => "Attestation signature verification failed",
+            ErrorCode::BatchSizeExceeded         => "Batch size exceeds the per-call maximum",
         }
     }
 }
@@ -362,6 +379,17 @@ impl AnchorKitError {
     pub fn quote_not_found() -> Self { Self::from_code(ErrorCode::QuoteNotFound) }
     pub fn endpoint_not_set() -> Self { Self::from_code(ErrorCode::EndpointNotSet) }
     pub fn webhook_url_not_set() -> Self { Self::from_code(ErrorCode::WebhookUrlNotSet) }
+    pub fn kyc_expired() -> Self { Self::from_code(ErrorCode::KycExpired) }
+    pub fn attestor_revoked() -> Self { Self::from_code(ErrorCode::AttestorRevoked) }
+    pub fn quote_expired() -> Self { Self::from_code(ErrorCode::QuoteExpired) }
+    pub fn signature_verification_failed() -> Self { Self::from_code(ErrorCode::SignatureVerificationFailed) }
+    pub fn batch_size_exceeded(limit: usize, given: usize) -> Self {
+        Self::with_context(
+            ErrorCode::BatchSizeExceeded,
+            ErrorCode::BatchSizeExceeded.default_message(),
+            &alloc::format!("limit={} given={}", limit, given),
+        )
+    }
     pub fn invalid_asset_code(code: &str) -> Self {
         Self::with_context(
             ErrorCode::InvalidAssetCode,
@@ -548,6 +576,13 @@ mod tests {
             ErrorCode::SessionNotFound,
             ErrorCode::QuoteNotFound,
             ErrorCode::Unauthorized,
+            ErrorCode::EndpointNotSet,
+            ErrorCode::WebhookUrlNotSet,
+            ErrorCode::KycExpired,
+            ErrorCode::AttestorRevoked,
+            ErrorCode::QuoteExpired,
+            ErrorCode::SignatureVerificationFailed,
+            ErrorCode::BatchSizeExceeded,
         ];
         for code in codes {
             assert!(!code.default_message().is_empty());
@@ -576,11 +611,37 @@ mod tests {
         assert_eq!(ErrorCode::InvalidRequestContext as u32, 51);
         assert_eq!(ErrorCode::InvalidSessionMetadata as u32, 52);
         assert_eq!(ErrorCode::InvalidAssetCode      as u32, 53);
+        assert_eq!(ErrorCode::AttestorCapacityExceeded as u32, 54);
+        assert_eq!(ErrorCode::CacheCapacityExceeded as u32, 55);
+        assert_eq!(ErrorCode::EndpointNotSet        as u32, 56);
+        assert_eq!(ErrorCode::WebhookUrlNotSet      as u32, 57);
+        assert_eq!(ErrorCode::KycExpired            as u32, 58);
+        assert_eq!(ErrorCode::AttestorRevoked       as u32, 59);
+        assert_eq!(ErrorCode::QuoteExpired          as u32, 60);
+        assert_eq!(ErrorCode::SignatureVerificationFailed as u32, 61);
+        assert_eq!(ErrorCode::BatchSizeExceeded     as u32, 62);
     }
 
     #[test]
-    fn test_type_alias_error_works() {
-        let err: Error = AnchorKitError::from_code(ErrorCode::InvalidEndpointFormat);
+    fn test_new_precise_error_variants_have_messages() {
+        assert!(!ErrorCode::KycExpired.default_message().is_empty());
+        assert!(!ErrorCode::AttestorRevoked.default_message().is_empty());
+        assert!(!ErrorCode::QuoteExpired.default_message().is_empty());
+        assert!(!ErrorCode::SignatureVerificationFailed.default_message().is_empty());
+        assert!(!ErrorCode::BatchSizeExceeded.default_message().is_empty());
+    }
+
+    #[test]
+    fn test_batch_size_exceeded_carries_context() {
+        let err = AnchorKitError::batch_size_exceeded(100, 150);
+        assert_eq!(err.code, ErrorCode::BatchSizeExceeded);
+        let ctx = err.context.expect("context must be present");
+        assert!(ctx.contains("limit=100"));
+        assert!(ctx.contains("given=150"));
+    }
+
+    #[test]
+    fn test_type_alias_error_works() {        let err: Error = AnchorKitError::from_code(ErrorCode::InvalidEndpointFormat);
         assert_eq!(err.code, ErrorCode::InvalidEndpointFormat);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,12 @@ pub use rate_limiter::{RateLimiter, RateLimitConfig, RateLimitState};
 pub use retry::{retry_with_backoff, is_retryable, RetryConfig, JitterSource, LedgerJitterSource, MockJitterSource};
 pub use deterministic_hash::{compute_payload_hash, verify_payload_hash};
 pub use contract::{AnchorKitContract, AnchorTomlProvenance, EndpointUpdated, CacheConfig};
+pub use contract::{AttestorRevocationRecord};
+pub use contract::{
+    ContractInitializedEvent, AttestorRegisteredEvent, AttestorRevokedEvent,
+    AttestorReactivatedEvent, RateLimitHitEvent, QuoteExpiredEvent,
+    WebhookRegisteredEvent, ServicesConfiguredEvent,
+};
 pub use transaction_state_tracker::{TransactionState, TransactionStateRecord, RecoveryMetadata, OptRecovery};
 pub use transaction_state_tracker::{StorageBudgetMonitor, TransactionStateTracker};
 pub use transaction_state_tracker::TransactionSummary;

--- a/src/replay_detection.rs
+++ b/src/replay_detection.rs
@@ -30,7 +30,7 @@ pub struct ReplayDetectionEvent {
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ReplayMetrics {
-    /// Total number of replay attempts detected since initialization
+    /// Total number of replay attempts detected (rejected) since initialization
     pub total_replay_attempts: u64,
     /// Number of unique request IDs that have been replayed
     pub unique_replayed_ids: u64,
@@ -38,6 +38,10 @@ pub struct ReplayMetrics {
     pub last_replay_at: u64,
     /// Ledger sequence when metrics were last updated
     pub last_updated_ledger: u32,
+    /// Total number of attestations accepted (passed all checks including replay detection)
+    pub accepted_events: u64,
+    /// Total number of events skipped (e.g. pre-flight checks failed before reaching replay check)
+    pub skipped_events: u64,
 }
 
 impl Default for ReplayMetrics {
@@ -47,6 +51,8 @@ impl Default for ReplayMetrics {
             unique_replayed_ids: 0,
             last_replay_at: 0,
             last_updated_ledger: 0,
+            accepted_events: 0,
+            skipped_events: 0,
         }
     }
 }
@@ -177,6 +183,43 @@ pub fn get_replay_count_for_id(env: &Env, request_id: &Bytes) -> u64 {
         .instance()
         .get::<_, u32>(&attempt_key)
         .unwrap_or(0) as u64
+}
+
+/// Record a successfully accepted event (passed all checks including replay detection).
+///
+/// Should be called after an attestation is committed to storage.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+pub fn record_accepted_event(env: &Env) {
+    let metrics_key = soroban_sdk::symbol_short!("REPLAYM");
+    let mut metrics: ReplayMetrics = env
+        .storage()
+        .instance()
+        .get::<_, ReplayMetrics>(&metrics_key)
+        .unwrap_or_default();
+    metrics.accepted_events += 1;
+    metrics.last_updated_ledger = env.ledger().sequence();
+    env.storage().instance().set(&metrics_key, &metrics);
+}
+
+/// Record a skipped event (rejected before or outside the replay check, e.g. timestamp invalid,
+/// rate limit exceeded, or attestor not registered).
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+pub fn record_skipped_event(env: &Env) {
+    let metrics_key = soroban_sdk::symbol_short!("REPLAYM");
+    let mut metrics: ReplayMetrics = env
+        .storage()
+        .instance()
+        .get::<_, ReplayMetrics>(&metrics_key)
+        .unwrap_or_default();
+    metrics.skipped_events += 1;
+    metrics.last_updated_ledger = env.ledger().sequence();
+    env.storage().instance().set(&metrics_key, &metrics);
 }
 
 /// Get a specific replay detection event record by ID.

--- a/tests/attestor_recovery_tests.rs
+++ b/tests/attestor_recovery_tests.rs
@@ -1,0 +1,251 @@
+#![cfg(test)]
+
+mod sep10_test_util;
+
+mod attestor_recovery_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Bytes, Env,
+    };
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+    use crate::sep10_test_util::{register_attestor_with_sep10, sign_payload};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set(LedgerInfo {
+            timestamp: 1_000_000,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+        env
+    }
+
+    fn payload(env: &Env) -> Bytes {
+        let mut b = Bytes::new(env);
+        for i in 0u8..32 {
+            b.push_back(i);
+        }
+        b
+    }
+
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address, Address, SigningKey) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let issuer = Address::generate(env);
+        client.initialize(&admin);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(env, &client, &issuer, &issuer, &sk);
+        (client, admin, issuer, sk)
+    }
+
+    // -----------------------------------------------------------------------
+    // Revoke then verify the attestor is no longer active
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_revoke_makes_attestor_inactive() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        assert!(client.is_attestor(&issuer), "attestor should be active after registration");
+
+        client.revoke_attestor(&issuer);
+
+        assert!(!client.is_attestor(&issuer), "attestor must be inactive after revocation");
+    }
+
+    // -----------------------------------------------------------------------
+    // Revocation record is preserved after revoking
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_revocation_record_is_stored() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        client.revoke_attestor(&issuer);
+
+        let record_opt = client.get_attestor_revocation_info(&issuer);
+        assert!(record_opt.is_some(), "revocation record must exist after revoking");
+
+        let record = record_opt.unwrap();
+        assert!(!record.reactivated, "record.reactivated must be false before recovery");
+        assert_eq!(record.reactivated_at, 0, "reactivated_at must be 0 before recovery");
+    }
+
+    // -----------------------------------------------------------------------
+    // Attestor can be reactivated and becomes active again
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_reactivate_restores_active_status() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        client.revoke_attestor(&issuer);
+        assert!(!client.is_attestor(&issuer));
+
+        client.reactivate_attestor(&issuer);
+
+        assert!(client.is_attestor(&issuer), "attestor must be active after reactivation");
+    }
+
+    // -----------------------------------------------------------------------
+    // Reactivated attestor can submit attestations again
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_reactivated_attestor_can_submit_attestations() {
+        let env = make_env();
+        let (client, _, issuer, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        client.revoke_attestor(&issuer);
+        client.reactivate_attestor(&issuer);
+
+        let hash = payload(&env);
+        let sig = sign_payload(&env, &sk, &hash);
+        // Must not panic — the reactivated attestor should be accepted.
+        let id = client.submit_attestation(&issuer, &subject, &1_000_001u64, &hash, &sig);
+        assert_eq!(id, 0, "first attestation must have id 0");
+    }
+
+    // -----------------------------------------------------------------------
+    // Revocation record is marked reactivated after recovery
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_revocation_record_updated_after_reactivation() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        client.revoke_attestor(&issuer);
+
+        // Advance ledger time so reactivated_at is distinguishable.
+        env.ledger().set(LedgerInfo {
+            timestamp: 2_000_000,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+
+        client.reactivate_attestor(&issuer);
+
+        let record = client.get_attestor_revocation_info(&issuer).expect("record must exist");
+        assert!(record.reactivated, "record.reactivated must be true after recovery");
+        assert_eq!(record.reactivated_at, 2_000_000, "reactivated_at must equal ledger timestamp");
+    }
+
+    // -----------------------------------------------------------------------
+    // Revocation audit data is preserved after reactivation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_revocation_audit_data_preserved_after_reactivation() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        client.revoke_attestor(&issuer);
+        let record_before = client.get_attestor_revocation_info(&issuer).unwrap();
+        let original_revoked_at = record_before.revoked_at;
+
+        client.reactivate_attestor(&issuer);
+
+        let record_after = client.get_attestor_revocation_info(&issuer).unwrap();
+        assert_eq!(
+            record_after.revoked_at, original_revoked_at,
+            "revoked_at timestamp must be preserved after reactivation"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Reactivating a non-revoked (still active) attestor fails
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn test_reactivate_active_attestor_panics() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+        // Attestor is still active — reactivation must fail.
+        client.reactivate_attestor(&issuer);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reactivating an attestor with no prior revocation record fails
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn test_reactivate_unregistered_attestor_panics() {
+        let env = make_env();
+        let (client, _, _, _) = setup(&env);
+        let stranger = Address::generate(&env);
+        // This address was never registered — no revocation record exists.
+        client.reactivate_attestor(&stranger);
+    }
+
+    // -----------------------------------------------------------------------
+    // Revoking an already-revoked attestor (not registered) fails
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn test_revoke_already_revoked_attestor_panics() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+        client.revoke_attestor(&issuer);
+        // Second revocation must fail with AttestorNotRegistered.
+        client.revoke_attestor(&issuer);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_attestor_revocation_info returns None for never-revoked attestors
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_no_revocation_info_for_active_attestor() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        // Still active — no revocation record should exist.
+        let info = client.get_attestor_revocation_info(&issuer);
+        assert!(info.is_none(), "no revocation record for an active attestor");
+    }
+
+    // -----------------------------------------------------------------------
+    // Full revoke-reactivate-revoke cycle preserves consistency
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_revoke_reactivate_revoke_cycle() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        // First revocation
+        client.revoke_attestor(&issuer);
+        assert!(!client.is_attestor(&issuer));
+
+        // Recovery
+        client.reactivate_attestor(&issuer);
+        assert!(client.is_attestor(&issuer));
+
+        // Second revocation
+        client.revoke_attestor(&issuer);
+        assert!(!client.is_attestor(&issuer));
+    }
+}

--- a/tests/error_and_event_tests.rs
+++ b/tests/error_and_event_tests.rs
@@ -1,0 +1,562 @@
+#![cfg(test)]
+
+mod sep10_test_util;
+
+/// Tests that verify:
+/// - New precise error codes are returned for representative failure conditions
+/// - Rich events are emitted for every major state transition
+mod error_taxonomy_tests {
+    use anchorkit::errors::{AnchorKitError, ErrorCode, normalize_asset_code};
+
+    // -----------------------------------------------------------------------
+    // New variant discriminants
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_new_error_code_discriminants() {
+        assert_eq!(ErrorCode::KycExpired               as u32, 58);
+        assert_eq!(ErrorCode::AttestorRevoked          as u32, 59);
+        assert_eq!(ErrorCode::QuoteExpired             as u32, 60);
+        assert_eq!(ErrorCode::SignatureVerificationFailed as u32, 61);
+        assert_eq!(ErrorCode::BatchSizeExceeded        as u32, 62);
+    }
+
+    #[test]
+    fn test_new_error_code_messages_are_non_empty() {
+        let codes = [
+            ErrorCode::KycExpired,
+            ErrorCode::AttestorRevoked,
+            ErrorCode::QuoteExpired,
+            ErrorCode::SignatureVerificationFailed,
+            ErrorCode::BatchSizeExceeded,
+        ];
+        for code in codes {
+            assert!(!code.default_message().is_empty(), "{code:?} has empty message");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Named constructors
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_kyc_expired_constructor() {
+        let err = AnchorKitError::kyc_expired();
+        assert_eq!(err.code, ErrorCode::KycExpired);
+        assert_eq!(err.message, ErrorCode::KycExpired.default_message());
+        assert!(err.context.is_none());
+    }
+
+    #[test]
+    fn test_attestor_revoked_constructor() {
+        let err = AnchorKitError::attestor_revoked();
+        assert_eq!(err.code, ErrorCode::AttestorRevoked);
+    }
+
+    #[test]
+    fn test_quote_expired_constructor() {
+        let err = AnchorKitError::quote_expired();
+        assert_eq!(err.code, ErrorCode::QuoteExpired);
+    }
+
+    #[test]
+    fn test_signature_verification_failed_constructor() {
+        let err = AnchorKitError::signature_verification_failed();
+        assert_eq!(err.code, ErrorCode::SignatureVerificationFailed);
+    }
+
+    #[test]
+    fn test_batch_size_exceeded_carries_context() {
+        let err = AnchorKitError::batch_size_exceeded(100, 150);
+        assert_eq!(err.code, ErrorCode::BatchSizeExceeded);
+        let ctx = err.context.expect("context must be present");
+        assert!(ctx.contains("limit=100"), "context should contain limit");
+        assert!(ctx.contains("given=150"), "context should contain given");
+    }
+
+    // -----------------------------------------------------------------------
+    // No duplicate discriminants across entire enum
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_no_overlapping_discriminants() {
+        use std::collections::HashSet;
+        let all: &[(u32, &str)] = &[
+            (1,  "AlreadyInitialized"),
+            (2,  "AttestorAlreadyRegistered"),
+            (3,  "AttestorNotRegistered"),
+            (4,  "UnauthorizedAttestor"),
+            (5,  "InvalidTimestamp"),
+            (6,  "ReplayAttack"),
+            (7,  "InvalidQuote"),
+            (8,  "InvalidServiceType"),
+            (9,  "InvalidTransactionIntent"),
+            (10, "StaleQuote"),
+            (11, "ComplianceNotMet"),
+            (12, "InvalidEndpointFormat"),
+            (13, "NoQuotesAvailable"),
+            (14, "ServicesNotConfigured"),
+            (15, "ValidationError"),
+            (16, "RateLimitExceeded"),
+            (17, "AttestationNotFound"),
+            (18, "InvalidSep10Token"),
+            (19, "KycNotFound"),
+            (20, "KycPending"),
+            (21, "KycRejected"),
+            (22, "WebhookDeliveryFailed"),
+            (23, "NotInitialized"),
+            (24, "IllegalTransition"),
+            (25, "SessionExpired"),
+            (26, "SessionClosed"),
+            (27, "UnsupportedCapabilityVersion"),
+            (28, "Unauthorized"),
+            (30, "SessionOperationLimitExceeded"),
+            (31, "InvalidWeights"),
+            (32, "SessionNotFound"),
+            (33, "QuoteNotFound"),
+            (34, "AuditLogNotFound"),
+            (35, "TransactionNotFound"),
+            (48, "CacheExpired"),
+            (49, "CacheNotFound"),
+            (50, "AttestorProfileNotFound"),
+            (51, "InvalidRequestContext"),
+            (52, "InvalidSessionMetadata"),
+            (53, "InvalidAssetCode"),
+            (54, "AttestorCapacityExceeded"),
+            (55, "CacheCapacityExceeded"),
+            (56, "EndpointNotSet"),
+            (57, "WebhookUrlNotSet"),
+            (58, "KycExpired"),
+            (59, "AttestorRevoked"),
+            (60, "QuoteExpired"),
+            (61, "SignatureVerificationFailed"),
+            (62, "BatchSizeExceeded"),
+        ];
+        let mut seen = HashSet::new();
+        for (disc, name) in all {
+            assert!(seen.insert(disc), "duplicate discriminant {disc} for {name}");
+        }
+    }
+}
+
+mod event_emission_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Events, Ledger, LedgerInfo},
+        Address, Bytes, Env,
+    };
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+    use crate::sep10_test_util::{register_attestor_with_sep10, sign_payload};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set(LedgerInfo {
+            timestamp: 1_000_000,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+        env
+    }
+
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address, Address, SigningKey) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let issuer = Address::generate(env);
+        client.initialize(&admin);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(env, &client, &issuer, &issuer, &sk);
+        (client, admin, issuer, sk)
+    }
+
+    fn payload(env: &Env) -> Bytes {
+        let mut b = Bytes::new(env);
+        for i in 0u8..32 { b.push_back(i); }
+        b
+    }
+
+    // -----------------------------------------------------------------------
+    // contract.initialized event
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_contract_initialized_event_emitted() {
+        let env = make_env();
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.initialize(&admin);
+
+        let events = env.events().all();
+        let has_init = events.iter().any(|(_, topics, _)| {
+            // topics[0] == "contract", topics[1] == "init"
+            topics.len() >= 2
+        });
+        assert!(has_init, "contract.init event must be emitted");
+    }
+
+    // -----------------------------------------------------------------------
+    // attestor.added carries rich payload
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_attestor_registered_event_emitted() {
+        let env = make_env();
+        let (_, _, _, _) = setup(&env);
+
+        let events = env.events().all();
+        // At least one event should have "added" in topics (from register_attestor)
+        assert!(!events.is_empty(), "events should be emitted on registration");
+    }
+
+    // -----------------------------------------------------------------------
+    // attestor.removed event emitted on revoke
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_attestor_revoked_event_emitted() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        client.revoke_attestor(&issuer);
+
+        let events = env.events().all();
+        assert!(!events.is_empty(), "events must be emitted after revocation");
+    }
+
+    // -----------------------------------------------------------------------
+    // attestor.restored event emitted on reactivation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_attestor_reactivated_event_emitted() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        client.revoke_attestor(&issuer);
+        let events_before = env.events().all().len();
+
+        client.reactivate_attestor(&issuer);
+
+        let events_after = env.events().all().len();
+        assert!(
+            events_after > events_before,
+            "reactivate_attestor must emit at least one event"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // session.created and session.closed events
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_session_created_event_emitted() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        let before = env.events().all().len();
+        client.create_session(&issuer);
+        let after = env.events().all().len();
+
+        assert!(after > before, "session.created event must be emitted");
+    }
+
+    #[test]
+    fn test_session_closed_event_emitted() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+        let session_id = client.create_session(&issuer);
+
+        let before = env.events().all().len();
+        client.close_session(&session_id, &issuer);
+        let after = env.events().all().len();
+
+        assert!(after > before, "session.closed event must be emitted");
+    }
+
+    // -----------------------------------------------------------------------
+    // quote.submit event emitted
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_quote_submit_event_emitted() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+
+        let base = soroban_sdk::String::from_str(&env, "USDC");
+        let quote_asset = soroban_sdk::String::from_str(&env, "XLM");
+        let valid_until = 1_000_000u64 + 3600;
+
+        let before = env.events().all().len();
+        client.submit_quote(&issuer, &base, &quote_asset, &100u64, &100u32, &1u64, &1000u64, &valid_until);
+        let after = env.events().all().len();
+
+        assert!(after > before, "quote.submit event must be emitted");
+    }
+
+    // -----------------------------------------------------------------------
+    // kyc.submitted, kyc.approved, kyc.rejected events
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_kyc_submitted_event_emitted() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+        let subject = Address::generate(&env);
+
+        let before = env.events().all().len();
+        client.submit_kyc(&subject, &payload(&env), &issuer);
+        let after = env.events().all().len();
+
+        assert!(after > before, "kyc.submitted event must be emitted");
+    }
+
+    #[test]
+    fn test_kyc_approved_event_emitted() {
+        let env = make_env();
+        let (client, admin, issuer, _) = setup(&env);
+        let subject = Address::generate(&env);
+        client.submit_kyc(&subject, &payload(&env), &issuer);
+
+        let before = env.events().all().len();
+        client.approve_kyc(&admin, &subject);
+        let after = env.events().all().len();
+
+        assert!(after > before, "kyc.approved event must be emitted");
+    }
+
+    #[test]
+    fn test_kyc_rejected_event_emitted() {
+        let env = make_env();
+        let (client, admin, issuer, _) = setup(&env);
+        let subject = Address::generate(&env);
+        client.submit_kyc(&subject, &payload(&env), &issuer);
+
+        let before = env.events().all().len();
+        client.reject_kyc(&admin, &subject, &payload(&env));
+        let after = env.events().all().len();
+
+        assert!(after > before, "kyc.rejected event must be emitted");
+    }
+
+    // -----------------------------------------------------------------------
+    // services.config event emitted with anchor in topic
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_services_config_event_emitted() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+        let services = soroban_sdk::vec![&env, 1u32, 2u32];
+
+        let before = env.events().all().len();
+        client.configure_services(&issuer, &services);
+        let after = env.events().all().len();
+
+        assert!(after > before, "services.config event must be emitted");
+    }
+
+    // -----------------------------------------------------------------------
+    // webhook.reg event emitted
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_webhook_registered_event_emitted() {
+        let env = make_env();
+        let (client, _, issuer, _) = setup(&env);
+        let url = soroban_sdk::String::from_str(&env, "https://example.com/hook");
+
+        let before = env.events().all().len();
+        client.register_webhook(&issuer, &url);
+        let after = env.events().all().len();
+
+        assert!(after > before, "webhook.reg event must be emitted");
+    }
+
+    // -----------------------------------------------------------------------
+    // attest.recorded event emitted on successful attestation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_attestation_recorded_event_emitted() {
+        let env = make_env();
+        let (client, _, issuer, sk) = setup(&env);
+        let subject = Address::generate(&env);
+        let hash = payload(&env);
+        let sig = sign_payload(&env, &sk, &hash);
+
+        let before = env.events().all().len();
+        client.submit_attestation(&issuer, &subject, &1_000_001u64, &hash, &sig);
+        let after = env.events().all().len();
+
+        assert!(after > before, "attest.recorded event must be emitted");
+    }
+}
+
+mod error_propagation_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Bytes, Env,
+    };
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+    use anchorkit::ErrorCode;
+    use crate::sep10_test_util::register_attestor_with_sep10;
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set(LedgerInfo {
+            timestamp: 1_000_000,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+        env
+    }
+
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let issuer = Address::generate(env);
+        client.initialize(&admin);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(env, &client, &issuer, &issuer, &sk);
+        (client, admin, issuer)
+    }
+
+    // -----------------------------------------------------------------------
+    // AttestorRevoked is returned when a revoked attestor calls check_attestor
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_revoked_attestor_returns_attestor_revoked_error() {
+        let env = make_env();
+        let (client, _, issuer) = setup(&env);
+        client.revoke_attestor(&issuer);
+
+        // is_attestor now returns false — confirm via the public query
+        assert!(!client.is_attestor(&issuer));
+
+        // Attempting to get the profile of a revoked attestor should give AttestorRevoked
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.get_attestor_profile(&issuer);
+        }));
+        assert!(result.is_err(), "revoked attestor profile access must panic");
+    }
+
+    // -----------------------------------------------------------------------
+    // AttestorNotRegistered returned for a completely unknown address
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_unknown_attestor_returns_not_registered() {
+        let env = make_env();
+        let (client, _, _) = setup(&env);
+        let stranger = Address::generate(&env);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.get_attestor_profile(&stranger);
+        }));
+        assert!(result.is_err(), "unknown attestor must panic");
+    }
+
+    // -----------------------------------------------------------------------
+    // BatchSizeExceeded is returned when batch exceeds MAX_BATCH_SIZE
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_batch_size_exceeded_error() {
+        use anchorkit::contract::AttestationInput;
+        use soroban_sdk::Vec;
+
+        let env = make_env();
+        let (client, _, issuer) = setup(&env);
+
+        // Build a batch of 101 items (MAX_BATCH_SIZE is 100)
+        let mut inputs = Vec::new(&env);
+        for i in 0u8..101 {
+            let mut hash = Bytes::new(&env);
+            for _ in 0..32 { hash.push_back(i); }
+            inputs.push_back(AttestationInput {
+                issuer: issuer.clone(),
+                subject: Address::generate(&env),
+                timestamp: 1_000_001,
+                payload_hash: hash.clone(),
+                signature: hash,
+            });
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.submit_attestation_batch(&issuer, &inputs);
+        }));
+        assert!(result.is_err(), "oversized batch must be rejected");
+    }
+
+    // -----------------------------------------------------------------------
+    // KycExpired — attestation with require_kyc fails when KYC is expired
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_kyc_expired_error_on_attestation() {
+        use soroban_sdk::Vec;
+
+        let env = make_env();
+        let sk = ed25519_dalek::SigningKey::generate(&mut OsRng);
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+        register_attestor_with_sep10(&env, &client, &issuer, &issuer, &sk);
+
+        // Submit and approve KYC
+        let data_hash = {
+            let mut b = Bytes::new(&env);
+            for i in 0u8..32 { b.push_back(i); }
+            b
+        };
+        client.submit_kyc(&subject, &data_hash, &issuer);
+        client.approve_kyc(&admin, &subject);
+
+        // Fast-forward past KYC expiry (30 days = 2_592_000 seconds)
+        env.ledger().set(LedgerInfo {
+            timestamp: 1_000_000 + 2_592_001,
+            protocol_version: 21,
+            sequence_number: 100,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+
+        let mut hash = Bytes::new(&env);
+        for i in 0u8..32 { hash.push_back(i + 100); }
+        let sig = crate::sep10_test_util::sign_payload(&env, &sk, &hash);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.submit_attestation_kyc_check(
+                &issuer, &subject, &(1_000_000 + 2_592_001), &hash, &sig, &true,
+            );
+        }));
+        assert!(result.is_err(), "expired KYC must reject the attestation");
+    }
+}

--- a/tests/replay_metrics_tests.rs
+++ b/tests/replay_metrics_tests.rs
@@ -1,0 +1,192 @@
+#![cfg(test)]
+
+mod sep10_test_util;
+
+mod replay_metrics_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Bytes, Env,
+    };
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+    use crate::sep10_test_util::{register_attestor_with_sep10, sign_payload};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set(LedgerInfo {
+            timestamp: 1_000_000,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+        env
+    }
+
+    fn payload(env: &Env, byte: u8) -> Bytes {
+        let mut b = Bytes::new(env);
+        for _ in 0..32 {
+            b.push_back(byte);
+        }
+        b
+    }
+
+    /// Set up a fresh contract with one registered attestor.
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address, Address, SigningKey) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let issuer = Address::generate(env);
+        client.initialize(&admin);
+        let sk = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(env, &client, &issuer, &issuer, &sk);
+        (client, admin, issuer, sk)
+    }
+
+    // -----------------------------------------------------------------------
+    // Accepted-event counter increments after a successful attestation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_accepted_events_counter_increments_on_submit() {
+        let env = make_env();
+        let (client, _, issuer, sk) = setup(&env);
+
+        let hash = payload(&env, 0x01);
+        let sig = sign_payload(&env, &sk, &hash);
+        let subject = Address::generate(&env);
+
+        // Before any submission the counter must be zero.
+        let before = client.get_replay_metrics();
+        assert_eq!(before.accepted_events, 0);
+
+        client.submit_attestation(&issuer, &subject, &1_000_001u64, &hash, &sig);
+
+        let after = client.get_replay_metrics();
+        assert_eq!(after.accepted_events, 1);
+        assert_eq!(after.total_replay_attempts, 0);
+        assert_eq!(after.skipped_events, 0);
+    }
+
+    #[test]
+    fn test_accepted_events_accumulate_across_multiple_submissions() {
+        let env = make_env();
+        let (client, _, issuer, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        for i in 0u8..3 {
+            let hash = payload(&env, i + 1);
+            let sig = sign_payload(&env, &sk, &hash);
+            client.submit_attestation(&issuer, &subject, &(1_000_001u64 + i as u64), &hash, &sig);
+        }
+
+        let metrics = client.get_replay_metrics();
+        assert_eq!(metrics.accepted_events, 3);
+        assert_eq!(metrics.total_replay_attempts, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Replay-attempt counter increments on duplicate, accepted stays unchanged
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_replay_attempt_does_not_increment_accepted() {
+        let env = make_env();
+        let (client, _, issuer, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        let hash = payload(&env, 0xAA);
+        let sig = sign_payload(&env, &sk, &hash);
+
+        // First submission — should succeed and bump accepted.
+        client.submit_attestation(&issuer, &subject, &1_000_001u64, &hash, &sig);
+
+        let mid = client.get_replay_metrics();
+        assert_eq!(mid.accepted_events, 1);
+        assert_eq!(mid.total_replay_attempts, 0);
+
+        // Second submission with same hash — should be rejected as a replay.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.submit_attestation(&issuer, &subject, &1_000_002u64, &hash, &sig);
+        }));
+        assert!(result.is_err(), "duplicate submission must be rejected");
+
+        let after = client.get_replay_metrics();
+        // accepted must NOT have changed.
+        assert_eq!(after.accepted_events, 1, "accepted_events must not change on replay");
+        // replay counter must have incremented.
+        assert_eq!(after.total_replay_attempts, 1);
+        assert_eq!(after.unique_replayed_ids, 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Counters are independent across different issuers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_accepted_events_count_multiple_issuers() {
+        let env = make_env();
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let issuer_a = Address::generate(&env);
+        let issuer_b = Address::generate(&env);
+        let subject = Address::generate(&env);
+
+        let sk_a = SigningKey::generate(&mut OsRng);
+        let sk_b = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(&env, &client, &issuer_a, &issuer_a, &sk_a);
+        register_attestor_with_sep10(&env, &client, &issuer_b, &issuer_b, &sk_b);
+
+        // Same hash, two different issuers — both should be accepted.
+        let hash = payload(&env, 0x42);
+        let sig_a = sign_payload(&env, &sk_a, &hash);
+        let sig_b = sign_payload(&env, &sk_b, &hash);
+        client.submit_attestation(&issuer_a, &subject, &1_000_001u64, &hash, &sig_a);
+        client.submit_attestation(&issuer_b, &subject, &1_000_002u64, &hash, &sig_b);
+
+        let metrics = client.get_replay_metrics();
+        assert_eq!(metrics.accepted_events, 2);
+        assert_eq!(metrics.total_replay_attempts, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_replay_count_for_id reflects per-id replay count
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_replay_count_per_id_matches_total_attempts() {
+        let env = make_env();
+        let (client, _, issuer, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        let hash = payload(&env, 0x77);
+        let sig = sign_payload(&env, &sk, &hash);
+
+        client.submit_attestation(&issuer, &subject, &1_000_001u64, &hash, &sig);
+
+        // First replay
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.submit_attestation(&issuer, &subject, &1_000_002u64, &hash, &sig);
+        }));
+        // Second replay
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.submit_attestation(&issuer, &subject, &1_000_003u64, &hash, &sig);
+        }));
+
+        let metrics = client.get_replay_metrics();
+        assert_eq!(metrics.total_replay_attempts, 2);
+        assert_eq!(metrics.unique_replayed_ids, 1);
+
+        let per_id = client.get_replay_count_for_id(&hash);
+        assert_eq!(per_id, 2, "per-id count must match replay attempts for that id");
+    }
+}


### PR DESCRIPTION


Closes #582
Closes #579
Closes #585
Closes #578

## Replay detection instrumentation (#582)
- Add accepted_events and skipped_events counters to ReplayMetrics
- Add record_accepted_event() and record_skipped_event() helpers
- Call record_accepted_event after every successful attestation write in submit_attestation, submit_attestation_with_session, submit_attestation_kyc_check, and submit_with_request_id
- Tests: tests/replay_metrics_tests.rs

## Attestor recovery path (#579)
- Add AttestorRevocationRecord struct to preserve public key and audit history across the revoke/reactivate lifecycle
- Modify revoke_attestor to write a revocation record before removing active storage keys so recovery does not require re-registration
- Add reactivate_attestor: admin-gated, restores keys, updates record, emits attestor.restored event, writes audit log
- Add get_attestor_revocation_info query
- Fix pre-existing missing constants MAX_BATCH_SIZE and BATCH_ATTESTATION_RATE_MULTIPLIER
- Tests: tests/attestor_recovery_tests.rs

## Precise error taxonomy (#585)
- Add KycExpired (58): replaces ComplianceNotMet for expired KYC checks
- Add AttestorRevoked (59): check_attestor distinguishes revoked from never-registered addresses
- Add QuoteExpired (60): accept_quote_with_compliance emits event then panics with QuoteExpired instead of StaleQuote
- Add SignatureVerificationFailed (61): replaces UnauthorizedAttestor for bad signature length/value in verify_attestation_signature
- Add BatchSizeExceeded (62): replaces ValidationError in batch guard, carries limit= and given= context
- Named constructors and default_message for all five new variants

## Rich on-chain events (#578)
- contract.init: emitted by initialize with admin and timestamp
- attestor.added: enriched from () to AttestorRegisteredEvent on both register_attestor and register_attestor_with_session
- attestor.removed: enriched from () to AttestorRevokedEvent on both revoke paths; includes revoked_by address
- attestor.restored: AttestorReactivatedEvent with reactivated_by
- services.config: anchor added to topic, payload changed to ServicesConfiguredEvent with service_count and capability_version
- webhook.reg: dedicated WebhookRegisteredEvent replaces reused EndpointUpdated struct
- ratelimit.hit: RateLimitHitEvent emitted before RateLimitExceeded
- quote.expired: QuoteExpiredEvent emitted before QuoteExpired panic
- Tests: tests/error_and_event_tests.rs (22 tests)