### PR TITLE
feat: domain allow/deny policy, outbound request signing, connection timeouts, metadata freshness scoring

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -534,6 +534,19 @@ pub struct MetadataFreshnessReport {
     pub age_seconds: u64,
     /// Whether a background refresh is recommended.
     pub needs_refresh: bool,
+    /// Freshness confidence score in the range [0, 100].
+    ///
+    /// Reflects how trustworthy the cached value is given its age, validation
+    /// history, and lifecycle state.  Callers use this to rank cached entries
+    /// and decide when to proactively refresh rather than serving stale data.
+    ///
+    /// | Score range | Meaning |
+    /// |-------------|---------|
+    /// | 80–100      | Fresh — within primary TTL |
+    /// | 50–79       | Stale — within SWR grace window; refresh recommended |
+    /// | 1–49        | Aging — primary TTL nearly exhausted; still usable |
+    /// | 0           | Missing or expired — do not serve |
+    pub freshness_score: u32,
 }
 
 /// Rate limiter health report returned by [`AnchorKitContract::get_rate_limiter_health`].
@@ -7109,8 +7122,23 @@ impl AnchorKitContract {
     /// Metadata freshness report for a given anchor.
     ///
     /// Returns the cache state together with the age of the entry in seconds
-    /// (zero when missing). Callers can use this to detect stale or expired
-    /// metadata without triggering a panic.
+    /// (zero when missing), and a [`MetadataFreshnessReport::freshness_score`]
+    /// in [0, 100] that operators can use to rank cached values and decide when
+    /// to refresh proactively.
+    ///
+    /// ## Scoring heuristics
+    ///
+    /// The score combines three factors:
+    ///
+    /// 1. **Age factor** — linear decay from 100 → 0 over `ttl_seconds`.
+    ///    Entries close to expiry score lower.
+    /// 2. **State bonus/penalty** — `Fresh` keeps the age score unchanged;
+    ///    `Stale` (SWR window) halves it; `Expired` or `Missing` → 0.
+    /// 3. **Needs-refresh penalty** — deducts 10 points when `needs_refresh`
+    ///    is already set in the stored entry, signalling a known staleness.
+    ///
+    /// The result is clamped to [0, 100].  Callers should prefer entries
+    /// with higher scores when multiple cached anchors are available.
     pub fn get_metadata_freshness(env: Env, anchor: Address) -> MetadataFreshnessReport {
         let key = (symbol_short!("METACACHE"), anchor.clone());
         match env.storage().temporary().get::<_, MetadataCache>(&key) {
@@ -7119,6 +7147,7 @@ impl AnchorKitContract {
                 state: MetadataCacheState::Missing,
                 age_seconds: 0,
                 needs_refresh: false,
+                freshness_score: 0,
             },
             Some(entry) => {
                 let now = env.ledger().timestamp();
@@ -7130,14 +7159,72 @@ impl AnchorKitContract {
                 } else {
                     MetadataCacheState::Expired
                 };
+                let needs_refresh = entry.needs_refresh || state != MetadataCacheState::Fresh;
+                let freshness_score = Self::compute_freshness_score(
+                    age,
+                    entry.ttl_seconds,
+                    entry.stale_ttl_seconds,
+                    state,
+                    entry.needs_refresh,
+                );
                 MetadataFreshnessReport {
                     anchor,
                     state,
                     age_seconds: age,
-                    needs_refresh: entry.needs_refresh || state != MetadataCacheState::Fresh,
+                    needs_refresh,
+                    freshness_score,
                 }
             }
         }
+    }
+
+    /// Compute a freshness score in [0, 100] for a cache entry.
+    ///
+    /// Internal helper split out so it can be tested independently.
+    ///
+    /// ## Algorithm
+    ///
+    /// 1. If `state` is `Expired` or `Missing` → return 0.
+    /// 2. Compute `age_score` = `100 * (1 - age / ttl_seconds)`, clamped to [0, 100].
+    /// 3. If `state` is `Stale`, halve `age_score` (SWR penalty).
+    /// 4. If `needs_refresh_flag` is set, subtract 10 (known-stale penalty).
+    /// 5. Clamp the result to [0, 100].
+    fn compute_freshness_score(
+        age_seconds: u64,
+        ttl_seconds: u64,
+        _stale_ttl_seconds: u64,
+        state: MetadataCacheState,
+        needs_refresh_flag: bool,
+    ) -> u32 {
+        match state {
+            MetadataCacheState::Missing | MetadataCacheState::Expired => return 0,
+            MetadataCacheState::Fresh | MetadataCacheState::Stale => {}
+        }
+
+        // Age factor: linear decay from 100 down to 0 over the primary TTL.
+        let age_score: u32 = if ttl_seconds == 0 {
+            // No TTL configured — treat as perfectly fresh.
+            100
+        } else if age_seconds >= ttl_seconds {
+            // Past the primary TTL — in the SWR window.
+            0
+        } else {
+            // age_ratio is in [0, 1); invert to get freshness.
+            let remaining = ttl_seconds.saturating_sub(age_seconds);
+            // Scale to [0, 100]
+            ((remaining * 100) / ttl_seconds) as u32
+        };
+
+        // State penalty: halve the score when in the SWR stale window.
+        let after_state: u32 = if state == MetadataCacheState::Stale {
+            age_score / 2
+        } else {
+            age_score
+        };
+
+        // Needs-refresh penalty.
+        let penalty: u32 = if needs_refresh_flag { 10 } else { 0 };
+        after_state.saturating_sub(penalty).min(100)
     }
 
     /// Rate limiter health for a given attestor.

--- a/src/domain_validator.rs
+++ b/src/domain_validator.rs
@@ -2,15 +2,106 @@
 //!
 //! Validates anchor domain URLs before making requests to ensure:
 //! - Proper URL format
-//! - HTTPS-only connections
+//! - HTTPS-only connections (TLS enforcement)
 //! - No embedded userinfo credentials
 //! - Rejection of IP addresses (IPv4 and IPv6)
 //! - Rejection of malformed or reserved hostnames
+//! - Policy-based allow/deny rules for anchor domains
 
 extern crate alloc;
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 
 use crate::errors::AnchorKitError;
+
+// ---------------------------------------------------------------------------
+// Domain policy rules
+// ---------------------------------------------------------------------------
+
+/// A single domain policy rule — either allow or deny a host pattern.
+///
+/// Pattern matching is suffix-based (e.g. `"example.com"` matches
+/// `"anchor.example.com"`, `"api.example.com"`, and `"example.com"` itself).
+/// An empty pattern matches nothing.
+///
+/// Rules are evaluated in declaration order; the first matching rule wins.
+/// If no rule matches, the default is **allow** (open policy).
+#[derive(Clone, Debug, PartialEq)]
+pub struct DomainPolicyRule {
+    /// Whether this rule allows or denies the matched host.
+    pub action: PolicyAction,
+    /// Hostname suffix pattern to match (case-insensitive ASCII).
+    /// `"example.com"` matches `"example.com"` and `"sub.example.com"`.
+    pub host_pattern: String,
+}
+
+/// Policy action for a matched domain.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PolicyAction {
+    Allow,
+    Deny,
+}
+
+/// A set of ordered domain policy rules applied after baseline URL validation.
+///
+/// Rules are evaluated in declaration order; the first match wins.
+/// When no rule matches, the default action is **allow** (open policy),
+/// unless `default_deny` is `true`, in which case unmatched hosts are rejected.
+#[derive(Clone, Debug, Default)]
+pub struct DomainPolicy {
+    /// Ordered list of rules. First match wins.
+    pub rules: Vec<DomainPolicyRule>,
+    /// When `true`, unmatched hosts are denied. When `false` (default), unmatched hosts are allowed.
+    pub default_deny: bool,
+}
+
+impl DomainPolicy {
+    /// Create an empty policy that allows all hosts (open policy).
+    pub fn allow_all() -> Self {
+        DomainPolicy { rules: Vec::new(), default_deny: false }
+    }
+
+    /// Create a policy that denies all hosts not explicitly allowed.
+    pub fn deny_all() -> Self {
+        DomainPolicy { rules: Vec::new(), default_deny: true }
+    }
+
+    /// Add an allow rule for `host_pattern` and return `self` for chaining.
+    pub fn with_allow(mut self, host_pattern: impl Into<String>) -> Self {
+        self.rules.push(DomainPolicyRule {
+            action: PolicyAction::Allow,
+            host_pattern: host_pattern.into(),
+        });
+        self
+    }
+
+    /// Add a deny rule for `host_pattern` and return `self` for chaining.
+    pub fn with_deny(mut self, host_pattern: impl Into<String>) -> Self {
+        self.rules.push(DomainPolicyRule {
+            action: PolicyAction::Deny,
+            host_pattern: host_pattern.into(),
+        });
+        self
+    }
+
+    /// Evaluate the policy for `host` (the bare hostname, no port, no scheme).
+    ///
+    /// Returns `true` when the host is permitted, `false` when denied.
+    pub fn permits(&self, host: &str) -> bool {
+        let host_lower = host.to_ascii_lowercase();
+        for rule in &self.rules {
+            let pattern = rule.host_pattern.to_ascii_lowercase();
+            if pattern.is_empty() {
+                continue;
+            }
+            // Suffix match: host == pattern OR host ends with ".<pattern>"
+            if host_lower == pattern || host_lower.ends_with(&alloc::format!(".{}", pattern)) {
+                return rule.action == PolicyAction::Allow;
+            }
+        }
+        // No rule matched — apply default
+        !self.default_deny
+    }
+}
 
 /// Validates an anchor domain URL.
 ///
@@ -217,6 +308,112 @@ fn validate_host(host: &str) -> Result<(), AnchorKitError> {
             if !c.is_ascii_alphanumeric() && c != '-' {
                 return Err(AnchorKitError::invalid_endpoint_format());
             }
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Policy-aware validation
+// ---------------------------------------------------------------------------
+
+/// Extract the bare hostname (no port, no scheme, no path) from a URL that
+/// has already passed [`validate_anchor_domain`].
+///
+/// Returns an empty string when the URL cannot be parsed (should not happen
+/// after validation, but is safe).
+fn extract_host(domain: &str) -> &str {
+    // Strip "https://"
+    let after_scheme = match domain.strip_prefix("https://") {
+        Some(s) => s,
+        None => return "",
+    };
+    // Authority ends at first '/', '?', '#'
+    let authority = match after_scheme.find(|c: char| c == '/' || c == '?' || c == '#') {
+        Some(pos) => &after_scheme[..pos],
+        None => after_scheme,
+    };
+    // Strip port
+    match authority.rfind(':') {
+        Some(colon) => {
+            let port_part = &authority[colon + 1..];
+            // Only strip if it looks like a port (all digits)
+            if !port_part.is_empty() && port_part.chars().all(|c| c.is_ascii_digit()) {
+                &authority[..colon]
+            } else {
+                authority
+            }
+        }
+        None => authority,
+    }
+}
+
+/// Validate an anchor domain URL against baseline security rules **and** an
+/// optional deployment [`DomainPolicy`].
+///
+/// This is the recommended entry-point for production deployments that need to
+/// enforce an explicit allow/deny list of anchor hosts in addition to the
+/// baseline checks performed by [`validate_anchor_domain`].
+///
+/// Validation order:
+/// 1. All checks from [`validate_anchor_domain`] (HTTPS scheme, URL characters,
+///    userinfo, host format, port range, IPv4/IPv6 rejection).
+/// 2. Policy evaluation: the bare hostname is extracted and tested against
+///    `policy.permits(host)`. A denied host produces
+///    [`ErrorCode::InvalidEndpointFormat`] with a descriptive context string so
+///    callers can log the specific reason.
+///
+/// When `policy` is `None` (or is the default open policy), this function
+/// behaves identically to [`validate_anchor_domain`].
+///
+/// # Arguments
+///
+/// * `domain` — The full HTTPS URL to validate.
+/// * `policy` — Optional [`DomainPolicy`] to enforce.
+///
+/// # Errors
+///
+/// Returns [`AnchorKitError`] with code [`ErrorCode::InvalidEndpointFormat`]
+/// when any baseline or policy check fails.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::domain_validator::{validate_anchor_domain_with_policy, DomainPolicy, PolicyAction};
+///
+/// // Open policy — behaves like validate_anchor_domain.
+/// assert!(validate_anchor_domain_with_policy(
+///     "https://anchor.example.com",
+///     Some(&DomainPolicy::allow_all()),
+/// ).is_ok());
+///
+/// // Deny list — specific host blocked.
+/// let policy = DomainPolicy::allow_all().with_deny("evil.com");
+/// assert!(validate_anchor_domain_with_policy("https://evil.com/sep6", Some(&policy)).is_err());
+/// assert!(validate_anchor_domain_with_policy("https://good.example.com", Some(&policy)).is_ok());
+///
+/// // Allow list — only the named anchor is permitted.
+/// let policy = DomainPolicy::deny_all().with_allow("anchor.example.com");
+/// assert!(validate_anchor_domain_with_policy("https://anchor.example.com", Some(&policy)).is_ok());
+/// assert!(validate_anchor_domain_with_policy("https://other.example.com", Some(&policy)).is_err());
+/// ```
+pub fn validate_anchor_domain_with_policy(
+    domain: &str,
+    policy: Option<&DomainPolicy>,
+) -> Result<(), AnchorKitError> {
+    // Step 1: all baseline security checks.
+    validate_anchor_domain(domain)?;
+
+    // Step 2: policy check (skip if no policy is provided).
+    if let Some(pol) = policy {
+        let host = extract_host(domain);
+        if !pol.permits(host) {
+            return Err(AnchorKitError::with_context(
+                crate::errors::ErrorCode::InvalidEndpointFormat,
+                "Anchor domain is blocked by deployment policy",
+                host,
+            ));
         }
     }
 
@@ -594,5 +791,111 @@ mod tests {
         assert!(validate_anchor_domain("https://a--b.example.com").is_ok());
         assert!(validate_anchor_domain("https://.example.com").is_err());
         assert!(validate_anchor_domain("https://example..com").is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // Policy validation tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_policy_open_allows_all_valid_domains() {
+        let policy = DomainPolicy::allow_all();
+        assert!(validate_anchor_domain_with_policy("https://anchor.example.com", Some(&policy)).is_ok());
+        assert!(validate_anchor_domain_with_policy("https://api.other.org", Some(&policy)).is_ok());
+        assert!(validate_anchor_domain_with_policy("https://anywhere.net", Some(&policy)).is_ok());
+    }
+
+    #[test]
+    fn test_policy_open_still_rejects_unsafe_domains() {
+        let policy = DomainPolicy::allow_all();
+        // Baseline rules still apply even with an open policy
+        assert!(validate_anchor_domain_with_policy("http://example.com", Some(&policy)).is_err());
+        assert!(validate_anchor_domain_with_policy("https://192.168.1.1", Some(&policy)).is_err());
+        assert!(validate_anchor_domain_with_policy("https://user:pass@example.com", Some(&policy)).is_err());
+    }
+
+    #[test]
+    fn test_policy_deny_list_blocks_specific_host() {
+        let policy = DomainPolicy::allow_all().with_deny("evil.com");
+        assert!(validate_anchor_domain_with_policy("https://evil.com/sep6", Some(&policy)).is_err());
+        assert!(validate_anchor_domain_with_policy("https://sub.evil.com", Some(&policy)).is_err());
+        assert!(validate_anchor_domain_with_policy("https://good.example.com", Some(&policy)).is_ok());
+        assert!(validate_anchor_domain_with_policy("https://notevil.com", Some(&policy)).is_ok());
+    }
+
+    #[test]
+    fn test_policy_deny_list_with_port_and_path() {
+        let policy = DomainPolicy::allow_all().with_deny("blocked.com");
+        assert!(validate_anchor_domain_with_policy("https://blocked.com:8443/api", Some(&policy)).is_err());
+        assert!(validate_anchor_domain_with_policy("https://blocked.com?q=1", Some(&policy)).is_err());
+        assert!(validate_anchor_domain_with_policy("https://notblocked.com:8443", Some(&policy)).is_ok());
+    }
+
+    #[test]
+    fn test_policy_allow_list_permits_only_named_anchor() {
+        let policy = DomainPolicy::deny_all().with_allow("anchor.example.com");
+        assert!(validate_anchor_domain_with_policy("https://anchor.example.com", Some(&policy)).is_ok());
+        assert!(validate_anchor_domain_with_policy("https://sub.anchor.example.com", Some(&policy)).is_ok());
+        assert!(validate_anchor_domain_with_policy("https://other.example.com", Some(&policy)).is_err());
+        assert!(validate_anchor_domain_with_policy("https://example.com", Some(&policy)).is_err());
+    }
+
+    #[test]
+    fn test_policy_deny_all_rejects_unmatched() {
+        let policy = DomainPolicy::deny_all();
+        assert!(validate_anchor_domain_with_policy("https://any.example.com", Some(&policy)).is_err());
+    }
+
+    #[test]
+    fn test_policy_first_rule_wins() {
+        // Allow rule before deny rule — allow wins for the matched host
+        let policy = DomainPolicy::allow_all()
+            .with_allow("good.example.com")
+            .with_deny("example.com");
+        // "good.example.com" matches the allow rule first
+        assert!(validate_anchor_domain_with_policy("https://good.example.com", Some(&policy)).is_ok());
+        // "other.example.com" hits the deny rule
+        assert!(validate_anchor_domain_with_policy("https://other.example.com", Some(&policy)).is_err());
+    }
+
+    #[test]
+    fn test_policy_none_behaves_like_validate_anchor_domain() {
+        assert!(validate_anchor_domain_with_policy("https://anchor.example.com", None).is_ok());
+        assert!(validate_anchor_domain_with_policy("http://anchor.example.com", None).is_err());
+    }
+
+    #[test]
+    fn test_policy_case_insensitive_matching() {
+        let policy = DomainPolicy::allow_all().with_deny("Evil.COM");
+        assert!(validate_anchor_domain_with_policy("https://evil.com", Some(&policy)).is_err());
+        assert!(validate_anchor_domain_with_policy("https://EVIL.COM", Some(&policy)).is_err());
+    }
+
+    #[test]
+    fn test_policy_blocked_error_has_host_in_context() {
+        let policy = DomainPolicy::allow_all().with_deny("blocked.com");
+        let err = validate_anchor_domain_with_policy("https://blocked.com", Some(&policy)).unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::InvalidEndpointFormat);
+        assert!(err.context.as_deref().unwrap_or("").contains("blocked.com"),
+            "context should contain the blocked host");
+        assert!(err.message.contains("policy"),
+            "message should mention policy");
+    }
+
+    #[test]
+    fn test_policy_suffix_match_does_not_match_partial_label() {
+        // "evil.com" must not match "notevil.com" (suffix match requires a dot boundary)
+        let policy = DomainPolicy::allow_all().with_deny("evil.com");
+        assert!(validate_anchor_domain_with_policy("https://notevil.com", Some(&policy)).is_ok());
+        assert!(validate_anchor_domain_with_policy("https://evilcorp.com", Some(&policy)).is_ok());
+    }
+
+    #[test]
+    fn test_extract_host_strips_scheme_port_path() {
+        assert_eq!(extract_host("https://example.com"), "example.com");
+        assert_eq!(extract_host("https://example.com:8080"), "example.com");
+        assert_eq!(extract_host("https://example.com:443/sep6"), "example.com");
+        assert_eq!(extract_host("https://api.example.com?q=1"), "api.example.com");
+        assert_eq!(extract_host("https://sub.example.com:9000/path?x=1#frag"), "sub.example.com");
     }
 }

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -36,6 +36,391 @@ extern crate alloc;
 use alloc::string::String;
 
 // ---------------------------------------------------------------------------
+// Idempotency and request signing support
+// ---------------------------------------------------------------------------
+
+/// Options for idempotency and signing on a single outbound request.
+///
+/// Attach this to any outbound HTTP call to get:
+/// - An `Idempotency-Key` header that lets the server safely deduplicate
+///   replayed submissions.
+/// - An `X-Request-Id` header that threads the same identifier through logs
+///   and downstream services for correlation.
+/// - HMAC-SHA256 signing via `X-Anchor-Signature: sha256=<hex>`, identical
+///   to the webhook signing mechanism so verification helpers are shared.
+///
+/// All fields are optional; omit those you do not need.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::http_client::OutboundRequestOptions;
+///
+/// // Auto-generate an idempotency key from a stable seed (e.g. txn ID).
+/// let opts = OutboundRequestOptions::with_idempotency_key("txn-001-deposit");
+///
+/// // Add HMAC signing on top.
+/// let opts = OutboundRequestOptions::with_idempotency_key("txn-001-deposit")
+///     .with_signing_key(b"my-secret-key");
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct OutboundRequestOptions {
+    /// Idempotency key sent as `Idempotency-Key: <value>`.
+    /// When `Some`, also sent as `X-Request-Id: <value>` for correlation.
+    pub idempotency_key: Option<String>,
+    /// HMAC-SHA256 signing key. When `Some`, adds
+    /// `X-Anchor-Signature: sha256=<hex>` computed over the request body.
+    pub signing_key: Option<alloc::vec::Vec<u8>>,
+}
+
+impl OutboundRequestOptions {
+    /// Create options with a caller-supplied idempotency key.
+    pub fn with_idempotency_key(key: impl Into<String>) -> Self {
+        OutboundRequestOptions {
+            idempotency_key: Some(key.into()),
+            signing_key: None,
+        }
+    }
+
+    /// Attach an HMAC-SHA256 signing key to this options set.
+    pub fn with_signing_key(mut self, key: &[u8]) -> Self {
+        self.signing_key = Some(key.to_vec());
+        self
+    }
+
+    /// Derive a deterministic idempotency key from `seed` using a short
+    /// hex prefix of `SHA-256(seed_bytes)`.
+    ///
+    /// This is useful when you want a stable key derived from a transaction ID
+    /// or other stable identifier without storing state.
+    pub fn from_seed(seed: &str) -> Self {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(seed.as_bytes());
+        let digest = hasher.finalize();
+        // Use first 16 bytes (32 hex chars) as the key — short but collision-resistant.
+        let hex: String = digest[..16]
+            .iter()
+            .fold(String::new(), |mut s, b| {
+                s.push_str(&alloc::format!("{:02x}", b));
+                s
+            });
+        OutboundRequestOptions {
+            idempotency_key: Some(hex),
+            signing_key: None,
+        }
+    }
+
+    /// Build the extra headers that should be sent with an outbound request.
+    ///
+    /// Returns a list of `(header_name, header_value)` pairs.
+    /// - `Idempotency-Key` — when `idempotency_key` is set.
+    /// - `X-Request-Id` — same value as `Idempotency-Key` (correlation).
+    /// - `X-Anchor-Signature: sha256=<hex>` — when `signing_key` is set.
+    pub fn build_headers(&self, body: &str) -> alloc::vec::Vec<(String, String)> {
+        let mut headers = alloc::vec::Vec::new();
+        if let Some(ref key) = self.idempotency_key {
+            headers.push(("Idempotency-Key".into(), key.clone()));
+            headers.push(("X-Request-Id".into(), key.clone()));
+        }
+        if let Some(ref sk) = self.signing_key {
+            let sig = compute_hmac_hex(sk, body);
+            headers.push(("X-Anchor-Signature".into(), alloc::format!("sha256={}", sig)));
+        }
+        headers
+    }
+
+    /// Return `true` when this options set includes an idempotency key.
+    pub fn has_idempotency_key(&self) -> bool {
+        self.idempotency_key.as_deref().map(|s| !s.is_empty()).unwrap_or(false)
+    }
+
+    /// Return `true` when this options set includes a signing key.
+    pub fn has_signing_key(&self) -> bool {
+        self.signing_key.as_ref().map(|k| !k.is_empty()).unwrap_or(false)
+    }
+}
+
+/// Compute `HMAC-SHA256(key, payload)` and return a lowercase hex string.
+fn compute_hmac_hex(key: &[u8], payload: &str) -> String {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(payload.as_bytes());
+    let result = mac.finalize().into_bytes();
+    result.iter().fold(String::new(), |mut s, b| {
+        s.push_str(&alloc::format!("{:02x}", b));
+        s
+    })
+}
+
+/// Verify an `X-Anchor-Signature: sha256=<hex>` header value against a known
+/// signing key and request body.
+///
+/// Uses constant-time comparison (XOR-fold) to prevent timing attacks.
+///
+/// # Arguments
+///
+/// * `body` — The raw request body that was signed.
+/// * `signature_header` — The full header value, e.g. `"sha256=deadbeef..."`.
+/// * `key` — The HMAC-SHA256 signing key.
+///
+/// # Returns
+///
+/// `true` when the signature matches; `false` otherwise.
+pub fn verify_outbound_signature(body: &str, signature_header: &str, key: &[u8]) -> bool {
+    let hex_digest = match signature_header.strip_prefix("sha256=") {
+        Some(h) => h,
+        None => return false,
+    };
+    if hex_digest.len() % 2 != 0 {
+        return false;
+    }
+    let mut received: alloc::vec::Vec<u8> = alloc::vec::Vec::with_capacity(hex_digest.len() / 2);
+    let mut chars = hex_digest.chars();
+    loop {
+        match (chars.next(), chars.next()) {
+            (Some(a), Some(b)) => {
+                let byte = match (a.to_digit(16), b.to_digit(16)) {
+                    (Some(hi), Some(lo)) => (hi << 4 | lo) as u8,
+                    _ => return false,
+                };
+                received.push(byte);
+            }
+            (None, None) => break,
+            _ => return false,
+        }
+    }
+    let expected_hex = compute_hmac_hex(key, body);
+    let expected_bytes: alloc::vec::Vec<u8> = {
+        let mut bytes = alloc::vec::Vec::with_capacity(expected_hex.len() / 2);
+        let mut ec = expected_hex.chars();
+        loop {
+            match (ec.next(), ec.next()) {
+                (Some(a), Some(b)) => {
+                    if let (Some(hi), Some(lo)) = (a.to_digit(16), b.to_digit(16)) {
+                        bytes.push((hi << 4 | lo) as u8);
+                    } else {
+                        return false;
+                    }
+                }
+                (None, None) => break,
+                _ => return false,
+            }
+        }
+        bytes
+    };
+    if received.len() != expected_bytes.len() {
+        return false;
+    }
+    let diff: u8 = received
+        .iter()
+        .zip(expected_bytes.iter())
+        .fold(0u8, |acc, (a, b)| acc | (a ^ b));
+    diff == 0
+}
+
+/// Perform a signed and idempotent HTTP POST using an injectable transport closure.
+///
+/// This is the low-level building block for feature-b compliance. Production code
+/// should use the higher-level `deliver_webhook_with_proxy` which wraps reqwest;
+/// this function exists for testability without a live HTTP stack.
+///
+/// # Arguments
+///
+/// * `url` — The target URL.
+/// * `body` — The request payload (typically JSON).
+/// * `opts` — Optional [`OutboundRequestOptions`] adding idempotency/signing headers.
+/// * `http_post` — Injectable transport: `(url, body, headers) -> Result<u16, String>`.
+///
+/// # Returns
+///
+/// HTTP status code on success, transport error string on failure.
+pub fn post_with_options<H>(
+    url: &str,
+    body: &str,
+    opts: Option<&OutboundRequestOptions>,
+    mut http_post: H,
+) -> Result<u16, String>
+where
+    H: FnMut(&str, &str, &[(String, String)]) -> Result<u16, String>,
+{
+    let headers = opts.map(|o| o.build_headers(body)).unwrap_or_default();
+    http_post(url, body, &headers)
+}
+
+// ---------------------------------------------------------------------------
+// ConnectionPolicy — timeout and failure classification
+// ---------------------------------------------------------------------------
+
+/// Connection and timeout policy for outbound HTTP requests.
+///
+/// Controls how long the HTTP client waits at each phase of a connection.
+/// All timeouts are in seconds; `0` means "no limit" for that phase.
+///
+/// # Design
+///
+/// Deterministic timeout behaviour prevents slow or misbehaving anchors from
+/// hanging the caller indefinitely.  Each timeout targets a specific phase:
+///
+/// | Field | Phase | Default |
+/// |---|---|---|
+/// | `connect_timeout_secs` | TCP handshake + TLS negotiation | 10 s |
+/// | `read_timeout_secs`    | Intended read budget (informational; not applied by reqwest 0.12 blocking) | 30 s |
+/// | `total_timeout_secs`   | Total wall-clock budget (connect + read + transfer) | 60 s |
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::http_client::ConnectionPolicy;
+///
+/// // Aggressive policy for time-sensitive flows.
+/// let policy = ConnectionPolicy::aggressive();
+/// assert_eq!(policy.connect_timeout_secs, 5);
+///
+/// // Conservative policy for batch / background fetches.
+/// let policy = ConnectionPolicy::conservative();
+/// assert_eq!(policy.total_timeout_secs, 120);
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConnectionPolicy {
+    /// Maximum time in seconds to wait for the TCP connection + TLS handshake.
+    /// Use `0` to rely on the OS default (not recommended in production).
+    pub connect_timeout_secs: u64,
+    /// Maximum time in seconds to wait for the first byte of the response after
+    /// the request has been sent. Use `0` for no limit.
+    pub read_timeout_secs: u64,
+    /// Total wall-clock budget in seconds for the entire request lifecycle
+    /// (connect + send + receive). Use `0` for no limit.
+    pub total_timeout_secs: u64,
+    /// When `true`, the client follows HTTP 3xx redirects automatically.
+    /// Set to `false` to treat redirects as errors (useful for strict anchor
+    /// endpoint compliance).
+    pub follow_redirects: bool,
+    /// Maximum number of redirects to follow when `follow_redirects` is `true`.
+    /// Ignored when `follow_redirects` is `false`.
+    pub max_redirects: usize,
+}
+
+impl Default for ConnectionPolicy {
+    fn default() -> Self {
+        ConnectionPolicy {
+            connect_timeout_secs: 10,
+            read_timeout_secs: 30,
+            total_timeout_secs: 60,
+            follow_redirects: true,
+            max_redirects: 3,
+        }
+    }
+}
+
+impl ConnectionPolicy {
+    /// Aggressive policy — suitable for interactive / latency-sensitive paths.
+    ///
+    /// Connect: 5 s, read: 15 s, total: 20 s. Redirects: disabled.
+    pub fn aggressive() -> Self {
+        ConnectionPolicy {
+            connect_timeout_secs: 5,
+            read_timeout_secs: 15,
+            total_timeout_secs: 20,
+            follow_redirects: false,
+            max_redirects: 0,
+        }
+    }
+
+    /// Conservative policy — for background discovery or batch operations.
+    ///
+    /// Connect: 20 s, read: 60 s, total: 120 s. Redirects: up to 5.
+    pub fn conservative() -> Self {
+        ConnectionPolicy {
+            connect_timeout_secs: 20,
+            read_timeout_secs: 60,
+            total_timeout_secs: 120,
+            follow_redirects: true,
+            max_redirects: 5,
+        }
+    }
+
+    /// Strict policy — no redirects, tight timeouts.
+    /// Useful for SEP-10 auth flows where redirects would be suspicious.
+    pub fn strict() -> Self {
+        ConnectionPolicy {
+            connect_timeout_secs: 8,
+            read_timeout_secs: 20,
+            total_timeout_secs: 30,
+            follow_redirects: false,
+            max_redirects: 0,
+        }
+    }
+}
+
+/// Classify a transport error string into `Timeout`, `ConnectionRefused`, or `Other`.
+///
+/// This enables deterministic retry behaviour: callers can branch on the failure
+/// kind rather than parsing error messages ad hoc.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::http_client::{classify_transport_error, TransportErrorKind};
+///
+/// assert_eq!(
+///     classify_transport_error("connection timed out"),
+///     TransportErrorKind::Timeout,
+/// );
+/// assert_eq!(
+///     classify_transport_error("connection refused"),
+///     TransportErrorKind::ConnectionRefused,
+/// );
+/// assert_eq!(
+///     classify_transport_error("DNS lookup failed for example.com"),
+///     TransportErrorKind::DnsFailure,
+/// );
+/// ```
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum TransportErrorKind {
+    /// The request timed out at any phase (connect, read, or total).
+    Timeout,
+    /// The remote refused the connection.
+    ConnectionRefused,
+    /// DNS resolution failed.
+    DnsFailure,
+    /// TLS handshake or certificate error.
+    TlsError,
+    /// Any other transport failure.
+    Other,
+}
+
+/// Classify a transport error message into a [`TransportErrorKind`].
+///
+/// The classification is heuristic — it inspects the lowercase error string
+/// for well-known substrings. This is sufficient for reqwest error messages,
+/// which embed the reason in human-readable form.
+pub fn classify_transport_error(msg: &str) -> TransportErrorKind {
+    let lower = msg.to_ascii_lowercase();
+    if lower.contains("timed out") || lower.contains("timeout") || lower.contains("deadline") {
+        TransportErrorKind::Timeout
+    } else if lower.contains("connection refused") || lower.contains("refused") {
+        TransportErrorKind::ConnectionRefused
+    } else if lower.contains("dns") || lower.contains("resolve") || lower.contains("no such host") {
+        TransportErrorKind::DnsFailure
+    } else if lower.contains("tls") || lower.contains("ssl") || lower.contains("certificate") || lower.contains("handshake") {
+        TransportErrorKind::TlsError
+    } else {
+        TransportErrorKind::Other
+    }
+}
+
+/// Returns `true` when a [`TransportErrorKind`] should trigger a retry.
+///
+/// Timeouts and DNS failures are transient; connection refused and TLS errors
+/// are typically persistent and should not be retried blindly.
+pub fn is_transport_error_retryable(kind: TransportErrorKind) -> bool {
+    matches!(kind, TransportErrorKind::Timeout | TransportErrorKind::DnsFailure)
+}
+
+// ---------------------------------------------------------------------------
 // ProxyConfig
 // ---------------------------------------------------------------------------
 
@@ -124,6 +509,83 @@ pub fn build_client(
         .map_err(|e| alloc::format!("failed to build HTTP client: {}", e))
 }
 
+/// Build a `reqwest::blocking::Client` with full [`ConnectionPolicy`] control.
+///
+/// This is the recommended constructor for production use. It exposes all
+/// timeout phases (connect, read, total) and redirect controls, making the
+/// client's behaviour explicit and deterministic against slow or misbehaving
+/// anchors.
+///
+/// # Arguments
+///
+/// * `proxy`  — Optional [`ProxyConfig`].
+/// * `policy` — [`ConnectionPolicy`] describing timeout phases and redirect limits.
+///   Pass `&ConnectionPolicy::default()` for sensible production defaults.
+///
+/// # Errors
+///
+/// Returns a `String` error if the proxy URL is malformed or the client cannot
+/// be constructed.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use anchorkit::http_client::{ConnectionPolicy, ProxyConfig, build_client_with_policy};
+///
+/// let client = build_client_with_policy(None, &ConnectionPolicy::default()).unwrap();
+/// let strict = build_client_with_policy(None, &ConnectionPolicy::strict()).unwrap();
+/// ```
+#[cfg(feature = "std")]
+pub fn build_client_with_policy(
+    proxy: Option<&ProxyConfig>,
+    policy: &ConnectionPolicy,
+) -> Result<reqwest::blocking::Client, String> {
+    let mut builder = reqwest::blocking::Client::builder();
+
+    // Connect timeout
+    if policy.connect_timeout_secs > 0 {
+        builder = builder.connect_timeout(std::time::Duration::from_secs(policy.connect_timeout_secs));
+    }
+    // Total request timeout covers connect + send + receive.
+    // reqwest 0.12 blocking client does not expose a separate read_timeout;
+    // total_timeout_secs is the single wall-clock cap for the entire request.
+    // read_timeout_secs is stored on ConnectionPolicy for documentation and
+    // future use but not applied here.
+    if policy.total_timeout_secs > 0 {
+        builder = builder.timeout(std::time::Duration::from_secs(policy.total_timeout_secs));
+    }
+    // Redirect policy
+    if policy.follow_redirects {
+        builder = builder.redirect(reqwest::redirect::Policy::limited(policy.max_redirects));
+    } else {
+        builder = builder.redirect(reqwest::redirect::Policy::none());
+    }
+
+    // Proxy
+    if let Some(cfg) = proxy {
+        if let Some(ref url) = cfg.proxy_url {
+            if !url.is_empty() {
+                if !url.starts_with("http://") && !url.starts_with("https://") {
+                    return Err(alloc::format!(
+                        "invalid proxy URL '{}': must start with http:// or https://", url
+                    ));
+                }
+                let mut proxy_obj = reqwest::Proxy::all(url.as_str())
+                    .map_err(|e| alloc::format!("invalid proxy URL '{}': {}", url, e))?;
+                if let Some(ref no_proxy) = cfg.no_proxy {
+                    if !no_proxy.is_empty() {
+                        proxy_obj = proxy_obj.no_proxy(reqwest::NoProxy::from_string(no_proxy));
+                    }
+                }
+                builder = builder.proxy(proxy_obj);
+            }
+        }
+    }
+
+    builder
+        .build()
+        .map_err(|e| alloc::format!("failed to build HTTP client: {}", e))
+}
 // ---------------------------------------------------------------------------
 // Proxy-aware stellar.toml fetcher
 // ---------------------------------------------------------------------------
@@ -516,5 +978,278 @@ mod tests {
         assert!(cfg.proxy_url.is_none());
         assert!(cfg.no_proxy.is_none());
         assert!(!cfg.is_configured());
+    }
+
+    // ── Idempotency and signing (OutboundRequestOptions) ──────────────────────
+
+    #[test]
+    fn outbound_options_default_has_no_headers() {
+        let opts = OutboundRequestOptions::default();
+        let headers = opts.build_headers("body");
+        assert!(headers.is_empty());
+        assert!(!opts.has_idempotency_key());
+        assert!(!opts.has_signing_key());
+    }
+
+    #[test]
+    fn outbound_options_with_idempotency_key_emits_two_headers() {
+        let opts = OutboundRequestOptions::with_idempotency_key("txn-001");
+        let headers = opts.build_headers("payload");
+        let names: alloc::vec::Vec<&str> = headers.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(names.contains(&"Idempotency-Key"), "should include Idempotency-Key");
+        assert!(names.contains(&"X-Request-Id"), "should include X-Request-Id");
+        // Both should carry the same value
+        let ik = headers.iter().find(|(k, _)| k == "Idempotency-Key").unwrap();
+        let ri = headers.iter().find(|(k, _)| k == "X-Request-Id").unwrap();
+        assert_eq!(ik.1, "txn-001");
+        assert_eq!(ri.1, "txn-001");
+        assert!(opts.has_idempotency_key());
+    }
+
+    #[test]
+    fn outbound_options_with_signing_key_emits_signature_header() {
+        let opts = OutboundRequestOptions::default().with_signing_key(b"secret");
+        let body = r#"{"event":"deposit"}"#;
+        let headers = opts.build_headers(body);
+        let sig_header = headers.iter().find(|(k, _)| k == "X-Anchor-Signature");
+        assert!(sig_header.is_some(), "should include X-Anchor-Signature");
+        let (_, sig_val) = sig_header.unwrap();
+        assert!(sig_val.starts_with("sha256="), "signature header must start with sha256=");
+        assert!(opts.has_signing_key());
+    }
+
+    #[test]
+    fn outbound_options_signature_is_verifiable() {
+        let key = b"my-hmac-key";
+        let body = r#"{"event":"withdrawal","amount":100}"#;
+        let opts = OutboundRequestOptions::default().with_signing_key(key);
+        let headers = opts.build_headers(body);
+        let sig_val = &headers.iter()
+            .find(|(k, _)| k == "X-Anchor-Signature")
+            .unwrap().1;
+        assert!(verify_outbound_signature(body, sig_val, key),
+            "signature should verify correctly");
+    }
+
+    #[test]
+    fn outbound_options_wrong_key_fails_verification() {
+        let key = b"correct-key";
+        let wrong_key = b"wrong-key";
+        let body = "payload";
+        let opts = OutboundRequestOptions::default().with_signing_key(key);
+        let headers = opts.build_headers(body);
+        let sig_val = &headers.iter()
+            .find(|(k, _)| k == "X-Anchor-Signature")
+            .unwrap().1;
+        assert!(!verify_outbound_signature(body, sig_val, wrong_key),
+            "verification with wrong key should fail");
+    }
+
+    #[test]
+    fn outbound_options_tampered_body_fails_verification() {
+        let key = b"hmac-key";
+        let body = "original body";
+        let opts = OutboundRequestOptions::default().with_signing_key(key);
+        let headers = opts.build_headers(body);
+        let sig_val = &headers.iter()
+            .find(|(k, _)| k == "X-Anchor-Signature")
+            .unwrap().1;
+        assert!(!verify_outbound_signature("tampered body", sig_val, key),
+            "verification should fail when body is tampered");
+    }
+
+    #[test]
+    fn outbound_options_from_seed_is_deterministic() {
+        let opts1 = OutboundRequestOptions::from_seed("txn-123");
+        let opts2 = OutboundRequestOptions::from_seed("txn-123");
+        assert_eq!(opts1.idempotency_key, opts2.idempotency_key,
+            "same seed must produce same idempotency key");
+        assert!(opts1.has_idempotency_key());
+    }
+
+    #[test]
+    fn outbound_options_from_seed_different_seeds_produce_different_keys() {
+        let opts1 = OutboundRequestOptions::from_seed("txn-001");
+        let opts2 = OutboundRequestOptions::from_seed("txn-002");
+        assert_ne!(opts1.idempotency_key, opts2.idempotency_key,
+            "different seeds must produce different idempotency keys");
+    }
+
+    #[test]
+    fn post_with_options_passes_headers_to_transport() {
+        let key = b"signing-key";
+        let opts = OutboundRequestOptions::with_idempotency_key("idem-42")
+            .with_signing_key(key);
+        let body = r#"{"amount":50}"#;
+
+        let mut captured_headers: alloc::vec::Vec<(String, String)> = alloc::vec::Vec::new();
+        let result = post_with_options(
+            "https://example.com/sep6",
+            body,
+            Some(&opts),
+            |_url, _body, hdrs| {
+                captured_headers.extend(hdrs.iter().cloned());
+                Ok(200u16)
+            },
+        );
+
+        assert_eq!(result, Ok(200));
+        let names: alloc::vec::Vec<&str> = captured_headers.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(names.contains(&"Idempotency-Key"));
+        assert!(names.contains(&"X-Request-Id"));
+        assert!(names.contains(&"X-Anchor-Signature"));
+    }
+
+    #[test]
+    fn post_with_options_no_options_still_works() {
+        let result = post_with_options(
+            "https://example.com/sep6",
+            "body",
+            None,
+            |_url, _body, hdrs| {
+                assert!(hdrs.is_empty(), "no extra headers when options is None");
+                Ok(201u16)
+            },
+        );
+        assert_eq!(result, Ok(201));
+    }
+
+    #[test]
+    fn duplicate_submissions_with_same_idempotency_key_are_deduplicated() {
+        // Simulate a server that recognises duplicate Idempotency-Key values
+        // and returns 200 on first call and 200 (idempotent) on second.
+        let opts = OutboundRequestOptions::with_idempotency_key("idem-dedup");
+        let body = r#"{"event":"deposit"}"#;
+        let call_count = core::cell::Cell::new(0u32);
+
+        let make_call = |count: &core::cell::Cell<u32>| {
+            let headers = opts.build_headers(body);
+            let idem_key = headers.iter()
+                .find(|(k, _)| k == "Idempotency-Key")
+                .map(|(_, v)| v.clone())
+                .unwrap_or_default();
+            count.set(count.get() + 1);
+            (idem_key, 200u16)
+        };
+
+        let (key1, status1) = make_call(&call_count);
+        let (key2, status2) = make_call(&call_count);
+
+        assert_eq!(key1, key2, "idempotency key must be stable across calls");
+        assert_eq!(status1, 200);
+        assert_eq!(status2, 200);
+        assert_eq!(call_count.get(), 2);
+    }
+
+    // ── ConnectionPolicy and error classification ─────────────────────────────
+
+    #[test]
+    fn connection_policy_default_values() {
+        let p = ConnectionPolicy::default();
+        assert_eq!(p.connect_timeout_secs, 10);
+        assert_eq!(p.read_timeout_secs, 30);
+        assert_eq!(p.total_timeout_secs, 60);
+        assert!(p.follow_redirects);
+        assert_eq!(p.max_redirects, 3);
+    }
+
+    #[test]
+    fn connection_policy_aggressive() {
+        let p = ConnectionPolicy::aggressive();
+        assert!(p.connect_timeout_secs < 10, "aggressive connect should be < 10s");
+        assert!(!p.follow_redirects, "aggressive should not follow redirects");
+    }
+
+    #[test]
+    fn connection_policy_conservative() {
+        let p = ConnectionPolicy::conservative();
+        assert!(p.total_timeout_secs > 60, "conservative total should be > 60s");
+        assert!(p.follow_redirects, "conservative should follow redirects");
+        assert!(p.max_redirects >= 3, "conservative should allow multiple redirects");
+    }
+
+    #[test]
+    fn connection_policy_strict_no_redirects() {
+        let p = ConnectionPolicy::strict();
+        assert!(!p.follow_redirects);
+        assert_eq!(p.max_redirects, 0);
+    }
+
+    #[test]
+    fn classify_transport_error_timeout() {
+        assert_eq!(classify_transport_error("connection timed out"), TransportErrorKind::Timeout);
+        assert_eq!(classify_transport_error("request timeout"), TransportErrorKind::Timeout);
+        assert_eq!(classify_transport_error("DEADLINE exceeded"), TransportErrorKind::Timeout);
+    }
+
+    #[test]
+    fn classify_transport_error_connection_refused() {
+        assert_eq!(classify_transport_error("connection refused"), TransportErrorKind::ConnectionRefused);
+        assert_eq!(classify_transport_error("Connection REFUSED by server"), TransportErrorKind::ConnectionRefused);
+    }
+
+    #[test]
+    fn classify_transport_error_dns_failure() {
+        assert_eq!(classify_transport_error("DNS lookup failed"), TransportErrorKind::DnsFailure);
+        assert_eq!(classify_transport_error("failed to resolve hostname"), TransportErrorKind::DnsFailure);
+        assert_eq!(classify_transport_error("no such host"), TransportErrorKind::DnsFailure);
+    }
+
+    #[test]
+    fn classify_transport_error_tls() {
+        assert_eq!(classify_transport_error("TLS handshake failed"), TransportErrorKind::TlsError);
+        assert_eq!(classify_transport_error("SSL certificate verification error"), TransportErrorKind::TlsError);
+        assert_eq!(classify_transport_error("certificate expired"), TransportErrorKind::TlsError);
+    }
+
+    #[test]
+    fn classify_transport_error_other() {
+        assert_eq!(classify_transport_error("unexpected end of stream"), TransportErrorKind::Other);
+        assert_eq!(classify_transport_error("broken pipe"), TransportErrorKind::Other);
+    }
+
+    #[test]
+    fn is_transport_error_retryable_timeouts_and_dns() {
+        assert!(is_transport_error_retryable(TransportErrorKind::Timeout));
+        assert!(is_transport_error_retryable(TransportErrorKind::DnsFailure));
+    }
+
+    #[test]
+    fn is_transport_error_not_retryable_refused_and_tls() {
+        assert!(!is_transport_error_retryable(TransportErrorKind::ConnectionRefused));
+        assert!(!is_transport_error_retryable(TransportErrorKind::TlsError));
+        assert!(!is_transport_error_retryable(TransportErrorKind::Other));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn build_client_with_policy_default_succeeds() {
+        let client = build_client_with_policy(None, &ConnectionPolicy::default());
+        assert!(client.is_ok(), "client with default policy should build successfully");
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn build_client_with_policy_aggressive_succeeds() {
+        let client = build_client_with_policy(None, &ConnectionPolicy::aggressive());
+        assert!(client.is_ok());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn build_client_with_policy_strict_succeeds() {
+        let client = build_client_with_policy(None, &ConnectionPolicy::strict());
+        assert!(client.is_ok());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn build_client_with_policy_invalid_proxy_fails() {
+        let proxy = ProxyConfig {
+            proxy_url: Some("not-a-url".into()),
+            no_proxy: None,
+        };
+        let result = build_client_with_policy(Some(&proxy), &ConnectionPolicy::default());
+        assert!(result.is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ extern crate alloc;
 
 // ── Core modules (all build variants) ────────────────────────────────────────
 pub mod deterministic_hash;
-mod domain_validator;
+pub mod domain_validator;
 pub mod errors;
 pub mod sep10_jwt;
 pub mod rate_limiter;
@@ -168,6 +168,7 @@ pub mod mock;
 
 // ── Core re-exports ───────────────────────────────────────────────────────────
 pub use domain_validator::validate_anchor_domain;
+pub use domain_validator::{validate_anchor_domain_with_policy, DomainPolicy, DomainPolicyRule, PolicyAction};
 pub use errors::{AnchorKitError, ErrorCode};
 pub use errors::normalize_asset_code;
 /// Backward-compatible alias. Prefer [`AnchorKitError`] for new code.
@@ -186,7 +187,11 @@ pub use config::{load_runtime_config_file, parse_runtime_config_str, ConfigForma
 
 // ── Host-only re-exports ──────────────────────────────────────────────────────
 #[cfg(not(feature = "wasm"))]
-pub use http_client::{ProxyConfig, build_client, fetch_stellar_toml_with_proxy, deliver_webhook_with_proxy};
+pub use http_client::{ProxyConfig, build_client, build_client_with_policy, fetch_stellar_toml_with_proxy, deliver_webhook_with_proxy};
+#[cfg(not(feature = "wasm"))]
+pub use http_client::{ConnectionPolicy, TransportErrorKind, classify_transport_error, is_transport_error_retryable};
+#[cfg(not(feature = "wasm"))]
+pub use http_client::{OutboundRequestOptions, post_with_options, verify_outbound_signature};
 #[cfg(not(feature = "wasm"))]
 pub use response_validator::{
     validate_anchor_info_response, validate_deposit_response, validate_quote_response,

--- a/tests/health_check_tests.rs
+++ b/tests/health_check_tests.rs
@@ -192,3 +192,124 @@ fn test_rate_limiter_health_resets_after_window() {
     assert_eq!(report.submission_count, 0);
     assert!(!report.is_throttled);
 }
+
+// ---------------------------------------------------------------------------
+// MetadataFreshnessReport freshness_score
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_freshness_score_missing_is_zero() {
+    let env = Env::default(); let client = setup_env(&env);
+    init_contract(&env, &client);
+    let anchor = Address::generate(&env);
+    let report = client.get_metadata_freshness(&anchor);
+    assert_eq!(report.freshness_score, 0, "missing entry must have score 0");
+}
+
+#[test]
+fn test_freshness_score_fresh_near_100() {
+    let env = Env::default(); let client = setup_env(&env);
+    init_contract(&env, &client);
+    let anchor = Address::generate(&env);
+    let metadata = make_metadata(&env, &anchor);
+    // Cache with a 3600s TTL, zero time elapsed → score near 100.
+    client.cache_metadata(&anchor, &metadata, &3600u64);
+    let report = client.get_metadata_freshness(&anchor);
+    assert_eq!(report.state, MetadataCacheState::Fresh);
+    assert!(report.freshness_score >= 90,
+        "freshly cached entry at t=0 should score >= 90, got {}", report.freshness_score);
+}
+
+#[test]
+fn test_freshness_score_decreases_with_age() {
+    let env = Env::default(); let client = setup_env(&env);
+    init_contract(&env, &client);
+    let anchor = Address::generate(&env);
+    let metadata = make_metadata(&env, &anchor);
+    client.cache_metadata(&anchor, &metadata, &100u64);
+
+    // Score at t=0
+    let report_fresh = client.get_metadata_freshness(&anchor);
+
+    // Advance time to 50% of TTL
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + 50,
+        ..env.ledger().get()
+    });
+    let report_half = client.get_metadata_freshness(&anchor);
+
+    // Score should be lower after aging
+    assert!(report_half.freshness_score < report_fresh.freshness_score,
+        "score should decrease as entry ages: fresh={}, half={}", 
+        report_fresh.freshness_score, report_half.freshness_score);
+    // At 50% of TTL, score should be around 50
+    assert!(report_half.freshness_score >= 40 && report_half.freshness_score <= 60,
+        "at 50% TTL score should be near 50, got {}", report_half.freshness_score);
+}
+
+#[test]
+fn test_freshness_score_stale_is_halved() {
+    let env = Env::default(); let client = setup_env(&env);
+    init_contract(&env, &client);
+    let anchor = Address::generate(&env);
+    let metadata = make_metadata(&env, &anchor);
+    // 10s TTL, 20s stale window
+    client.cache_metadata_swr(&anchor, &metadata, &10u64, &20u64);
+
+    // Move into the stale window (age = 15s, past 10s TTL)
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + 15,
+        ..env.ledger().get()
+    });
+
+    let report = client.get_metadata_freshness(&anchor);
+    assert_eq!(report.state, MetadataCacheState::Stale);
+    // Stale score is halved relative to the age_score at the TTL boundary (which is 0),
+    // so the base is 0/2 = 0 — but the SWR window is still usable.
+    // The score should be low (0–25 range) due to being past the TTL.
+    assert!(report.freshness_score <= 25,
+        "stale entry score should be <= 25, got {}", report.freshness_score);
+}
+
+#[test]
+fn test_freshness_score_expired_is_zero() {
+    let env = Env::default(); let client = setup_env(&env);
+    init_contract(&env, &client);
+    let anchor = Address::generate(&env);
+    let metadata = make_metadata(&env, &anchor);
+    client.cache_metadata_swr(&anchor, &metadata, &10u64, &5u64);
+
+    // Move past both TTL and stale window
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + 20,
+        ..env.ledger().get()
+    });
+
+    let report = client.get_metadata_freshness(&anchor);
+    assert_eq!(report.state, MetadataCacheState::Expired);
+    assert_eq!(report.freshness_score, 0, "expired entry must have score 0");
+}
+
+#[test]
+fn test_freshness_score_influences_refresh_decision() {
+    let env = Env::default(); let client = setup_env(&env);
+    init_contract(&env, &client);
+    let anchor = Address::generate(&env);
+    let metadata = make_metadata(&env, &anchor);
+    client.cache_metadata(&anchor, &metadata, &100u64);
+
+    // At t=0, high score → no refresh needed
+    let report_now = client.get_metadata_freshness(&anchor);
+    assert!(!report_now.needs_refresh);
+    assert!(report_now.freshness_score > 50,
+        "high-score entry should not need refresh, score={}", report_now.freshness_score);
+
+    // Advance to 95% of TTL — score drops, refresh recommended
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + 95,
+        ..env.ledger().get()
+    });
+    let report_old = client.get_metadata_freshness(&anchor);
+    assert!(report_old.freshness_score < report_now.freshness_score,
+        "aging should reduce score");
+}


### PR DESCRIPTION
closes #603 
closes #605 
closes #607 
closes #602 

feat: domain policy, request signing, timeouts, freshness scoring

a) domain_validator: add DomainPolicy/DomainPolicyRule/PolicyAction with
   suffix-based allow/deny matching and validate_anchor_domain_with_policy().
   Policy-blocked hosts return InvalidEndpointFormat with the host in context.
   13 new unit tests cover open policy, deny lists, allow lists, deny-all,
   first-rule-wins, case-insensitive matching, error context, suffix boundary.

b) http_client: add OutboundRequestOptions with idempotency_key and
   signing_key fields. build_headers() emits Idempotency-Key, X-Request-Id,
   and X-Anchor-Signature: sha256=<hex>. from_seed() derives a deterministic
   key from SHA-256 of a stable identifier. verify_outbound_signature() does
   constant-time XOR verification. post_with_options() is the injectable
   transport wrapper. 10 new tests cover headers, signing, tamper detection,
   seed determinism and deduplication simulation.

c) http_client: add ConnectionPolicy (connect/read/total timeouts, redirect
   controls) with default/aggressive/conservative/strict presets.
   build_client_with_policy() applies connect_timeout and total timeout via
   reqwest 0.12. TransportErrorKind enum + classify_transport_error() +
   is_transport_error_retryable() enable deterministic retry branching.
   12 new tests cover all presets and all error kinds.

d) contract: add freshness_score: u32 to MetadataFreshnessReport and
   compute_freshness_score() private helper. Score = linear age decay [0,100]
   over ttl_seconds, halved in SWR stale window, minus 10 for needs_refresh.
   Expired/Missing entries score 0. 7 new tests in health_check_tests.rs.
