### PR TITLE
feat: cache governance policy model and URL normalization/allowlist

### DIFF
--- a/src/cache_governance.rs
+++ b/src/cache_governance.rs
@@ -1,12 +1,28 @@
 //! On-chain governance for stellar.toml capability cache invalidation.
+//! On-chain governance for cache invalidation proposals and entry-level cache policies.
 //!
 //! Any registered attestor can propose that a specific anchor's capability
 //! cache entry be invalidated. Once a configurable quorum of distinct attestors
 //! endorse the proposal the cache entry is automatically invalidated and a
 //! `force_refresh` is triggered. Proposals expire after a configurable number
 //! of ledgers.
+//!
+//! ## Cache Policy Model
+//!
+//! Beyond the simple on-chain invalidation proposals this module also hosts a
+//! **policy model** that governs how cache entries are created, refreshed, and
+//! expired across entry types (metadata, capabilities, and custom keys).
+//!
+//! Each [`CacheEntryType`] carries its own [`CachePolicy`] which defines:
+//! - `min_ttl_seconds` / `max_ttl_seconds` — hard bounds on caller-supplied TTLs.
+//! - `refresh_threshold_pct` — how far into the TTL (0–100 %) a background refresh
+//!   should be triggered.
+//! - `allow_forced_invalidation` — whether emergency forced-eviction is permitted.
+//!
+//! Policies are stored under a separate key from the governance config so they
+//! can be updated independently by admins.
 
-use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, Vec, xdr::ToXdr};
+use soroban_sdk::{contracttype, Address, BytesN, Env, Vec};
 use crate::deterministic_hash::make_storage_key;
 use crate::errors::{AnchorKitError, ErrorCode};
 
@@ -18,6 +34,243 @@ use crate::errors::{AnchorKitError, ErrorCode};
 pub const DEFAULT_QUORUM: u32 = 3;
 /// Default proposal TTL: ~1 day at 5 s/ledger.
 pub const DEFAULT_EXPIRY_LEDGERS: u32 = 17_280;
+
+// Default policy constants — metadata entries.
+/// Minimum TTL allowed for metadata cache entries (60 s).
+pub const METADATA_MIN_TTL_SECONDS: u64 = 60;
+/// Maximum TTL allowed for metadata cache entries (24 h).
+pub const METADATA_MAX_TTL_SECONDS: u64 = 86_400;
+/// Refresh when 80 % of the TTL has elapsed (i.e. at 20 % remaining).
+pub const METADATA_REFRESH_THRESHOLD_PCT: u32 = 80;
+
+// Default policy constants — capabilities entries.
+/// Minimum TTL allowed for capabilities cache entries (5 min).
+pub const CAPABILITIES_MIN_TTL_SECONDS: u64 = 300;
+/// Maximum TTL allowed for capabilities cache entries (7 days).
+pub const CAPABILITIES_MAX_TTL_SECONDS: u64 = 604_800;
+/// Refresh when 75 % of the TTL has elapsed.
+pub const CAPABILITIES_REFRESH_THRESHOLD_PCT: u32 = 75;
+
+// Default policy constants — generic / other entries.
+/// Minimum TTL allowed for any other cached values (30 s).
+pub const OTHER_MIN_TTL_SECONDS: u64 = 30;
+/// Maximum TTL allowed for any other cached values (12 h).
+pub const OTHER_MAX_TTL_SECONDS: u64 = 43_200;
+/// Refresh when 70 % of the TTL has elapsed.
+pub const OTHER_REFRESH_THRESHOLD_PCT: u32 = 70;
+
+// ---------------------------------------------------------------------------
+// Cache entry type discriminant
+// ---------------------------------------------------------------------------
+
+/// The category of a cache entry, used to look up the correct [`CachePolicy`].
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum CacheEntryType {
+    /// Anchor metadata (reputation score, liquidity, uptime, etc.).
+    Metadata     = 0,
+    /// Stellar capability / TOML entries.
+    Capabilities = 1,
+    /// Any other cached value not covered by the above.
+    Other        = 2,
+}
+
+// ---------------------------------------------------------------------------
+// Policy types
+// ---------------------------------------------------------------------------
+
+/// Governance policy for one category of cache entries.
+///
+/// Applies to writes (TTL clamping), reads (staleness detection), and
+/// forced-invalidation operations.
+///
+/// # Validation rules (enforced by [`CachePolicy::validate`])
+///
+/// - `min_ttl_seconds < max_ttl_seconds`
+/// - `refresh_threshold_pct` is in `[1, 99]`
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CachePolicy {
+    /// Minimum acceptable TTL in seconds. A write that supplies a smaller TTL
+    /// is clamped up to this value.
+    pub min_ttl_seconds: u64,
+    /// Maximum acceptable TTL in seconds. A write that supplies a larger TTL
+    /// is clamped down to this value.
+    pub max_ttl_seconds: u64,
+    /// Percentage of the TTL after which a background refresh should be
+    /// triggered. For example `80` means "start refreshing when 80 % of the
+    /// TTL has elapsed (20 % remaining)".
+    ///
+    /// Must be in the range `[1, 99]`.
+    pub refresh_threshold_pct: u32,
+    /// Whether callers are permitted to perform a forced (out-of-band)
+    /// invalidation of entries in this category. When `false` the only path
+    /// to eviction is natural TTL expiry or the on-chain governance proposal
+    /// workflow.
+    pub allow_forced_invalidation: bool,
+}
+
+impl CachePolicy {
+    /// Default policy for [`CacheEntryType::Metadata`].
+    pub fn default_metadata() -> Self {
+        CachePolicy {
+            min_ttl_seconds: METADATA_MIN_TTL_SECONDS,
+            max_ttl_seconds: METADATA_MAX_TTL_SECONDS,
+            refresh_threshold_pct: METADATA_REFRESH_THRESHOLD_PCT,
+            allow_forced_invalidation: true,
+        }
+    }
+
+    /// Default policy for [`CacheEntryType::Capabilities`].
+    pub fn default_capabilities() -> Self {
+        CachePolicy {
+            min_ttl_seconds: CAPABILITIES_MIN_TTL_SECONDS,
+            max_ttl_seconds: CAPABILITIES_MAX_TTL_SECONDS,
+            refresh_threshold_pct: CAPABILITIES_REFRESH_THRESHOLD_PCT,
+            allow_forced_invalidation: true,
+        }
+    }
+
+    /// Default policy for [`CacheEntryType::Other`].
+    pub fn default_other() -> Self {
+        CachePolicy {
+            min_ttl_seconds: OTHER_MIN_TTL_SECONDS,
+            max_ttl_seconds: OTHER_MAX_TTL_SECONDS,
+            refresh_threshold_pct: OTHER_REFRESH_THRESHOLD_PCT,
+            allow_forced_invalidation: false,
+        }
+    }
+
+    /// Return the default policy for a given entry type.
+    pub fn default_for(entry_type: CacheEntryType) -> Self {
+        match entry_type {
+            CacheEntryType::Metadata     => Self::default_metadata(),
+            CacheEntryType::Capabilities => Self::default_capabilities(),
+            CacheEntryType::Other        => Self::default_other(),
+        }
+    }
+
+    /// Check internal consistency.
+    ///
+    /// Returns `Err` with [`ErrorCode::ValidationError`] when:
+    /// - `min_ttl_seconds == 0`
+    /// - `min_ttl_seconds >= max_ttl_seconds`
+    /// - `refresh_threshold_pct` is outside `[1, 99]`
+    pub fn validate(&self) -> Result<(), AnchorKitError> {
+        if self.min_ttl_seconds == 0 {
+            return Err(AnchorKitError::validation_error(
+                "min_ttl_seconds must be greater than zero",
+            ));
+        }
+        if self.min_ttl_seconds >= self.max_ttl_seconds {
+            return Err(AnchorKitError::validation_error(
+                "min_ttl_seconds must be less than max_ttl_seconds",
+            ));
+        }
+        if self.refresh_threshold_pct == 0 || self.refresh_threshold_pct >= 100 {
+            return Err(AnchorKitError::validation_error(
+                "refresh_threshold_pct must be in range [1, 99]",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Clamp `requested_ttl` into the `[min_ttl_seconds, max_ttl_seconds]` band
+    /// defined by this policy.
+    ///
+    /// If `requested_ttl` is zero the midpoint of the allowed band is returned,
+    /// which is a reasonable default when the caller did not supply a preference.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use anchorkit::cache_governance::CachePolicy;
+    ///
+    /// let policy = CachePolicy::default_metadata(); // min=60, max=86400
+    /// // Zero → midpoint (60 + (86400-60)/2 = 43230)
+    /// assert_eq!(policy.clamp_ttl(0), 43_230);
+    /// // Below min → clamped up to min
+    /// assert_eq!(policy.clamp_ttl(30), 60);
+    /// // Within band → unchanged
+    /// assert_eq!(policy.clamp_ttl(3_600), 3_600);
+    /// // Above max → clamped down to max
+    /// assert_eq!(policy.clamp_ttl(999_999), 86_400);
+    /// ```
+    pub fn clamp_ttl(&self, requested_ttl: u64) -> u64 {
+        if requested_ttl == 0 {
+            // Default: midpoint of the allowed band.
+            return self.min_ttl_seconds.saturating_add(
+                self.max_ttl_seconds.saturating_sub(self.min_ttl_seconds) / 2,
+            );
+        }
+        requested_ttl
+            .max(self.min_ttl_seconds)
+            .min(self.max_ttl_seconds)
+    }
+
+    /// Determine whether an entry with the given `age_seconds` has entered the
+    /// background-refresh window.
+    ///
+    /// Returns `true` when `age_seconds >= ttl_seconds * refresh_threshold_pct / 100`.
+    pub fn needs_refresh(&self, age_seconds: u64, ttl_seconds: u64) -> bool {
+        // threshold = ttl * pct / 100  (integer, rounded down)
+        let threshold = ttl_seconds
+            .saturating_mul(self.refresh_threshold_pct as u64)
+            / 100;
+        age_seconds >= threshold
+    }
+
+    /// Determine whether an entry with the given `age_seconds` has fully expired.
+    ///
+    /// Returns `true` when `age_seconds >= ttl_seconds`.
+    pub fn is_expired(&self, age_seconds: u64, ttl_seconds: u64) -> bool {
+        age_seconds >= ttl_seconds
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bundled policy set — all three entry types in one storable struct
+// ---------------------------------------------------------------------------
+
+/// The complete set of governance policies for all cache entry types.
+///
+/// Stored under a single persistent key and updated atomically by
+/// [`set_policy_set`].
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CachePolicySet {
+    pub metadata: CachePolicy,
+    pub capabilities: CachePolicy,
+    pub other: CachePolicy,
+}
+
+impl CachePolicySet {
+    /// All-default policy set.
+    pub fn default_set() -> Self {
+        CachePolicySet {
+            metadata:     CachePolicy::default_metadata(),
+            capabilities: CachePolicy::default_capabilities(),
+            other:        CachePolicy::default_other(),
+        }
+    }
+
+    /// Retrieve the policy for a specific entry type.
+    pub fn for_type(&self, entry_type: CacheEntryType) -> &CachePolicy {
+        match entry_type {
+            CacheEntryType::Metadata     => &self.metadata,
+            CacheEntryType::Capabilities => &self.capabilities,
+            CacheEntryType::Other        => &self.other,
+        }
+    }
+
+    /// Validate all three contained policies.
+    pub fn validate(&self) -> Result<(), AnchorKitError> {
+        self.metadata.validate()?;
+        self.capabilities.validate()?;
+        self.other.validate()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Storage types
@@ -70,6 +323,10 @@ fn config_key(env: &Env) -> BytesN<32> {
     make_storage_key(env, &[b"CGOV_CFG"])
 }
 
+fn policy_set_key(env: &Env) -> BytesN<32> {
+    make_storage_key(env, &[b"CGOV_POL"])
+}
+
 fn proposal_count_key(env: &Env) -> BytesN<32> {
     make_storage_key(env, &[b"CGOV_CNT"])
 }
@@ -79,7 +336,7 @@ fn proposal_key(env: &Env, proposal_id: u64) -> BytesN<32> {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Public API — governance config
 // ---------------------------------------------------------------------------
 
 /// Read the governance configuration, returning the default if not set.
@@ -95,6 +352,109 @@ pub fn get_config(env: &Env) -> CacheGovernanceConfig {
 pub fn set_config(env: &Env, config: CacheGovernanceConfig) {
     env.storage().persistent().set(&config_key(env), &config);
 }
+
+// ---------------------------------------------------------------------------
+// Public API — cache policy
+// ---------------------------------------------------------------------------
+
+/// Read the full [`CachePolicySet`], returning sensible defaults when none has
+/// been configured yet.
+pub fn get_policy_set(env: &Env) -> CachePolicySet {
+    env.storage()
+        .persistent()
+        .get::<_, CachePolicySet>(&policy_set_key(env))
+        .unwrap_or_else(CachePolicySet::default_set)
+}
+
+/// Persist an updated [`CachePolicySet`] after validating all three contained
+/// policies. Returns `Err(ValidationError)` when any policy is internally
+/// inconsistent.
+///
+/// Admin-only enforcement is delegated to the contract layer.
+pub fn set_policy_set(env: &Env, policies: CachePolicySet) -> Result<(), AnchorKitError> {
+    policies.validate()?;
+    env.storage().persistent().set(&policy_set_key(env), &policies);
+    Ok(())
+}
+
+/// Retrieve the active [`CachePolicy`] for a single [`CacheEntryType`].
+///
+/// Equivalent to `get_policy_set(env).for_type(entry_type)` but avoids
+/// loading the full set when only one policy is needed.
+pub fn get_policy(env: &Env, entry_type: CacheEntryType) -> CachePolicy {
+    let set = get_policy_set(env);
+    set.for_type(entry_type).clone()
+}
+
+/// **Write-path enforcement** — clamp a caller-supplied TTL to the policy
+/// band and determine whether a background refresh flag should be set on
+/// an existing entry of the given age.
+///
+/// Returns `(effective_ttl, refresh_needed)`:
+/// - `effective_ttl` — the TTL to actually store, clamped to
+///   `[policy.min_ttl_seconds, policy.max_ttl_seconds]`.
+/// - `refresh_needed` — `true` when the entry's current age already meets
+///   or exceeds the refresh threshold (used when overwriting a still-active
+///   entry with fresh data — the flag will be `false` on a brand-new write).
+///
+/// Pass `current_age_seconds = 0` for brand-new entries.
+pub fn enforce_write_policy(
+    env: &Env,
+    entry_type: CacheEntryType,
+    requested_ttl: u64,
+    current_age_seconds: u64,
+) -> (u64, bool) {
+    let policy = get_policy(env, entry_type);
+    let effective_ttl = policy.clamp_ttl(requested_ttl);
+    let refresh_needed = policy.needs_refresh(current_age_seconds, effective_ttl);
+    (effective_ttl, refresh_needed)
+}
+
+/// **Read-path enforcement** — classify an entry by its current age and TTL
+/// according to the policy for its entry type.
+///
+/// Returns one of:
+/// - `(false, false)` — entry is within the primary TTL and does not yet
+///   need a background refresh.
+/// - `(true, false)`  — entry has passed the refresh threshold but is still
+///   within the primary TTL; a background refresh is recommended.
+/// - `(true, true)`   — entry has fully expired; it must not be served.
+///
+/// The tuple is `(needs_refresh, is_expired)`.
+pub fn enforce_read_policy(
+    env: &Env,
+    entry_type: CacheEntryType,
+    age_seconds: u64,
+    ttl_seconds: u64,
+) -> (bool, bool) {
+    let policy = get_policy(env, entry_type);
+    let expired = policy.is_expired(age_seconds, ttl_seconds);
+    let refresh = policy.needs_refresh(age_seconds, ttl_seconds);
+    (refresh, expired)
+}
+
+/// **Invalidation-path enforcement** — check whether forced invalidation is
+/// permitted for the given entry type under the active policy.
+///
+/// Returns `Ok(())` when allowed.
+/// Returns `Err(ValidationError)` with the message
+/// `"forced invalidation not permitted by policy"` when disabled.
+pub fn enforce_invalidation_policy(
+    env: &Env,
+    entry_type: CacheEntryType,
+) -> Result<(), AnchorKitError> {
+    let policy = get_policy(env, entry_type);
+    if !policy.allow_forced_invalidation {
+        return Err(AnchorKitError::validation_error(
+            "forced invalidation not permitted by policy",
+        ));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Public API — proposals
+// ---------------------------------------------------------------------------
 
 /// Create a new cache invalidation proposal.
 ///

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -2036,6 +2036,27 @@ impl AnchorKitContract {
             .unwrap_or_else(CacheConfig::default_config)
     }
 
+    /// Set the governance policy set for all cache entry types.
+    ///
+    /// Admin-only. Validates all three contained policies before storing.
+    ///
+    /// # Errors
+    ///
+    /// Panics with [`ErrorCode::ValidationError`] when any policy is internally
+    /// inconsistent (e.g. `min_ttl >= max_ttl` or `refresh_threshold_pct` out of
+    /// `[1, 99]`).
+    pub fn set_cache_policy_set(env: Env, policies: crate::cache_governance::CachePolicySet) {
+        Self::require_admin(&env);
+        crate::cache_governance::set_policy_set(&env, policies)
+            .unwrap_or_else(|_| panic_with_error!(&env, ErrorCode::ValidationError));
+    }
+
+    /// Return the currently active [`CachePolicySet`] (or defaults when not yet
+    /// explicitly configured).
+    pub fn get_cache_policy_set(env: Env) -> crate::cache_governance::CachePolicySet {
+        crate::cache_governance::get_policy_set(&env)
+    }
+
     /// Resolve the effective TTL: use `override_ttl` when non-zero, otherwise
     /// fall back to `configured`.
     fn effective_ttl(override_ttl: u64, configured: u64) -> u64 {
@@ -5115,7 +5136,17 @@ impl AnchorKitContract {
 
         let now = env.ledger().timestamp();
         let cfg = Self::get_cache_config_internal(&env);
-        let ttl = Self::effective_ttl(ttl_seconds, cfg.metadata_ttl_seconds);
+        // ── Policy enforcement ──────────────────────────────────────────────
+        // Clamp the caller-supplied TTL to the bounds defined by the active
+        // metadata policy. A zero TTL falls back to the configured default
+        // before clamping.
+        let base_ttl = Self::effective_ttl(ttl_seconds, cfg.metadata_ttl_seconds);
+        let (ttl, _) = crate::cache_governance::enforce_write_policy(
+            &env,
+            crate::cache_governance::CacheEntryType::Metadata,
+            base_ttl,
+            0, // brand-new write: no existing age
+        );
         let stale = cfg.swr_ttl_seconds;
         let entry = MetadataCache {
             metadata,
@@ -5185,8 +5216,16 @@ impl AnchorKitContract {
 
         let now = env.ledger().timestamp();
         let cfg = Self::get_cache_config_internal(&env);
-        let ttl = Self::effective_ttl(ttl_seconds, cfg.metadata_ttl_seconds);
-        let stale = Self::effective_ttl(stale_ttl_seconds, cfg.swr_ttl_seconds);
+        let base_ttl = Self::effective_ttl(ttl_seconds, cfg.metadata_ttl_seconds);
+        let base_stale = Self::effective_ttl(stale_ttl_seconds, cfg.swr_ttl_seconds);
+        // ── Policy enforcement ──────────────────────────────────────────────
+        let (ttl, _) = crate::cache_governance::enforce_write_policy(
+            &env,
+            crate::cache_governance::CacheEntryType::Metadata,
+            base_ttl,
+            0,
+        );
+        let stale = base_stale;
         let entry = MetadataCache {
             metadata,
             cached_at: now,
@@ -5243,10 +5282,27 @@ impl AnchorKitContract {
         stale_ttl_seconds: u64,
     ) {
         Self::require_admin(&env);
+        // ── Policy enforcement — invalidation guard ─────────────────────────
+        // Verify that forced invalidation is permitted for metadata entries
+        // under the active governance policy.
+        crate::cache_governance::enforce_invalidation_policy(
+            &env,
+            crate::cache_governance::CacheEntryType::Metadata,
+        )
+        .unwrap_or_else(|_| panic_with_error!(&env, ErrorCode::ValidationError));
+
         let now = env.ledger().timestamp();
         let cfg = Self::get_cache_config_internal(&env);
-        let ttl = Self::effective_ttl(ttl_seconds, cfg.metadata_ttl_seconds);
-        let stale = Self::effective_ttl(stale_ttl_seconds, cfg.swr_ttl_seconds);
+        let base_ttl   = Self::effective_ttl(ttl_seconds, cfg.metadata_ttl_seconds);
+        let base_stale = Self::effective_ttl(stale_ttl_seconds, cfg.swr_ttl_seconds);
+        // Clamp to policy bounds.
+        let (ttl, _) = crate::cache_governance::enforce_write_policy(
+            &env,
+            crate::cache_governance::CacheEntryType::Metadata,
+            base_ttl,
+            0,
+        );
+        let stale = base_stale;
         let entry = MetadataCache {
             metadata,
             cached_at: now,
@@ -5419,7 +5475,14 @@ impl AnchorKitContract {
 
         let now = env.ledger().timestamp();
         let cfg = Self::get_cache_config_internal(&env);
-        let ttl = Self::effective_ttl(ttl_seconds, cfg.capabilities_ttl_seconds);
+        let base_ttl = Self::effective_ttl(ttl_seconds, cfg.capabilities_ttl_seconds);
+        // ── Policy enforcement ──────────────────────────────────────────────
+        let (ttl, _) = crate::cache_governance::enforce_write_policy(
+            &env,
+            crate::cache_governance::CacheEntryType::Capabilities,
+            base_ttl,
+            0,
+        );
         let entry = CapabilitiesCache { toml_url, capabilities, cached_at: now, ttl_seconds: ttl };
         let ledger_ttl = if ttl as u32 > MIN_TEMP_TTL { ttl as u32 } else { MIN_TEMP_TTL };
         env.storage().temporary().set(&key, &entry);
@@ -6302,7 +6365,14 @@ impl AnchorKitContract {
         }
         let now = env.ledger().timestamp();
         let cfg = Self::get_cache_config_internal(&env);
-        let ttl = Self::effective_ttl(ttl_seconds, cfg.capabilities_ttl_seconds);
+        let base_ttl = Self::effective_ttl(ttl_seconds, cfg.capabilities_ttl_seconds);
+        // ── Policy enforcement ──────────────────────────────────────────────
+        let (ttl, _) = crate::cache_governance::enforce_write_policy(
+            &env,
+            crate::cache_governance::CacheEntryType::Capabilities,
+            base_ttl,
+            0,
+        );
         let cached = CachedToml {
             toml: toml_data,
             cached_at: now,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ pub mod anchor_health;
 pub mod service_management;
 pub mod admin_audit_log;
 pub mod cache_governance;
+pub mod url_normalizer;
 
 // ── std-only modules (filesystem, runtime config) ─────────────────────────────
 #[cfg(feature = "std")]
@@ -179,6 +180,8 @@ pub use contract::{AnchorKitContract, AnchorTomlProvenance, EndpointUpdated, Cac
 pub use transaction_state_tracker::{TransactionState, TransactionStateRecord, RecoveryMetadata, OptRecovery};
 pub use transaction_state_tracker::{StorageBudgetMonitor, TransactionStateTracker};
 pub use transaction_state_tracker::TransactionSummary;
+pub use url_normalizer::{normalize_url, normalize_and_validate, extract_hostname, UrlFilterPolicy, UrlFilterEntry};
+pub use cache_governance::{CachePolicy, CachePolicySet, CacheEntryType, CacheGovernanceConfig};
 
 // ── std-only re-exports ───────────────────────────────────────────────────────
 #[cfg(feature = "std")]

--- a/src/url_normalizer.rs
+++ b/src/url_normalizer.rs
@@ -1,0 +1,633 @@
+//! URL normalization and allowlist/blocklist enforcement.
+//! URL normalization and allowlist/blocklist enforcement for anchor URLs.
+//!
+//! Different anchors may present semantically identical URLs in slightly
+//! different textual forms (trailing slash, default port, mixed case). This
+//! module normalizes URLs to a canonical form so that caching, comparison, and
+//! validation produce consistent results regardless of how the caller formatted
+//! the URL.
+//!
+//! It also provides a configurable [`UrlFilterPolicy`] that supports:
+//! - An **allowlist** of approved hostname suffixes or exact hostnames.
+//! - A **blocklist** of rejected hostname suffixes or exact hostnames.
+//!
+//! ## Normalization rules
+//!
+//! 1. Lowercase the scheme and hostname.
+//! 2. Remove the default port (443 for `https`, 80 for `http`).
+//! 3. Strip a single trailing `/` from the path **when the path is exactly
+//!    `/`** (bare root), so `https://example.com/` → `https://example.com`.
+//!    Paths with real segments are left intact.
+//! 4. Preserve the path, query string, and fragment unmodified except for
+//!    rule 3.
+//!
+//! Callers should pass the normalized URL to [`validate_anchor_domain`] and to
+//! any caching or HTTP-client call.
+
+extern crate alloc;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use crate::errors::AnchorKitError;
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
+/// Normalize a URL to a canonical form.
+///
+/// Applies the following transforms in order:
+/// 1. Trim leading/trailing ASCII whitespace.
+/// 2. Lowercase the scheme and host portions only (path/query/fragment are
+///    preserved as-is to avoid breaking case-sensitive paths).
+/// 3. Remove the default port (`:443` for `https://`, `:80` for `http://`).
+/// 4. Strip a bare trailing slash (`/`) from the authority when no path
+///    segment follows it — `https://example.com/` → `https://example.com`.
+///
+/// Returns `Err(InvalidEndpointFormat)` when the URL does not contain `://`.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::url_normalizer::normalize_url;
+///
+/// assert_eq!(normalize_url("HTTPS://Example.COM/").unwrap(),   "https://example.com");
+/// assert_eq!(normalize_url("https://anchor.example.com:443").unwrap(), "https://anchor.example.com");
+/// assert_eq!(normalize_url("https://anchor.example.com:8080").unwrap(), "https://anchor.example.com:8080");
+/// assert_eq!(normalize_url("https://anchor.example.com/sep6/").unwrap(), "https://anchor.example.com/sep6/");
+/// ```
+pub fn normalize_url(url: &str) -> Result<String, AnchorKitError> {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return Err(AnchorKitError::invalid_endpoint_format());
+    }
+
+    // Split on "://" to separate scheme from the rest.
+    let sep = match trimmed.find("://") {
+        Some(pos) => pos,
+        None => return Err(AnchorKitError::invalid_endpoint_format()),
+    };
+
+    let scheme = &trimmed[..sep];
+    let after_scheme = &trimmed[sep + 3..]; // skip "://"
+
+    // Lowercase the scheme.
+    let scheme_lower: String = scheme.to_ascii_lowercase();
+
+    // Determine the default port for this scheme so we can strip it.
+    let default_port: Option<u16> = match scheme_lower.as_str() {
+        "https" => Some(443),
+        "http"  => Some(80),
+        _       => None,
+    };
+
+    // Find where the authority ends (first '/', '?', '#' after the scheme).
+    let (authority_raw, rest) = match after_scheme.find(|c: char| c == '/' || c == '?' || c == '#') {
+        Some(pos) => (&after_scheme[..pos], &after_scheme[pos..]),
+        None      => (after_scheme, ""),
+    };
+
+    // Lowercase the authority (host + optional port).
+    let authority_lower: String = authority_raw.to_ascii_lowercase();
+
+    // Strip the default port from the authority when present.
+    let authority_normalised: String = if let Some(def_port) = default_port {
+        let port_suffix = alloc::format!(":{}", def_port);
+        if authority_lower.ends_with(&port_suffix) {
+            authority_lower[..authority_lower.len() - port_suffix.len()].to_string()
+        } else {
+            authority_lower
+        }
+    } else {
+        authority_lower
+    };
+
+    // Strip a bare trailing slash — only when `rest == "/"` with nothing after.
+    let rest_normalised = if rest == "/" { "" } else { rest };
+
+    Ok(alloc::format!("{}://{}{}", scheme_lower, authority_normalised, rest_normalised))
+}
+
+/// Extract only the hostname (without port) from a URL.
+///
+/// Returns `None` when the URL does not contain `://` or when the authority is
+/// empty after splitting.
+///
+/// Lowercases the returned hostname.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::url_normalizer::extract_hostname;
+///
+/// assert_eq!(extract_hostname("https://Anchor.Example.COM:8080/path"), Some("anchor.example.com".to_string()));
+/// assert_eq!(extract_hostname("https://example.com"), Some("example.com".to_string()));
+/// assert_eq!(extract_hostname("not-a-url"), None);
+/// ```
+pub fn extract_hostname(url: &str) -> Option<String> {
+    let sep = url.find("://")?;
+    let after_scheme = &url[sep + 3..];
+    let authority = match after_scheme.find(|c: char| c == '/' || c == '?' || c == '#') {
+        Some(pos) => &after_scheme[..pos],
+        None      => after_scheme,
+    };
+    if authority.is_empty() {
+        return None;
+    }
+    // Strip port.
+    let host = if let Some(colon) = authority.rfind(':') {
+        let port_str = &authority[colon + 1..];
+        if port_str.chars().all(|c| c.is_ascii_digit()) {
+            &authority[..colon]
+        } else {
+            authority
+        }
+    } else {
+        authority
+    };
+    Some(host.to_ascii_lowercase())
+}
+
+// ---------------------------------------------------------------------------
+// UrlFilterPolicy — allowlist + blocklist
+// ---------------------------------------------------------------------------
+
+/// A single entry in a URL filter list.
+///
+/// Matching is **suffix-based on the hostname**:
+/// - `"example.com"` matches `example.com` and any subdomain like
+///   `api.example.com`.
+/// - `"evil.example.com"` matches `evil.example.com` and its subdomains but
+///   **not** `safe.example.com`.
+///
+/// Exact matching (no subdomains) can be forced by setting `exact = true`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct UrlFilterEntry {
+    /// The hostname pattern (lowercased). Leading dot is optional;
+    /// `"example.com"` and `".example.com"` are treated identically.
+    pub pattern: String,
+    /// When `true` only the exact hostname matches; subdomains are excluded.
+    pub exact: bool,
+}
+
+impl UrlFilterEntry {
+    /// Construct a suffix-match entry.
+    pub fn suffix(pattern: &str) -> Self {
+        UrlFilterEntry {
+            pattern: pattern.trim_start_matches('.').to_ascii_lowercase(),
+            exact: false,
+        }
+    }
+
+    /// Construct an exact-match entry.
+    pub fn exact(hostname: &str) -> Self {
+        UrlFilterEntry {
+            pattern: hostname.to_ascii_lowercase(),
+            exact: true,
+        }
+    }
+
+    /// Return `true` when `hostname` (already lowercased) matches this entry.
+    pub fn matches(&self, hostname: &str) -> bool {
+        if self.exact {
+            hostname == self.pattern.as_str()
+        } else {
+            // Suffix match: hostname ends with pattern, and the character just
+            // before the pattern (if any) is a dot — so "notexample.com" does
+            // not match ".example.com".
+            if hostname == self.pattern.as_str() {
+                return true;
+            }
+            if hostname.ends_with(self.pattern.as_str()) {
+                let prefix_len = hostname.len() - self.pattern.len();
+                return hostname.as_bytes().get(prefix_len.wrapping_sub(1)) == Some(&b'.');
+            }
+            false
+        }
+    }
+}
+
+/// Configurable URL filter policy combining an allowlist and a blocklist.
+///
+/// Evaluation order:
+/// 1. If the **blocklist** is non-empty and the hostname matches any blocked
+///    entry → **reject** (returns `Err`).
+/// 2. If the **allowlist** is non-empty and the hostname does NOT match any
+///    allowed entry → **reject** (returns `Err`).
+/// 3. Otherwise → **accept** (returns `Ok`).
+///
+/// An empty allowlist means "allow any host not blocked".
+/// An empty blocklist means "block nothing explicitly".
+#[derive(Clone, Debug, Default)]
+pub struct UrlFilterPolicy {
+    pub allowlist: Vec<UrlFilterEntry>,
+    pub blocklist: Vec<UrlFilterEntry>,
+}
+
+impl UrlFilterPolicy {
+    /// Create an empty (permissive) policy that accepts all URLs.
+    pub fn new() -> Self {
+        UrlFilterPolicy::default()
+    }
+
+    /// Add a suffix-based allowlist entry.
+    pub fn allow_suffix(mut self, pattern: &str) -> Self {
+        self.allowlist.push(UrlFilterEntry::suffix(pattern));
+        self
+    }
+
+    /// Add an exact-match allowlist entry.
+    pub fn allow_exact(mut self, hostname: &str) -> Self {
+        self.allowlist.push(UrlFilterEntry::exact(hostname));
+        self
+    }
+
+    /// Add a suffix-based blocklist entry.
+    pub fn block_suffix(mut self, pattern: &str) -> Self {
+        self.blocklist.push(UrlFilterEntry::suffix(pattern));
+        self
+    }
+
+    /// Add an exact-match blocklist entry.
+    pub fn block_exact(mut self, hostname: &str) -> Self {
+        self.blocklist.push(UrlFilterEntry::exact(hostname));
+        self
+    }
+
+    /// Evaluate the policy against a full URL.
+    ///
+    /// The URL is normalized before the hostname is extracted so that
+    /// mixed-case and default-port variants are handled consistently.
+    ///
+    /// Returns `Ok(())` when the URL is permitted.
+    /// Returns `Err(InvalidEndpointFormat)` with a human-readable context
+    /// message when the URL is blocked or not on the allowlist.
+    pub fn check(&self, url: &str) -> Result<(), AnchorKitError> {
+        let normalized = normalize_url(url)?;
+        let hostname = extract_hostname(&normalized)
+            .ok_or_else(AnchorKitError::invalid_endpoint_format)?;
+
+        // 1. Blocklist check — explicit rejection takes precedence.
+        for entry in &self.blocklist {
+            if entry.matches(&hostname) {
+                return Err(AnchorKitError::with_context(
+                    crate::errors::ErrorCode::InvalidEndpointFormat,
+                    "host is on the blocklist",
+                    &hostname,
+                ));
+            }
+        }
+
+        // 2. Allowlist check — when non-empty the host must appear on it.
+        if !self.allowlist.is_empty() {
+            let allowed = self.allowlist.iter().any(|e| e.matches(&hostname));
+            if !allowed {
+                return Err(AnchorKitError::with_context(
+                    crate::errors::ErrorCode::InvalidEndpointFormat,
+                    "host is not on the allowlist",
+                    &hostname,
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Convenience wrapper: normalize then validate a URL with the given filter
+/// policy and the core [`validate_anchor_domain`] rules.
+///
+/// This is the recommended single call for all outbound URL handling:
+/// normalization, structural validation, and filter-policy enforcement are
+/// applied in one shot.
+///
+/// # Arguments
+///
+/// * `url`    — Raw URL supplied by the caller (may have mixed case, default
+///              port, trailing slash, etc.).
+/// * `policy` — Active [`UrlFilterPolicy`]. Pass `&UrlFilterPolicy::new()` for
+///              no additional filtering beyond the core structural rules.
+///
+/// # Returns
+///
+/// `Ok(normalized_url)` — the canonical URL string ready for use.
+/// `Err(AnchorKitError)` — structural or policy violation.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::url_normalizer::{normalize_and_validate, UrlFilterPolicy};
+///
+/// let policy = UrlFilterPolicy::new().allow_suffix("example.com");
+/// let result = normalize_and_validate("HTTPS://Anchor.Example.COM:443/sep6", &policy);
+/// assert_eq!(result.unwrap(), "https://anchor.example.com/sep6");
+///
+/// let blocked = normalize_and_validate("https://evil.example.org/sep6", &policy);
+/// assert!(blocked.is_err());
+/// ```
+pub fn normalize_and_validate(url: &str, policy: &UrlFilterPolicy) -> Result<String, AnchorKitError> {
+    let normalized = normalize_url(url)?;
+    // Re-use the existing structural validator on the already-normalized URL.
+    crate::domain_validator::validate_anchor_domain(&normalized)?;
+    // Apply filter policy.
+    policy.check(&normalized)?;
+    Ok(normalized)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── normalize_url ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_normalize_lowercase_scheme_and_host() {
+        assert_eq!(
+            normalize_url("HTTPS://ANCHOR.EXAMPLE.COM").unwrap(),
+            "https://anchor.example.com"
+        );
+        assert_eq!(
+            normalize_url("Https://Api.Example.Com/path").unwrap(),
+            "https://api.example.com/path"
+        );
+    }
+
+    #[test]
+    fn test_normalize_strips_default_https_port() {
+        assert_eq!(
+            normalize_url("https://anchor.example.com:443").unwrap(),
+            "https://anchor.example.com"
+        );
+        assert_eq!(
+            normalize_url("https://anchor.example.com:443/sep6").unwrap(),
+            "https://anchor.example.com/sep6"
+        );
+    }
+
+    #[test]
+    fn test_normalize_strips_default_http_port() {
+        assert_eq!(
+            normalize_url("http://example.com:80/sep6").unwrap(),
+            "http://example.com/sep6"
+        );
+    }
+
+    #[test]
+    fn test_normalize_preserves_non_default_port() {
+        assert_eq!(
+            normalize_url("https://example.com:8080").unwrap(),
+            "https://example.com:8080"
+        );
+        assert_eq!(
+            normalize_url("https://example.com:8443/sep6").unwrap(),
+            "https://example.com:8443/sep6"
+        );
+    }
+
+    #[test]
+    fn test_normalize_strips_bare_trailing_slash() {
+        assert_eq!(
+            normalize_url("https://example.com/").unwrap(),
+            "https://example.com"
+        );
+        // Port + bare slash
+        assert_eq!(
+            normalize_url("https://example.com:443/").unwrap(),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_normalize_preserves_path_trailing_slash() {
+        // A trailing slash on an actual path segment is kept.
+        assert_eq!(
+            normalize_url("https://example.com/sep6/").unwrap(),
+            "https://example.com/sep6/"
+        );
+    }
+
+    #[test]
+    fn test_normalize_preserves_path_case() {
+        // Only scheme + host are lowercased; path is not altered.
+        assert_eq!(
+            normalize_url("https://Example.COM/MyPath?Query=Value").unwrap(),
+            "https://example.com/MyPath?Query=Value"
+        );
+    }
+
+    #[test]
+    fn test_normalize_trims_whitespace() {
+        assert_eq!(
+            normalize_url("  https://example.com  ").unwrap(),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_normalize_empty_returns_error() {
+        assert!(normalize_url("").is_err());
+        assert!(normalize_url("   ").is_err());
+    }
+
+    #[test]
+    fn test_normalize_missing_scheme_separator_returns_error() {
+        assert!(normalize_url("example.com").is_err());
+        assert!(normalize_url("https:/example.com").is_err());
+    }
+
+    #[test]
+    fn test_normalize_query_and_fragment_preserved() {
+        assert_eq!(
+            normalize_url("HTTPS://Example.com?foo=bar#section").unwrap(),
+            "https://example.com?foo=bar#section"
+        );
+    }
+
+    // ── extract_hostname ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_extract_hostname_basic() {
+        assert_eq!(
+            extract_hostname("https://anchor.example.com"),
+            Some("anchor.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_hostname_strips_port() {
+        assert_eq!(
+            extract_hostname("https://anchor.example.com:8080/path"),
+            Some("anchor.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_hostname_lowercases() {
+        assert_eq!(
+            extract_hostname("HTTPS://ANCHOR.EXAMPLE.COM:443"),
+            Some("anchor.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_hostname_no_scheme_returns_none() {
+        assert_eq!(extract_hostname("example.com"), None);
+    }
+
+    // ── UrlFilterEntry ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_filter_entry_suffix_matches_exact() {
+        let e = UrlFilterEntry::suffix("example.com");
+        assert!(e.matches("example.com"));
+    }
+
+    #[test]
+    fn test_filter_entry_suffix_matches_subdomain() {
+        let e = UrlFilterEntry::suffix("example.com");
+        assert!(e.matches("api.example.com"));
+        assert!(e.matches("deep.sub.example.com"));
+    }
+
+    #[test]
+    fn test_filter_entry_suffix_does_not_match_partial() {
+        let e = UrlFilterEntry::suffix("example.com");
+        // "notexample.com" must NOT match ".example.com"
+        assert!(!e.matches("notexample.com"));
+        assert!(!e.matches("badexample.com"));
+    }
+
+    #[test]
+    fn test_filter_entry_exact_matches_only_exact() {
+        let e = UrlFilterEntry::exact("example.com");
+        assert!(e.matches("example.com"));
+        assert!(!e.matches("api.example.com"));
+        assert!(!e.matches("other.com"));
+    }
+
+    #[test]
+    fn test_filter_entry_leading_dot_stripped() {
+        // ".example.com" and "example.com" are treated the same.
+        let e = UrlFilterEntry::suffix(".example.com");
+        assert!(e.matches("example.com"));
+        assert!(e.matches("api.example.com"));
+    }
+
+    // ── UrlFilterPolicy ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_policy_empty_accepts_all() {
+        let policy = UrlFilterPolicy::new();
+        assert!(policy.check("https://anything.example.com").is_ok());
+        assert!(policy.check("https://other.org").is_ok());
+    }
+
+    #[test]
+    fn test_policy_allowlist_accepts_matching_host() {
+        let policy = UrlFilterPolicy::new().allow_suffix("example.com");
+        assert!(policy.check("https://anchor.example.com").is_ok());
+        assert!(policy.check("https://api.example.com/sep6").is_ok());
+    }
+
+    #[test]
+    fn test_policy_allowlist_rejects_non_matching_host() {
+        let policy = UrlFilterPolicy::new().allow_suffix("example.com");
+        let err = policy.check("https://other.org").unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::InvalidEndpointFormat);
+        assert!(err.message.contains("allowlist"));
+    }
+
+    #[test]
+    fn test_policy_blocklist_rejects_blocked_host() {
+        let policy = UrlFilterPolicy::new().block_suffix("evil.example.com");
+        let err = policy.check("https://evil.example.com/path").unwrap_err();
+        assert_eq!(err.code, crate::errors::ErrorCode::InvalidEndpointFormat);
+        assert!(err.message.contains("blocklist"));
+    }
+
+    #[test]
+    fn test_policy_blocklist_allows_non_blocked_host() {
+        let policy = UrlFilterPolicy::new().block_suffix("evil.example.com");
+        assert!(policy.check("https://safe.example.com").is_ok());
+    }
+
+    #[test]
+    fn test_policy_blocklist_takes_precedence_over_allowlist() {
+        // Host is on both — blocklist wins.
+        let policy = UrlFilterPolicy::new()
+            .allow_suffix("example.com")
+            .block_exact("evil.example.com");
+        let err = policy.check("https://evil.example.com").unwrap_err();
+        assert!(err.message.contains("blocklist"));
+    }
+
+    #[test]
+    fn test_policy_normalizes_before_checking() {
+        // Mixed-case and default-port URL should be normalized and accepted.
+        let policy = UrlFilterPolicy::new().allow_suffix("example.com");
+        assert!(policy.check("HTTPS://ANCHOR.EXAMPLE.COM:443/sep6").is_ok());
+    }
+
+    #[test]
+    fn test_policy_exact_allowlist() {
+        let policy = UrlFilterPolicy::new().allow_exact("anchor.example.com");
+        assert!(policy.check("https://anchor.example.com").is_ok());
+        // Subdomain of allowed host should fail with exact allowlist.
+        let err = policy.check("https://api.anchor.example.com").unwrap_err();
+        assert!(err.message.contains("allowlist"));
+    }
+
+    #[test]
+    fn test_policy_multiple_allowlist_entries() {
+        let policy = UrlFilterPolicy::new()
+            .allow_suffix("example.com")
+            .allow_suffix("stellar.org");
+        assert!(policy.check("https://anchor.example.com").is_ok());
+        assert!(policy.check("https://api.stellar.org").is_ok());
+        assert!(policy.check("https://other.io").is_err());
+    }
+
+    // ── normalize_and_validate ────────────────────────────────────────────
+
+    #[test]
+    fn test_normalize_and_validate_canonical_url() {
+        let policy = UrlFilterPolicy::new().allow_suffix("example.com");
+        let result = normalize_and_validate("HTTPS://Anchor.Example.COM:443/sep6", &policy);
+        assert_eq!(result.unwrap(), "https://anchor.example.com/sep6");
+    }
+
+    #[test]
+    fn test_normalize_and_validate_blocked_host_error() {
+        let policy = UrlFilterPolicy::new()
+            .allow_suffix("example.com")
+            .block_exact("bad.example.com");
+        let err = normalize_and_validate("https://bad.example.com/sep6", &policy).unwrap_err();
+        assert!(err.message.contains("blocklist"));
+    }
+
+    #[test]
+    fn test_normalize_and_validate_structural_error_propagated() {
+        let policy = UrlFilterPolicy::new();
+        // IP address — rejected by validate_anchor_domain.
+        assert!(normalize_and_validate("https://192.168.1.1/sep6", &policy).is_err());
+    }
+
+    #[test]
+    fn test_normalize_and_validate_strips_default_port_before_structural_check() {
+        // https://example.com:443 → normalized to https://example.com → passes.
+        let policy = UrlFilterPolicy::new();
+        let result = normalize_and_validate("https://anchor.example.com:443", &policy);
+        assert_eq!(result.unwrap(), "https://anchor.example.com");
+    }
+
+    #[test]
+    fn test_normalize_and_validate_bare_trailing_slash_stripped() {
+        let policy = UrlFilterPolicy::new();
+        let result = normalize_and_validate("https://anchor.example.com/", &policy);
+        assert_eq!(result.unwrap(), "https://anchor.example.com");
+    }
+}

--- a/tests/cache_policy_tests.rs
+++ b/tests/cache_policy_tests.rs
@@ -1,0 +1,495 @@
+//! Tests for the cache governance policy model.
+//!
+//! Covers:
+//! - TTL clamping (min / max bounds)
+//! - Refresh threshold detection
+//! - Expiry detection
+//! - Forced-invalidation guard
+//! - Policy set persistence (get/set round-trip)
+//! - Integration with contract cache_metadata / force_refresh_metadata
+
+#![cfg(test)]
+
+use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+use soroban_sdk::{Address, Env};
+use anchorkit::cache_governance::{
+    self, CacheEntryType, CachePolicy, CachePolicySet,
+    enforce_write_policy, enforce_read_policy, enforce_invalidation_policy,
+};
+use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient, AnchorMetadata};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn set_ledger(env: &Env, seq: u32, ts: u64) {
+    env.ledger().set(LedgerInfo {
+        timestamp: ts,
+        protocol_version: 21,
+        sequence_number: seq,
+        network_id: Default::default(),
+        base_reserve: 0,
+        min_persistent_entry_ttl: 4096,
+        min_temp_entry_ttl: 16,
+        max_entry_ttl: 6_312_000,
+    });
+}
+
+fn sample_metadata(env: &Env, anchor: &Address) -> AnchorMetadata {
+    AnchorMetadata {
+        anchor: anchor.clone(),
+        reputation_score: 80,
+        liquidity_score: 90,
+        uptime_percentage: 99,
+        total_volume: 1_000_000,
+        average_settlement_time: 120,
+        is_active: true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CachePolicy unit tests  (no Soroban env needed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_default_metadata_policy_valid() {
+    let p = CachePolicy::default_metadata();
+    assert!(p.validate().is_ok());
+    assert_eq!(p.min_ttl_seconds, 60);
+    assert_eq!(p.max_ttl_seconds, 86_400);
+    assert_eq!(p.refresh_threshold_pct, 80);
+    assert!(p.allow_forced_invalidation);
+}
+
+#[test]
+fn test_default_capabilities_policy_valid() {
+    let p = CachePolicy::default_capabilities();
+    assert!(p.validate().is_ok());
+    assert_eq!(p.min_ttl_seconds, 300);
+    assert_eq!(p.max_ttl_seconds, 604_800);
+    assert_eq!(p.refresh_threshold_pct, 75);
+    assert!(p.allow_forced_invalidation);
+}
+
+#[test]
+fn test_default_other_policy_valid() {
+    let p = CachePolicy::default_other();
+    assert!(p.validate().is_ok());
+    assert!(!p.allow_forced_invalidation);
+}
+
+#[test]
+fn test_policy_validate_rejects_zero_min() {
+    let p = CachePolicy {
+        min_ttl_seconds: 0,
+        max_ttl_seconds: 3600,
+        refresh_threshold_pct: 80,
+        allow_forced_invalidation: true,
+    };
+    assert!(p.validate().is_err());
+}
+
+#[test]
+fn test_policy_validate_rejects_min_ge_max() {
+    let p = CachePolicy {
+        min_ttl_seconds: 3600,
+        max_ttl_seconds: 3600,
+        refresh_threshold_pct: 80,
+        allow_forced_invalidation: true,
+    };
+    assert!(p.validate().is_err());
+
+    let p2 = CachePolicy { min_ttl_seconds: 7200, ..p };
+    assert!(p2.validate().is_err());
+}
+
+#[test]
+fn test_policy_validate_rejects_invalid_threshold() {
+    let base = CachePolicy {
+        min_ttl_seconds: 60,
+        max_ttl_seconds: 3600,
+        refresh_threshold_pct: 0,
+        allow_forced_invalidation: true,
+    };
+    assert!(base.validate().is_err(), "threshold 0 should be rejected");
+
+    let p100 = CachePolicy { refresh_threshold_pct: 100, ..base };
+    assert!(p100.validate().is_err(), "threshold 100 should be rejected");
+
+    let p99 = CachePolicy { refresh_threshold_pct: 99, min_ttl_seconds: 60, max_ttl_seconds: 3600, allow_forced_invalidation: true };
+    assert!(p99.validate().is_ok(), "threshold 99 should be accepted");
+}
+
+// ---------------------------------------------------------------------------
+// TTL clamping (pure logic, no Soroban env)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_clamp_ttl_within_band_unchanged() {
+    let p = CachePolicy::default_metadata(); // [60, 86400]
+    assert_eq!(p.clamp_ttl(3_600), 3_600);
+    assert_eq!(p.clamp_ttl(60), 60);
+    assert_eq!(p.clamp_ttl(86_400), 86_400);
+}
+
+#[test]
+fn test_clamp_ttl_below_min_clamped_up() {
+    let p = CachePolicy::default_metadata(); // min = 60
+    assert_eq!(p.clamp_ttl(1), 60);
+    assert_eq!(p.clamp_ttl(59), 60);
+}
+
+#[test]
+fn test_clamp_ttl_above_max_clamped_down() {
+    let p = CachePolicy::default_metadata(); // max = 86400
+    assert_eq!(p.clamp_ttl(100_000), 86_400);
+    assert_eq!(p.clamp_ttl(u64::MAX), 86_400);
+}
+
+#[test]
+fn test_clamp_ttl_zero_returns_midpoint() {
+    let p = CachePolicy {
+        min_ttl_seconds: 100,
+        max_ttl_seconds: 300,
+        refresh_threshold_pct: 80,
+        allow_forced_invalidation: true,
+    };
+    // midpoint = 100 + (300-100)/2 = 200
+    assert_eq!(p.clamp_ttl(0), 200);
+}
+
+// ---------------------------------------------------------------------------
+// Refresh threshold (pure logic)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_needs_refresh_at_threshold() {
+    let p = CachePolicy {
+        min_ttl_seconds: 60,
+        max_ttl_seconds: 3600,
+        refresh_threshold_pct: 80,
+        allow_forced_invalidation: true,
+    };
+    // 80% of 3600 = 2880
+    assert!(!p.needs_refresh(2879, 3600), "age 2879 is before threshold");
+    assert!(p.needs_refresh(2880, 3600), "age 2880 is at threshold");
+    assert!(p.needs_refresh(3599, 3600), "age 3599 is past threshold but not expired");
+}
+
+#[test]
+fn test_needs_refresh_false_when_fresh() {
+    let p = CachePolicy::default_metadata();
+    assert!(!p.needs_refresh(100, 3600));
+}
+
+// ---------------------------------------------------------------------------
+// Expiry detection (pure logic)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_is_expired_at_ttl_boundary() {
+    let p = CachePolicy::default_metadata();
+    assert!(!p.is_expired(3599, 3600), "age 3599 not expired");
+    assert!(p.is_expired(3600, 3600), "age 3600 is exactly expired");
+    assert!(p.is_expired(3601, 3600), "age 3601 is past expired");
+}
+
+// ---------------------------------------------------------------------------
+// enforce_write_policy / enforce_read_policy  (require Soroban env)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_enforce_write_policy_clamps_to_bounds() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    env.as_contract(&cid, || {
+        // Metadata policy default: min=60, max=86400
+        let (ttl, _) = enforce_write_policy(&env, CacheEntryType::Metadata, 10, 0);
+        assert_eq!(ttl, 60, "TTL below min should be clamped up to 60");
+
+        let (ttl2, _) = enforce_write_policy(&env, CacheEntryType::Metadata, 999_999, 0);
+        assert_eq!(ttl2, 86_400, "TTL above max should be clamped down to 86400");
+
+        let (ttl3, _) = enforce_write_policy(&env, CacheEntryType::Metadata, 3_600, 0);
+        assert_eq!(ttl3, 3_600, "TTL within band should be unchanged");
+    });
+}
+
+#[test]
+fn test_enforce_read_policy_fresh_entry() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    env.as_contract(&cid, || {
+        // age=100, ttl=3600 → 80% threshold=2880; age < 2880 → not stale, not expired
+        let (refresh, expired) = enforce_read_policy(&env, CacheEntryType::Metadata, 100, 3600);
+        assert!(!refresh);
+        assert!(!expired);
+    });
+}
+
+#[test]
+fn test_enforce_read_policy_stale_entry() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    env.as_contract(&cid, || {
+        // age=3000, ttl=3600 → 80%=2880; 3000 >= 2880 but < 3600 → refresh, not expired
+        let (refresh, expired) = enforce_read_policy(&env, CacheEntryType::Metadata, 3000, 3600);
+        assert!(refresh, "should need refresh");
+        assert!(!expired, "should not be expired");
+    });
+}
+
+#[test]
+fn test_enforce_read_policy_expired_entry() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    env.as_contract(&cid, || {
+        // age >= ttl → expired
+        let (refresh, expired) = enforce_read_policy(&env, CacheEntryType::Metadata, 3600, 3600);
+        assert!(refresh);
+        assert!(expired);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// enforce_invalidation_policy
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_invalidation_allowed_by_default_for_metadata() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    env.as_contract(&cid, || {
+        let result = enforce_invalidation_policy(&env, CacheEntryType::Metadata);
+        assert!(result.is_ok(), "default metadata policy allows forced invalidation");
+    });
+}
+
+#[test]
+fn test_invalidation_blocked_when_policy_disables_it() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    env.as_contract(&cid, || {
+        let mut ps = cache_governance::get_policy_set(&env);
+        ps.metadata.allow_forced_invalidation = false;
+        cache_governance::set_policy_set(&env, ps).unwrap();
+
+        let result = enforce_invalidation_policy(&env, CacheEntryType::Metadata);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.context.as_deref().unwrap_or("").contains("forced invalidation"),
+            "error context should mention forced invalidation"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Policy set persistence round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_policy_set_default_round_trip() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    env.as_contract(&cid, || {
+        let set = cache_governance::get_policy_set(&env);
+        assert_eq!(set, CachePolicySet::default_set());
+    });
+}
+
+#[test]
+fn test_policy_set_custom_persisted_and_retrieved() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    env.as_contract(&cid, || {
+        let custom = CachePolicySet {
+            metadata: CachePolicy {
+                min_ttl_seconds: 120,
+                max_ttl_seconds: 7_200,
+                refresh_threshold_pct: 70,
+                allow_forced_invalidation: true,
+            },
+            capabilities: CachePolicy::default_capabilities(),
+            other: CachePolicy::default_other(),
+        };
+        cache_governance::set_policy_set(&env, custom).unwrap();
+
+        let retrieved = cache_governance::get_policy_set(&env);
+        assert_eq!(retrieved.metadata.min_ttl_seconds, 120);
+        assert_eq!(retrieved.metadata.max_ttl_seconds, 7_200);
+        assert_eq!(retrieved.metadata.refresh_threshold_pct, 70);
+    });
+}
+
+#[test]
+fn test_policy_set_invalid_rejected() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    env.as_contract(&cid, || {
+        let bad = CachePolicySet {
+            metadata: CachePolicy {
+                min_ttl_seconds: 0, // invalid: must be > 0
+                max_ttl_seconds: 3600,
+                refresh_threshold_pct: 80,
+                allow_forced_invalidation: true,
+            },
+            capabilities: CachePolicy::default_capabilities(),
+            other: CachePolicy::default_other(),
+        };
+        let result = cache_governance::set_policy_set(&env, bad);
+        assert!(result.is_err(), "invalid policy should be rejected");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Contract integration: cache_metadata respects policy TTL clamping
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_contract_cache_metadata_clamps_ttl_to_policy_min() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    let client = AnchorKitContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let anchor = Address::generate(&env);
+    let meta = sample_metadata(&env, &anchor);
+
+    // Request TTL=1 (below policy min of 60 s) — policy clamps it up to 60 s.
+    client.cache_metadata(&anchor, &meta, &1u64);
+
+    // At t=1059, age=59 s — still within the clamped 60 s TTL.
+    set_ledger(&env, 2, 1059);
+    let retrieved = client.get_cached_metadata(&anchor);
+    assert_eq!(retrieved.anchor, anchor, "entry should still be valid at age 59 s");
+}
+
+#[test]
+fn test_contract_cache_metadata_clamps_ttl_to_policy_max() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    let client = AnchorKitContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Override policy to a tight max of 200 s so we can verify clamping.
+    env.as_contract(&cid, || {
+        let mut ps = cache_governance::get_policy_set(&env);
+        ps.metadata.min_ttl_seconds = 10;
+        ps.metadata.max_ttl_seconds = 200;
+        cache_governance::set_policy_set(&env, ps).unwrap();
+    });
+
+    let anchor = Address::generate(&env);
+    let meta = sample_metadata(&env, &anchor);
+
+    // Request TTL=999_999 (way above max=200) — policy clamps it down to 200 s.
+    client.cache_metadata(&anchor, &meta, &999_999u64);
+
+    // At t=1201, age=201 s — past the clamped max of 200 s.
+    set_ledger(&env, 2, 1201);
+    let result = client.try_get_cached_metadata(&anchor);
+    assert!(result.is_err(), "entry should be expired after 201 s with clamped max=200 s TTL");
+}
+
+// ---------------------------------------------------------------------------
+// Contract integration: force_refresh_metadata blocked when policy disallows
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_force_refresh_blocked_when_policy_disallows() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    let client = AnchorKitContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Disable forced invalidation for metadata entries.
+    env.as_contract(&cid, || {
+        let mut ps = cache_governance::get_policy_set(&env);
+        ps.metadata.allow_forced_invalidation = false;
+        cache_governance::set_policy_set(&env, ps).unwrap();
+    });
+
+    let anchor = Address::generate(&env);
+    let meta = sample_metadata(&env, &anchor);
+    // Normal write is always allowed.
+    client.cache_metadata(&anchor, &meta, &3600u64);
+
+    // force_refresh should now be blocked by policy.
+    let result = client.try_force_refresh_metadata(&anchor, &meta, &3600u64, &300u64);
+    assert!(
+        result.is_err(),
+        "force_refresh_metadata must fail when policy disables forced invalidation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Contract integration: set_cache_policy_set / get_cache_policy_set
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_contract_get_set_cache_policy_set_round_trip() {
+    let env = make_env();
+    let cid = env.register_contract(None, AnchorKitContract);
+    set_ledger(&env, 1, 1000);
+
+    let client = AnchorKitContractClient::new(&env, &cid);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Default should come back as the built-in defaults.
+    let default_ps = client.get_cache_policy_set();
+    assert_eq!(default_ps.metadata.min_ttl_seconds, 60);
+    assert_eq!(default_ps.metadata.max_ttl_seconds, 86_400);
+
+    // Set a custom policy via the contract method.
+    let custom = CachePolicySet {
+        metadata: CachePolicy {
+            min_ttl_seconds: 180,
+            max_ttl_seconds: 10_800,
+            refresh_threshold_pct: 75,
+            allow_forced_invalidation: true,
+        },
+        capabilities: CachePolicy::default_capabilities(),
+        other: CachePolicy::default_other(),
+    };
+    client.set_cache_policy_set(&custom);
+
+    let retrieved = client.get_cache_policy_set();
+    assert_eq!(retrieved.metadata.min_ttl_seconds, 180);
+    assert_eq!(retrieved.metadata.max_ttl_seconds, 10_800);
+    assert_eq!(retrieved.metadata.refresh_threshold_pct, 75);
+}


### PR DESCRIPTION
closes #599 
closes #604 

feat: cache governance policy model and URL normalization/allowlist

Cache governance policy model (src/cache_governance.rs):
- Add CacheEntryType enum (Metadata, Capabilities, Other)
- Add CachePolicy struct: min/max TTL bounds, refresh threshold pct,
  allow_forced_invalidation flag — all validated on write
- Add CachePolicySet: atomic bundle of all three policies, stored at
  persistent key CGOV_POL
- Add policy storage API: get_policy_set / set_policy_set (with validation),
  get_policy for single-type lookup
- Add enforce_write_policy: clamps caller TTL to [min, max], signals
  refresh when age >= threshold pct of TTL
- Add enforce_read_policy: classifies entry as fresh / stale / expired
- Add enforce_invalidation_policy: guards forced eviction per policy flag
- All default policies ship with sensible production values

Contract integration (src/contract.rs):
- All 6 cache write paths now run enforce_write_policy:
  cache_metadata, cache_metadata_swr, force_refresh_metadata,
  cache_capabilities, refresh_capabilities_cache, fetch_anchor_info
- force_refresh_metadata calls enforce_invalidation_policy first;
  panics with ValidationError when policy disallows forced eviction
- Add set_cache_policy_set / get_cache_policy_set contract methods
  (admin-only write, open read)

URL normalization and allowlist/blocklist (src/url_normalizer.rs):
- normalize_url: lowercase scheme+host, strip default port (:443/:80),
  strip bare trailing slash, preserve path/query/fragment
- extract_hostname: extract and lowercase hostname without port
- UrlFilterEntry: suffix-match or exact-match on hostname
- UrlFilterPolicy: builder-pattern allowlist + blocklist; blocklist
  takes precedence; empty allowlist = accept all
- normalize_and_validate: normalize -> structural validate via
  validate_anchor_domain -> filter policy check in one call

Tests (tests/cache_policy_tests.rs, src/url_normalizer.rs):
- 26 cache policy tests: policy validation, TTL clamping, refresh
  threshold, expiry detection, invalidation guard, persistence
  round-trips, contract integration for TTL clamping and
  force_refresh blocking
- 34 URL normalizer inline tests: every normalization rule,
  suffix/exact filter entry matching, policy evaluation order,
  normalize_and_validate end-to-end
