### PR TITLE
SEP improvements: interactive flow hardening, origin validation, paym…

### DIFF
--- a/src/sep24.rs
+++ b/src/sep24.rs
@@ -10,6 +10,7 @@ use crate::domain_validator::validate_anchor_domain;
 use crate::errors::{AnchorKitError, ErrorCode};
 use crate::errors::normalize_asset_code;
 use crate::sep6::TransactionStatus;
+use crate::url_normalizer::normalize_url;
 
 /// Raw response from anchor's `/transactions/deposit/interactive` endpoint.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -37,18 +38,22 @@ pub struct RawSep24TransactionResponse {
 }
 
 /// Normalized response for interactive deposit initiation.
+///
+/// The `url` field is validated and normalized to a canonical HTTPS origin.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InteractiveDepositResponse {
-    /// URL to redirect user to for interactive flow.
+    /// URL to redirect user to for interactive flow (normalized).
     pub url: String,
     /// Unique transaction ID assigned by the anchor.
     pub id: String,
 }
 
 /// Normalized response for interactive withdrawal initiation.
+///
+/// The `url` field is validated and normalized to a canonical HTTPS origin.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InteractiveWithdrawalResponse {
-    /// URL to redirect user to for interactive flow.
+    /// URL to redirect user to for interactive flow (normalized).
     pub url: String,
     /// Unique transaction ID assigned by the anchor.
     pub id: String,
@@ -73,11 +78,17 @@ pub struct Sep24TransactionStatusResponse {
 // Validation helpers
 // ---------------------------------------------------------------------------
 
-/// Validates that a SEP-24 interactive flow URL is a well-formed HTTPS URL.
+/// Validates that a SEP-24 interactive flow URL is a well-formed HTTPS URL
+/// with a valid, non-empty path, and (optionally) that its origin matches an
+/// expected value.
 ///
-/// Delegates structural validation to [`validate_anchor_domain`], which
-/// enforces https-only, no userinfo, no IP literals, and a valid registered
-/// domain.
+/// The input URL is first **normalized** via [`normalize_url`] (lowercases
+/// scheme/host, strips default port and bare trailing slash) so that
+/// semantically identical variants are treated the same way.
+///
+/// Normalization is followed by structural validation via
+/// [`validate_anchor_domain`], which enforces https-only, no userinfo, no IP
+/// literals, and a valid registered domain.
 ///
 /// When `allowed_origin` is `Some`, the scheme + host (+ optional port) of
 /// `url` must match it case-insensitively. Any mismatch returns
@@ -104,57 +115,164 @@ pub struct Sep24TransactionStatusResponse {
 /// ).is_err());
 /// ```
 pub fn validate_interactive_url(url: &str, allowed_origin: Option<&str>) -> Result<(), AnchorKitError> {
-    validate_anchor_domain(url).map_err(|_| AnchorKitError::invalid_endpoint_format())?;
+    let normalized = normalize_url(url)?;
+    validate_anchor_domain(&normalized).map_err(|_| AnchorKitError::invalid_endpoint_format())?;
+
+    if normalized == "https://" {
+        return Err(AnchorKitError::invalid_endpoint_format());
+    }
 
     if let Some(origin) = allowed_origin {
-        let url_origin = extract_origin(url);
-        let expected_origin = extract_origin(origin);
-        if !url_origin.eq_ignore_ascii_case(&expected_origin) {
-            return Err(AnchorKitError::invalid_endpoint_format());
+        let url_origin = extract_normalized_origin(&normalized);
+        let expected_origin = extract_normalized_origin(
+            &normalize_url(origin).unwrap_or_else(|_| alloc::format!("{}", origin)),
+        );
+        if url_origin != expected_origin {
+            return Err(AnchorKitError::with_context(
+                ErrorCode::InvalidEndpointFormat,
+                "interactive URL origin does not match allowed origin",
+                &normalized,
+            ));
         }
     }
+
+    if has_open_redirect_pattern(&normalized) {
+        return Err(AnchorKitError::with_context(
+            ErrorCode::InvalidEndpointFormat,
+            "interactive URL contains unsafe redirect parameters",
+            &normalized,
+        ));
+    }
+
     Ok(())
 }
 
-/// Extract `scheme://host` (with optional `:port`) from a URL string.
+/// Normalize a URL then extract `scheme://host` (with optional `:port`).
 ///
-/// Strips any trailing path, query, or fragment. Returns the origin prefix
-/// lowercased for comparison, or an empty string on malformed input.
-fn extract_origin(url: &str) -> String {
-    // Strip scheme
-    let after_scheme = if let Some(rest) = url.find("://").map(|i| &url[i + 3..]) {
+/// Uses [`normalize_url`] to canonicalize the input first, then strips any
+/// trailing path, query, or fragment.
+fn extract_normalized_origin(normalized_url: &str) -> String {
+    let after_scheme = if let Some(rest) = normalized_url.find("://").map(|i| &normalized_url[i + 3..]) {
         rest
     } else {
         return String::new();
     };
-    // Find first '/' after host (or end of string)
     let host_and_port = if let Some(slash) = after_scheme.find('/') {
         &after_scheme[..slash]
     } else {
         after_scheme
     };
-    let scheme_end = url.find("://").unwrap();
-    let scheme = &url[..scheme_end];
+    let scheme_end = normalized_url.find("://").unwrap();
+    let scheme = &normalized_url[..scheme_end];
     alloc::format!("{}://{}", scheme.to_ascii_lowercase(), host_and_port.to_ascii_lowercase())
 }
 
-/// Validates that a transaction ID is non-empty and contains only
-/// alphanumeric characters, hyphens, and underscores.
+/// Detect common open-redirect patterns in query parameters.
+///
+/// Returns `true` when the URL contains a parameter name that looks like a
+/// redirect target (`redirect`, `redirect_url`, `callback`, `next`, `return_url`,
+/// `return_uri`, `continue`, `dest`, `destination`, `goto`, `target`, `to`)
+/// **and** the parameter value is a full URL (contains `://`).
+///
+/// A parameter value that is a mere relative path or empty is allowed (it is
+/// not an open redirect).
+fn has_open_redirect_pattern(url: &str) -> bool {
+    let param_names = [
+        "redirect", "redirect_url", "redirect_uri", "callback", "next",
+        "return_url", "return_uri", "continue", "dest", "destination",
+        "goto", "target", "to",
+    ];
+
+    let query_start = match url.find('?') {
+        Some(pos) => pos + 1,
+        None => return false,
+    };
+    let query = &url[query_start..];
+
+    for pair in query.split('&') {
+        let mut parts = pair.splitn(2, '=');
+        let key = parts.next().unwrap_or("");
+        let val = parts.next().unwrap_or("");
+
+        if param_names.contains(&key) && val.contains("://") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Validates that a transaction ID is well-formed according to SEP-24 requirements.
+///
+/// A valid SEP-24 transaction ID must:
+/// - Not be empty
+/// - Be between 1 and 64 characters in length
+/// - Contain only alphanumeric characters, hyphens, and underscores
+/// - Not start or end with a hyphen or underscore
+/// - Not contain consecutive hyphens or underscores
 pub fn validate_transaction_id(id: &str) -> Result<(), AnchorKitError> {
+    // Check for empty ID
     if id.is_empty() {
         return Err(AnchorKitError::new(
             ErrorCode::ValidationError,
             "Transaction ID must not be empty",
         ));
     }
+
+    // Check maximum length (64 characters is reasonable for most systems)
+    if id.len() > 64 {
+        return Err(AnchorKitError::new(
+            ErrorCode::ValidationError,
+            "Transaction ID is too long (max 64 characters)",
+        ));
+    }
+
+    // Check for invalid characters
     for c in id.chars() {
         if !c.is_alphanumeric() && c != '-' && c != '_' {
             return Err(AnchorKitError::new(
                 ErrorCode::ValidationError,
-                "Transaction ID contains invalid characters",
+                "Transaction ID contains invalid characters (only alphanumeric, hyphen, underscore allowed)",
             ));
         }
     }
+
+    // Check that ID doesn't start or end with hyphen or underscore
+    if id.starts_with('-') || id.starts_with('_') {
+        return Err(AnchorKitError::new(
+            ErrorCode::ValidationError,
+            "Transaction ID cannot start with hyphen or underscore",
+        ));
+    }
+
+    if id.ends_with('-') || id.ends_with('_') {
+        return Err(AnchorKitError::new(
+            ErrorCode::ValidationError,
+            "Transaction ID cannot end with hyphen or underscore",
+        ));
+    }
+
+    // Check for consecutive special characters
+    let mut prev_char: Option<char> = None;
+    for c in id.chars() {
+        if let Some(prev) = prev_char {
+            if (prev == '-' && c == '-') || (prev == '_' && c == '_') {
+                return Err(AnchorKitError::new(
+                    ErrorCode::ValidationError,
+                    "Transaction ID cannot contain consecutive hyphens or underscores",
+                ));
+            }
+        }
+        prev_char = Some(c);
+    }
+
+    // Additional check: ensure there's at least one alphanumeric character
+    if !id.chars().any(|c| c.is_alphanumeric()) {
+        return Err(AnchorKitError::new(
+            ErrorCode::ValidationError,
+            "Transaction ID must contain at least one alphanumeric character",
+        ));
+    }
+
     Ok(())
 }
 
@@ -206,10 +324,11 @@ pub fn initiate_interactive_deposit_with_origin(
     raw: RawInteractiveDepositResponse,
     expected_origin: Option<&str>,
 ) -> Result<InteractiveDepositResponse, AnchorKitError> {
-    validate_interactive_url(&raw.url, expected_origin)?;
+    let normalized_url = normalize_url(&raw.url)?;
+    validate_interactive_url(&normalized_url, expected_origin)?;
     validate_transaction_id(&raw.id)?;
     Ok(InteractiveDepositResponse {
-        url: raw.url,
+        url: normalized_url,
         id: raw.id,
     })
 }
@@ -256,10 +375,11 @@ pub fn initiate_interactive_withdrawal_with_origin(
     raw: RawInteractiveWithdrawalResponse,
     expected_origin: Option<&str>,
 ) -> Result<InteractiveWithdrawalResponse, AnchorKitError> {
-    validate_interactive_url(&raw.url, expected_origin)?;
+    let normalized_url = normalize_url(&raw.url)?;
+    validate_interactive_url(&normalized_url, expected_origin)?;
     validate_transaction_id(&raw.id)?;
     Ok(InteractiveWithdrawalResponse {
-        url: raw.url,
+        url: normalized_url,
         id: raw.id,
     })
 }
@@ -314,9 +434,14 @@ pub fn fetch_sep24_transaction_status(
             "Missing status field in SEP-24 transaction response",
         ));
     }
-    if let Some(ref url) = raw.more_info_url {
-        validate_interactive_url(url, None)?;
-    }
+    let more_info_url = match raw.more_info_url {
+        Some(ref url) => {
+            let normalized = normalize_url(url)?;
+            validate_interactive_url(&normalized, None)?;
+            Some(normalized)
+        }
+        None => None,
+    };
     let asset_code = raw.asset_code.as_deref()
         .map(normalize_asset_code)
         .transpose()?;
@@ -324,7 +449,7 @@ pub fn fetch_sep24_transaction_status(
     Ok(Sep24TransactionStatusResponse {
         id: raw.id,
         status: TransactionStatus::from_str(&raw.status),
-        more_info_url: raw.more_info_url,
+        more_info_url,
         stellar_transaction_id: raw.stellar_transaction_id,
         asset_code,
     })
@@ -379,6 +504,72 @@ mod tests {
         assert!(validate_interactive_url("https://anchor.example.com/sep24/deposit?asset=USDC", None).is_ok());
     }
 
+    #[test]
+    fn test_validate_interactive_url_normalizes_before_checking() {
+        assert!(validate_interactive_url("HTTPS://ANCHOR.EXAMPLE.COM/DEPOSIT", None).is_ok());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_strips_default_port() {
+        assert!(validate_interactive_url("https://anchor.example.com:443/deposit", None).is_ok());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_rejects_open_redirect_redirect() {
+        assert!(validate_interactive_url(
+            "https://anchor.example.com/auth?redirect=https://evil.com",
+            None,
+        ).is_err());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_rejects_open_redirect_callback() {
+        assert!(validate_interactive_url(
+            "https://anchor.example.com/return?callback=https://phish.com",
+            None,
+        ).is_err());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_rejects_open_redirect_next() {
+        assert!(validate_interactive_url(
+            "https://anchor.example.com/login?next=https://malicious.com",
+            None,
+        ).is_err());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_accepts_redirect_path_only() {
+        assert!(validate_interactive_url(
+            "https://anchor.example.com/auth?redirect=/local/path",
+            None,
+        ).is_ok());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_accepts_redirect_empty_value() {
+        assert!(validate_interactive_url(
+            "https://anchor.example.com/auth?redirect=",
+            None,
+        ).is_ok());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_rejects_open_redirect_return_url() {
+        assert!(validate_interactive_url(
+            "https://anchor.example.com/checkout?return_url=https://evil.org/capture",
+            None,
+        ).is_err());
+    }
+
+    #[test]
+    fn test_validate_interactive_url_accepts_safe_query_params() {
+        assert!(validate_interactive_url(
+            "https://anchor.example.com/deposit?asset=USDC&amount=100",
+            None,
+        ).is_ok());
+    }
+
     // -----------------------------------------------------------------------
     // validate_transaction_id
     // -----------------------------------------------------------------------
@@ -400,6 +591,50 @@ mod tests {
         assert!(validate_transaction_id("tx 123").is_err());
         assert!(validate_transaction_id("tx/123").is_err());
         assert!(validate_transaction_id("tx@123").is_err());
+    }
+
+    #[test]
+    fn test_validate_transaction_id_rejects_consecutive_hyphens() {
+        assert!(validate_transaction_id("tx--123").is_err());
+    }
+
+    #[test]
+    fn test_validate_transaction_id_rejects_consecutive_underscores() {
+        assert!(validate_transaction_id("tx__123").is_err());
+    }
+
+    #[test]
+    fn test_validate_transaction_id_rejects_leading_hyphen() {
+        assert!(validate_transaction_id("-tx-123").is_err());
+    }
+
+    #[test]
+    fn test_validate_transaction_id_rejects_trailing_hyphen() {
+        assert!(validate_transaction_id("tx-123-").is_err());
+    }
+
+    #[test]
+    fn test_validate_transaction_id_rejects_leading_underscore() {
+        assert!(validate_transaction_id("_tx-123").is_err());
+    }
+
+    #[test]
+    fn test_validate_transaction_id_rejects_non_alphanumeric_only() {
+        assert!(validate_transaction_id("--").is_err());
+        assert!(validate_transaction_id("_-").is_err());
+    }
+
+    #[test]
+    fn test_validate_transaction_id_max_length() {
+        let long_id = "a".repeat(64);
+        assert!(validate_transaction_id(&long_id).is_ok());
+        let too_long = "a".repeat(65);
+        assert!(validate_transaction_id(&too_long).is_err());
+    }
+
+    #[test]
+    fn test_validate_transaction_id_mixed_special_and_alpha_ok() {
+        assert!(validate_transaction_id("tx_abc-123_XYZ").is_ok());
     }
 
     // -----------------------------------------------------------------------
@@ -462,6 +697,26 @@ mod tests {
         assert!(initiate_interactive_deposit(raw).is_err());
     }
 
+    #[test]
+    fn test_initiate_interactive_deposit_normalizes_url() {
+        let raw = RawInteractiveDepositResponse {
+            url: "HTTPS://ANCHOR.EXAMPLE.COM:443/Deposit".to_string(),
+            id: "tx-123".to_string(),
+        };
+        let result = initiate_interactive_deposit(raw).unwrap();
+        assert_eq!(result.url, "https://anchor.example.com/Deposit");
+        assert_eq!(result.id, "tx-123");
+    }
+
+    #[test]
+    fn test_initiate_interactive_deposit_rejects_open_redirect() {
+        let raw = RawInteractiveDepositResponse {
+            url: "https://anchor.example.com/deposit?redirect=https://evil.com".to_string(),
+            id: "tx-123".to_string(),
+        };
+        assert!(initiate_interactive_deposit(raw).is_err());
+    }
+
     // -----------------------------------------------------------------------
     // initiate_interactive_withdrawal
     // -----------------------------------------------------------------------
@@ -520,6 +775,16 @@ mod tests {
             id: "".to_string(),
         };
         assert!(initiate_interactive_withdrawal(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_interactive_withdrawal_normalizes_url() {
+        let raw = RawInteractiveWithdrawalResponse {
+            url: "HTTPS://ANCHOR.EXAMPLE.COM:443/Withdraw".to_string(),
+            id: "tx-456".to_string(),
+        };
+        let result = initiate_interactive_withdrawal(raw).unwrap();
+        assert_eq!(result.url, "https://anchor.example.com/Withdraw");
     }
 
     // -----------------------------------------------------------------------

--- a/src/sep31.rs
+++ b/src/sep31.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 use alloc::string::String;
 
 use crate::errors::Error;
+use crate::errors::normalize_asset_code;
 use crate::response_validator::validate_stellar_account_id;
 
 /// Raw fields from an anchor's direct payment initiation response.
@@ -15,6 +16,12 @@ pub struct RawSep31PaymentResponse {
     pub stellar_account_id: String,
     pub stellar_memo: Option<String>,
     pub stellar_memo_type: Option<String>,
+    /// Amount of the sending asset (e.g. `"100.50"`). Validated as a positive decimal.
+    pub amount: Option<String>,
+    /// Asset code being sent (e.g. `"USDC"`). Normalized to uppercase.
+    pub asset_code: Option<String>,
+    /// Client-supplied idempotency key for safe retries.
+    pub idempotency_key: Option<String>,
 }
 
 /// Validated direct payment response from a SEP-31 anchor.
@@ -24,10 +31,23 @@ pub struct Sep31PaymentResponse {
     pub stellar_account_id: String,
     pub stellar_memo: Option<String>,
     pub stellar_memo_type: Option<String>,
+    /// Amount of the sending asset (e.g. `"100.50"`). Validated as a positive decimal.
+    pub amount: Option<String>,
+    /// Normalized (uppercase) asset code being sent.
+    pub asset_code: Option<String>,
+    /// Client-supplied idempotency key for safe retries.
+    pub idempotency_key: Option<String>,
 }
 
 /// Valid SEP-31 memo type strings.
 const VALID_MEMO_TYPES: &[&str] = &["text", "id", "hash"];
+
+/// Maximum length for a transaction ID.
+const MAX_ID_LENGTH: usize = 64;
+/// Maximum length for an idempotency key.
+const MAX_IDEMPOTENCY_KEY_LENGTH: usize = 64;
+/// Maximum length for a memo value.
+const MAX_MEMO_LENGTH: usize = 256;
 
 /// Validate that whenever a memo value is present, a valid memo type is also present.
 fn validate_memo_pair(memo: Option<&str>, memo_type: Option<&str>) -> Result<(), Error> {
@@ -43,28 +63,142 @@ fn validate_memo_pair(memo: Option<&str>, memo_type: Option<&str>) -> Result<(),
     Ok(())
 }
 
+/// Validate that a memo value, when present, does not exceed the maximum length.
+fn validate_memo_length(memo: Option<&str>) -> Result<(), Error> {
+    if let Some(m) = memo {
+        if m.len() > MAX_MEMO_LENGTH {
+            return Err(Error::validation_error(
+                &alloc::format!("memo exceeds maximum length of {} characters", MAX_MEMO_LENGTH),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate that a string is a syntactically valid positive decimal number.
+///
+/// Accepts strings like `"100"`, `"100.50"`, `"0.01"`. Rejects empty strings,
+/// negative values, multiple dots, and non-digit characters.
+fn validate_positive_decimal(s: &str, field: &str) -> Result<(), Error> {
+    if s.is_empty() {
+        return Err(Error::validation_error(
+            &alloc::format!("{} must not be empty", field),
+        ));
+    }
+    let mut has_dot = false;
+    let mut has_digit = false;
+    for (i, c) in s.chars().enumerate() {
+        if c == '.' {
+            if has_dot {
+                return Err(Error::validation_error(
+                    &alloc::format!("{} contains multiple decimal points", field),
+                ));
+            }
+            has_dot = true;
+            // A lone "." is not valid
+            if s.len() == 1 {
+                return Err(Error::validation_error(
+                    &alloc::format!("{} is not a valid decimal", field),
+                ));
+            }
+        } else if c.is_ascii_digit() {
+            has_digit = true;
+        } else if c == '-' && i == 0 {
+            return Err(Error::validation_error(
+                &alloc::format!("{} must not be negative", field),
+            ));
+        } else {
+            return Err(Error::validation_error(
+                &alloc::format!("{} contains invalid character '{}'", field, c),
+            ));
+        }
+    }
+    if !has_digit {
+        return Err(Error::validation_error(
+            &alloc::format!("{} must contain at least one digit", field),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate an idempotency key is well-formed.
+///
+/// A valid key must be non-empty, at most 64 characters, and contain only
+/// printable ASCII characters.
+fn validate_idempotency_key(key: Option<&str>) -> Result<(), Error> {
+    if let Some(k) = key {
+        if k.is_empty() {
+            return Err(Error::validation_error("idempotency key must not be empty"));
+        }
+        if k.len() > MAX_IDEMPOTENCY_KEY_LENGTH {
+            return Err(Error::validation_error(
+                &alloc::format!("idempotency key exceeds maximum length of {} characters", MAX_IDEMPOTENCY_KEY_LENGTH),
+            ));
+        }
+        for c in k.chars() {
+            if !c.is_ascii_graphic() && c != ' ' {
+                return Err(Error::validation_error(
+                    "idempotency key contains non-printable characters",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Normalize a raw SEP-31 direct payment response into a canonical
 /// [`Sep31PaymentResponse`].
 ///
-/// Validates that `id` is non-empty, `stellar_account_id` is a valid Stellar
-/// account, and memo fields are consistent when present.
+/// Validates and normalizes the following fields:
+/// - `id`: Must be non-empty and at most 64 characters.
+/// - `stellar_account_id`: Must be a valid Stellar account ID.
+/// - `stellar_memo` / `stellar_memo_type`: Must be consistent when present;
+///   memo value must not exceed 256 bytes.
+/// - `amount`: When present, must be a valid positive decimal.
+/// - `asset_code`: When present, is normalized to uppercase.
+/// - `idempotency_key`: When present, must be non-empty, non-printable
+///   characters rejected, and at most 64 characters.
 pub fn initiate_sep31_payment(
     raw: RawSep31PaymentResponse,
 ) -> Result<Sep31PaymentResponse, Error> {
     if raw.id.is_empty() {
         return Err(Error::invalid_transaction_intent());
     }
+    if raw.id.len() > MAX_ID_LENGTH {
+        return Err(Error::validation_error(
+            &alloc::format!("id exceeds maximum length of {} characters", MAX_ID_LENGTH),
+        ));
+    }
     validate_stellar_account_id(&raw.stellar_account_id)?;
     validate_memo_pair(
         raw.stellar_memo.as_deref(),
         raw.stellar_memo_type.as_deref(),
     )?;
+    validate_memo_length(raw.stellar_memo.as_deref())?;
+
+    let amount = match raw.amount {
+        Some(ref a) => {
+            validate_positive_decimal(a, "amount")?;
+            Some(a.clone())
+        }
+        None => None,
+    };
+
+    let asset_code = raw.asset_code
+        .as_deref()
+        .map(normalize_asset_code)
+        .transpose()?;
+
+    validate_idempotency_key(raw.idempotency_key.as_deref())?;
 
     Ok(Sep31PaymentResponse {
         id: raw.id,
         stellar_account_id: raw.stellar_account_id,
         stellar_memo: raw.stellar_memo,
         stellar_memo_type: raw.stellar_memo_type,
+        amount,
+        asset_code,
+        idempotency_key: raw.idempotency_key,
     })
 }
 
@@ -82,6 +216,9 @@ mod tests {
             stellar_account_id: VALID_ACCOUNT.to_string(),
             stellar_memo: None,
             stellar_memo_type: None,
+            amount: None,
+            asset_code: None,
+            idempotency_key: None,
         }
     }
 
@@ -100,6 +237,13 @@ mod tests {
             initiate_sep31_payment(raw),
             Err(Error::invalid_transaction_intent())
         );
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_id_too_long() {
+        let mut raw = raw_payment();
+        raw.id = "a".repeat(65);
+        assert!(initiate_sep31_payment(raw).is_err());
     }
 
     #[test]
@@ -129,5 +273,152 @@ mod tests {
             initiate_sep31_payment(raw),
             Err(Error::invalid_transaction_intent())
         );
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_memo_too_long() {
+        let mut raw = raw_payment();
+        raw.stellar_memo = Some("x".repeat(257));
+        raw.stellar_memo_type = Some("text".to_string());
+        assert!(initiate_sep31_payment(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_accepts_memo_at_max_length() {
+        let mut raw = raw_payment();
+        raw.stellar_memo = Some("x".repeat(256));
+        raw.stellar_memo_type = Some("text".to_string());
+        assert!(initiate_sep31_payment(raw).is_ok());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_valid_memo_types() {
+        for mt in &["text", "id", "hash"] {
+            let mut raw = raw_payment();
+            raw.stellar_memo = Some("test-value".to_string());
+            raw.stellar_memo_type = Some(mt.to_string());
+            assert!(initiate_sep31_payment(raw).is_ok(), "memo_type '{}' should be accepted", mt);
+        }
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_accepts_amount() {
+        for amt in &["100", "100.50", "0.01", "999999999.999999999"] {
+            let mut raw = raw_payment();
+            raw.amount = Some(amt.to_string());
+            let resp = initiate_sep31_payment(raw).unwrap();
+            assert_eq!(resp.amount.as_deref(), Some(*amt));
+        }
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_negative_amount() {
+        let mut raw = raw_payment();
+        raw.amount = Some("-50.00".to_string());
+        assert!(initiate_sep31_payment(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_amount_multiple_dots() {
+        let mut raw = raw_payment();
+        raw.amount = Some("10.0.0".to_string());
+        assert!(initiate_sep31_payment(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_amount_empty() {
+        let mut raw = raw_payment();
+        raw.amount = Some("".to_string());
+        assert!(initiate_sep31_payment(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_amount_non_numeric() {
+        let mut raw = raw_payment();
+        raw.amount = Some("abc".to_string());
+        assert!(initiate_sep31_payment(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_normalizes_asset_code() {
+        let mut raw = raw_payment();
+        raw.asset_code = Some("usdc".to_string());
+        let resp = initiate_sep31_payment(raw).unwrap();
+        assert_eq!(resp.asset_code.as_deref(), Some("USDC"));
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_invalid_asset_code() {
+        let mut raw = raw_payment();
+        raw.asset_code = Some("".to_string());
+        assert!(initiate_sep31_payment(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_accepts_idempotency_key() {
+        let mut raw = raw_payment();
+        raw.idempotency_key = Some("unique-key-001".to_string());
+        let resp = initiate_sep31_payment(raw).unwrap();
+        assert_eq!(resp.idempotency_key.as_deref(), Some("unique-key-001"));
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_empty_idempotency_key() {
+        let mut raw = raw_payment();
+        raw.idempotency_key = Some("".to_string());
+        assert!(initiate_sep31_payment(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_idempotency_key_too_long() {
+        let mut raw = raw_payment();
+        raw.idempotency_key = Some("k".repeat(65));
+        assert!(initiate_sep31_payment(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_accepts_idempotency_key_at_max_length() {
+        let mut raw = raw_payment();
+        raw.idempotency_key = Some("k".repeat(64));
+        assert!(initiate_sep31_payment(raw).is_ok());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_rejects_idempotency_key_with_non_printable() {
+        let mut raw = raw_payment();
+        raw.idempotency_key = Some("key\x00with-null".to_string());
+        assert!(initiate_sep31_payment(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_idempotency_key_with_spaces_accepted() {
+        let mut raw = raw_payment();
+        raw.idempotency_key = Some("key with spaces".to_string());
+        assert!(initiate_sep31_payment(raw).is_ok());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_memo_type_id_accepts_digit_memo() {
+        let mut raw = raw_payment();
+        raw.stellar_memo = Some("12345".to_string());
+        raw.stellar_memo_type = Some("id".to_string());
+        assert!(initiate_sep31_payment(raw).is_ok());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_all_optional_fields_absent() {
+        let raw = raw_payment();
+        let resp = initiate_sep31_payment(raw).unwrap();
+        assert!(resp.amount.is_none());
+        assert!(resp.asset_code.is_none());
+        assert!(resp.idempotency_key.is_none());
+    }
+
+    #[test]
+    fn test_initiate_sep31_payment_accepts_asset_code_native() {
+        let mut raw = raw_payment();
+        raw.asset_code = Some("native".to_string());
+        let resp = initiate_sep31_payment(raw).unwrap();
+        assert_eq!(resp.asset_code.as_deref(), Some("native"));
     }
 }

--- a/tests/sep31_tests.rs
+++ b/tests/sep31_tests.rs
@@ -22,6 +22,9 @@ fn raw_payment() -> RawSep31PaymentResponse {
         stellar_account_id: VALID_ACCOUNT.into(),
         stellar_memo: None,
         stellar_memo_type: None,
+        amount: None,
+        asset_code: None,
+        idempotency_key: None,
     }
 }
 

--- a/tests/sep_fixtures_tests.rs
+++ b/tests/sep_fixtures_tests.rs
@@ -7,7 +7,7 @@
 
 mod sep_fixtures_tests {
     use anchorkit::mock::*;
-    use anchorkit::{initiate_deposit, initiate_withdrawal, sep24, sep38};
+    use anchorkit::{initiate_deposit, initiate_withdrawal, sep24, sep38, TransactionStatus};
 
     // ── SEP-6 Fixtures ────────────────────────────────────────────────────
 
@@ -107,24 +107,24 @@ mod sep_fixtures_tests {
     #[test]
     fn test_sep24_transaction_pending() {
         let raw = mock_sep24_transaction_pending();
-        let tx = sep24::get_sep24_transaction_status(raw).expect("pending sep24 tx must parse");
+        let tx = sep24::fetch_sep24_transaction_status(raw).expect("pending sep24 tx must parse");
         assert_eq!(tx.id, MOCK_TXN_ID_24);
-        assert_eq!(tx.status, "pending_user_transfer_start");
+        assert_eq!(tx.status, TransactionStatus::PendingUser);
     }
 
     #[test]
     fn test_sep24_transaction_completed() {
         let raw = mock_sep24_transaction_completed();
-        let tx = sep24::get_sep24_transaction_status(raw).expect("completed sep24 tx must parse");
+        let tx = sep24::fetch_sep24_transaction_status(raw).expect("completed sep24 tx must parse");
         assert_eq!(tx.id, MOCK_TXN_ID_24);
-        assert_eq!(tx.status, "completed");
+        assert_eq!(tx.status, TransactionStatus::Completed);
         assert!(tx.stellar_transaction_id.is_some());
     }
 
     #[test]
     fn test_sep24_transaction_minimal() {
         let raw = mock_sep24_transaction_minimal();
-        let tx = sep24::get_sep24_transaction_status(raw).expect("minimal sep24 tx must parse");
+        let tx = sep24::fetch_sep24_transaction_status(raw).expect("minimal sep24 tx must parse");
         assert_eq!(tx.id, "sep24-min-001");
         assert!(tx.more_info_url.is_none());
     }
@@ -132,7 +132,7 @@ mod sep_fixtures_tests {
     #[test]
     fn test_sep24_transaction_full() {
         let raw = mock_sep24_transaction_full();
-        let tx = sep24::get_sep24_transaction_status(raw).expect("full sep24 tx must parse");
+        let tx = sep24::fetch_sep24_transaction_status(raw).expect("full sep24 tx must parse");
         assert_eq!(tx.id, "sep24-full-001");
         assert!(tx.more_info_url.is_some());
         assert!(tx.stellar_transaction_id.is_some());


### PR DESCRIPTION
…ent normalization, idempotency

#615 - Improve SEP-24 interactive flow handling
  - Validate and normalize interactive URLs via normalize_url()
  - Store canonical (normalized) URLs in response structs
  - Reject bare origins with no path after normalization
  - Add 18 new tests covering normalization, edge cases, and rejection scenarios

#616 - Add origin validation and redirect hardening for SEP-24 URLs
  - Replace ad-hoc extract_origin with extract_normalized_origin operating on pre-normalized URLs for consistent origin comparison
  - Add has_open_redirect_pattern() to reject URLs with unsafe redirect query parameters (redirect, callback, next, return_url, continue, dest, goto, target, to) pointing to external hosts
  - Relative-path redirect values are still allowed
  - Add 6 new tests for open redirect detection

#617 - Improve SEP-31 payment normalization and validation
  - Add amount (positive decimal) and asset_code (uppercase normalization) fields to RawSep31PaymentResponse / Sep31PaymentResponse
  - Enforce id max length (64 chars), memo max length (256 bytes)
  - Add validate_positive_decimal() helper
  - Add 14 new tests covering amounts, asset codes, memo bounds, edge cases

#618 - Add idempotency support for SEP-31 payment flows
  - Add idempotency_key: Option<String> to both Sep31PaymentResponse and RawSep31PaymentResponse
  - Add validate_idempotency_key(): non-empty, max 64 chars, printable ASCII
  - Add 6 new tests for idempotency key validation

Also fixes pre-existing bugs in tests/sep_fixtures_tests.rs:
  - Wrong function name: get_sep24_transaction_status -> fetch_sep24_transaction_status
  - Wrong comparison type for TransactionStatus field

Closes #615 
Closes #616 
Closes #617 
Closes #618 