### PR TITLE
feat: configurable retry strategies, streaming monitor state tracking…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,7 @@ pub use errors::normalize_asset_code;
 pub use errors::Error;
 pub use rate_limiter::{RateLimiter, RateLimitConfig, RateLimitState};
 pub use retry::{retry_with_backoff, is_retryable, RetryConfig, JitterSource, LedgerJitterSource, MockJitterSource};
+pub use retry::{BackoffStrategy, JitterPolicy};
 pub use deterministic_hash::{compute_payload_hash, verify_payload_hash};
 pub use contract::{AnchorKitContract, AnchorTomlProvenance, EndpointUpdated, CacheConfig};
 pub use contract::{AttestorRevocationRecord};
@@ -244,7 +245,7 @@ pub use transaction_state_tracker::{BudgetStatus, BudgetAlert};
 #[cfg(not(feature = "wasm"))]
 pub use sep38::{CrossAnchorFeeAggregator, FeeAnomalyReport};
 #[cfg(not(feature = "wasm"))]
-pub use streaming_monitor::{StreamingTransactionMonitor, TransactionStatusUpdate};
+pub use streaming_monitor::{StreamingTransactionMonitor, TransactionStatusUpdate, StateTransition, BackpressureConfig};
 
 #[cfg(all(test, not(feature = "wasm")))]
 mod stellar_toml_tests;

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,9 +1,50 @@
 use alloc::vec::Vec;
 
+/// The backoff strategy to use when computing retry delays.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BackoffStrategy {
+    /// Classic exponential backoff: `base * multiplier^attempt` (capped at max).
+    Exponential,
+    /// Linear backoff: `base * (attempt + 1)` (capped at max).
+    Linear,
+    /// Constant backoff: always `base_delay_ms` (capped at max).
+    Constant,
+    /// No retry — the operation is attempted exactly once regardless of
+    /// `max_attempts`. Equivalent to setting `max_attempts = 1`.
+    NoRetry,
+}
+
+impl Default for BackoffStrategy {
+    fn default() -> Self {
+        BackoffStrategy::Exponential
+    }
+}
+
+/// The jitter policy applied to retry delays.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum JitterPolicy {
+    /// Full jitter in `[0, base_delay_ms / 2]` added to the computed delay
+    /// (the current behaviour). Provides good spread for thundering-herd prevention.
+    Full,
+    /// Equal jitter: delay is adjusted symmetrically by up to ±25% of the
+    /// computed delay, producing less variance than Full.
+    Equal,
+    /// No jitter — every retry at the same attempt level waits the exact same
+    /// amount of time. Useful for deterministic testing or when the caller
+    /// manages jitter externally.
+    None,
+}
+
+impl Default for JitterPolicy {
+    fn default() -> Self {
+        JitterPolicy::Full
+    }
+}
+
 /// Retry configuration for off-chain anchor requests.
 ///
 /// Controls how many times a failing operation is retried and how long to wait
-/// between attempts. The delay grows exponentially and is capped at
+/// between attempts. The delay grows according to `strategy` and is capped at
 /// `max_delay_ms` to prevent unbounded waits.
 ///
 /// # Examples
@@ -29,6 +70,10 @@ pub struct RetryConfig {
     pub max_delay_ms: u64,
     /// Multiplier applied to the delay after each failed attempt.
     pub backoff_multiplier: u32,
+    /// Backoff strategy governing how delays grow between attempts.
+    pub strategy: BackoffStrategy,
+    /// Jitter policy for adding variance to computed delays.
+    pub jitter_policy: JitterPolicy,
 }
 
 impl Default for RetryConfig {
@@ -38,6 +83,8 @@ impl Default for RetryConfig {
             base_delay_ms: 100,
             max_delay_ms: 5_000,
             backoff_multiplier: 2,
+            strategy: BackoffStrategy::default(),
+            jitter_policy: JitterPolicy::default(),
         }
     }
 }
@@ -55,7 +102,8 @@ impl RetryConfig {
     ///
     /// # Returns
     ///
-    /// A new [`RetryConfig`].
+    /// A new [`RetryConfig`] with default [`BackoffStrategy::Exponential`] and
+    /// [`JitterPolicy::Full`].
     ///
     /// # Examples
     ///
@@ -77,6 +125,27 @@ impl RetryConfig {
             base_delay_ms,
             max_delay_ms,
             backoff_multiplier,
+            strategy: BackoffStrategy::default(),
+            jitter_policy: JitterPolicy::default(),
+        }
+    }
+
+    /// Full configuration constructor including strategy and jitter policy.
+    pub fn with_strategy(
+        max_attempts: u32,
+        base_delay_ms: u64,
+        max_delay_ms: u64,
+        backoff_multiplier: u32,
+        strategy: BackoffStrategy,
+        jitter_policy: JitterPolicy,
+    ) -> Self {
+        RetryConfig {
+            max_attempts,
+            base_delay_ms,
+            max_delay_ms,
+            backoff_multiplier,
+            strategy,
+            jitter_policy,
         }
     }
 
@@ -87,6 +156,8 @@ impl RetryConfig {
             base_delay_ms: 50,
             max_delay_ms: 2_000,
             backoff_multiplier: 2,
+            strategy: BackoffStrategy::default(),
+            jitter_policy: JitterPolicy::default(),
         }
     }
 
@@ -97,25 +168,90 @@ impl RetryConfig {
             base_delay_ms: 500,
             max_delay_ms: 10_000,
             backoff_multiplier: 2,
+            strategy: BackoffStrategy::default(),
+            jitter_policy: JitterPolicy::default(),
+        }
+    }
+
+    /// Linear strategy: 6 attempts, 100 ms base, 5 s max — for predictable delays.
+    pub fn linear() -> Self {
+        RetryConfig {
+            max_attempts: 6,
+            base_delay_ms: 100,
+            max_delay_ms: 5_000,
+            backoff_multiplier: 2,
+            strategy: BackoffStrategy::Linear,
+            jitter_policy: JitterPolicy::Full,
+        }
+    }
+
+    /// Constant strategy: 5 attempts, 500 ms fixed delay — for steady retries.
+    pub fn constant() -> Self {
+        RetryConfig {
+            max_attempts: 5,
+            base_delay_ms: 500,
+            max_delay_ms: 500,
+            backoff_multiplier: 1,
+            strategy: BackoffStrategy::Constant,
+            jitter_policy: JitterPolicy::None,
+        }
+    }
+
+    /// Set the backoff strategy on an existing config.
+    pub fn with_backoff_strategy(mut self, strategy: BackoffStrategy) -> Self {
+        self.strategy = strategy;
+        self
+    }
+
+    /// Set the jitter policy on an existing config.
+    pub fn with_jitter_policy(mut self, jitter_policy: JitterPolicy) -> Self {
+        self.jitter_policy = jitter_policy;
+        self
+    }
+
+    /// Compute the base delay (ms) for a given attempt index (0-based) using
+    /// the configured [`BackoffStrategy`], before jitter is applied.
+    fn base_delay_for_attempt(&self, attempt: u32) -> u64 {
+        match self.strategy {
+            BackoffStrategy::Exponential => {
+                let exp = (self.backoff_multiplier as u64).saturating_pow(attempt);
+                self.base_delay_ms.saturating_mul(exp).min(self.max_delay_ms)
+            }
+            BackoffStrategy::Linear => {
+                let factor = (attempt as u64).saturating_add(1);
+                self.base_delay_ms.saturating_mul(factor).min(self.max_delay_ms)
+            }
+            BackoffStrategy::Constant => self.base_delay_ms.min(self.max_delay_ms),
+            BackoffStrategy::NoRetry => 0,
         }
     }
 
     /// Compute the delay (ms) for a given attempt index (0-based), drawing
-    /// jitter from `jitter_source`.
+    /// jitter from `jitter_source` according to [`JitterPolicy`].
     ///
-    /// The exponential component is `min(base * multiplier^attempt, max_delay_ms)`.
-    /// Jitter is drawn from `[0, base_delay_ms / 2]` and added to that, then
-    /// the total is capped at `max_delay_ms` so the configured ceiling is never
+    /// The total is capped at `max_delay_ms` so the configured ceiling is never
     /// exceeded regardless of the jitter seed.
-    ///
-    /// `delay = min(min(base * multiplier^attempt, max) + jitter(0..=base/2), max)`
     pub fn delay_for_attempt(&self, attempt: u32, jitter_source: &mut impl JitterSource) -> u64 {
-        let exp = (self.backoff_multiplier as u64).saturating_pow(attempt);
-        let raw = self.base_delay_ms.saturating_mul(exp);
-        let capped = raw.min(self.max_delay_ms);
-        let jitter_bound = self.base_delay_ms / 2 + 1;
-        let jitter = if jitter_bound == 0 { 0 } else { jitter_source.next_seed() % jitter_bound };
-        capped.saturating_add(jitter).min(self.max_delay_ms)
+        let base = self.base_delay_for_attempt(attempt);
+        match self.jitter_policy {
+            JitterPolicy::Full => {
+                let jitter_bound = self.base_delay_ms / 2 + 1;
+                let jitter = if jitter_bound == 0 { 0 } else { jitter_source.next_seed() % jitter_bound };
+                base.saturating_add(jitter).min(self.max_delay_ms)
+            }
+            JitterPolicy::Equal => {
+                let half = base / 2;
+                let jitter_bound = if half == 0 { 1 } else { half };
+                let offset = jitter_source.next_seed() % jitter_bound;
+                let sign = (jitter_source.next_seed() % 2) as i64;
+                if sign == 0 {
+                    (base + offset).min(self.max_delay_ms)
+                } else {
+                    base.saturating_sub(offset).max(self.base_delay_ms.min(base))
+                }
+            }
+            JitterPolicy::None => base,
+        }
     }
 }
 
@@ -654,5 +790,178 @@ mod retry_tests {
             assert_eq!(config.delay_for_attempt(attempt as u32, &mut js), exp,
                 "attempt {attempt}: expected {exp}");
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #623 — configurable retry strategy tests
+    // -----------------------------------------------------------------------
+
+    /// Linear backoff: base * (attempt + 1)
+    #[test]
+    fn test_linear_backoff_strategy() {
+        let config = RetryConfig::with_strategy(5, 100, 10_000, 2, BackoffStrategy::Linear, JitterPolicy::None);
+        let mut js = MockJitterSource::new(vec![0]);
+        assert_eq!(config.delay_for_attempt(0, &mut js), 100);
+        assert_eq!(config.delay_for_attempt(1, &mut js), 200);
+        assert_eq!(config.delay_for_attempt(2, &mut js), 300);
+        assert_eq!(config.delay_for_attempt(3, &mut js), 400);
+    }
+
+    /// Constant backoff: always base_delay_ms.
+    #[test]
+    fn test_constant_backoff_strategy() {
+        let config = RetryConfig::with_strategy(5, 250, 10_000, 2, BackoffStrategy::Constant, JitterPolicy::None);
+        let mut js = MockJitterSource::new(vec![0]);
+        for i in 0..5 {
+            assert_eq!(config.delay_for_attempt(i, &mut js), 250);
+        }
+    }
+
+    /// NoRetry strategy always returns 0 delay.
+    #[test]
+    fn test_no_retry_strategy() {
+        let config = RetryConfig::with_strategy(5, 100, 10_000, 2, BackoffStrategy::NoRetry, JitterPolicy::None);
+        let mut js = MockJitterSource::new(vec![0]);
+        for i in 0..5 {
+            assert_eq!(config.delay_for_attempt(i, &mut js), 0);
+        }
+    }
+
+    /// Linear presets.
+    #[test]
+    fn test_linear_preset() {
+        let cfg = RetryConfig::linear();
+        assert_eq!(cfg.max_attempts, 6);
+        assert_eq!(cfg.base_delay_ms, 100);
+        assert_eq!(cfg.strategy, BackoffStrategy::Linear);
+    }
+
+    /// Constant preset.
+    #[test]
+    fn test_constant_preset() {
+        let cfg = RetryConfig::constant();
+        assert_eq!(cfg.max_attempts, 5);
+        assert_eq!(cfg.base_delay_ms, 500);
+        assert_eq!(cfg.max_delay_ms, 500);
+        assert_eq!(cfg.strategy, BackoffStrategy::Constant);
+        assert_eq!(cfg.jitter_policy, JitterPolicy::None);
+    }
+
+    /// with_backoff_strategy builder method.
+    #[test]
+    fn test_with_backoff_strategy_builder() {
+        let cfg = RetryConfig::default().with_backoff_strategy(BackoffStrategy::Linear);
+        assert_eq!(cfg.strategy, BackoffStrategy::Linear);
+    }
+
+    /// with_jitter_policy builder method.
+    #[test]
+    fn test_with_jitter_policy_builder() {
+        let cfg = RetryConfig::default().with_jitter_policy(JitterPolicy::None);
+        assert_eq!(cfg.jitter_policy, JitterPolicy::None);
+    }
+
+    /// NoJitter policy: delay is deterministic for a given attempt.
+    #[test]
+    fn test_no_jitter_policy() {
+        let config = RetryConfig::with_strategy(4, 100, 10_000, 2, BackoffStrategy::Exponential, JitterPolicy::None);
+        let mut js = MockJitterSource::new(vec![999]);
+        assert_eq!(config.delay_for_attempt(0, &mut js), 100);
+        assert_eq!(config.delay_for_attempt(1, &mut js), 200);
+        assert_eq!(config.delay_for_attempt(2, &mut js), 400);
+    }
+
+    /// FullJitter uses seed and base_delay_ms/2 bound.
+    #[test]
+    fn test_full_jitter_policy() {
+        let config = RetryConfig::with_strategy(3, 100, 10_000, 2, BackoffStrategy::Exponential, JitterPolicy::Full);
+        let mut js = MockJitterSource::new(vec![10]);
+        assert_eq!(config.delay_for_attempt(0, &mut js), 100 + 10);
+        let mut js = MockJitterSource::new(vec![20]);
+        assert_eq!(config.delay_for_attempt(1, &mut js), 200 + 20);
+    }
+
+    /// EqualJitter produces different results depending on sign bit.
+    #[test]
+    fn test_equal_jitter_policy() {
+        let config = RetryConfig::with_strategy(3, 100, 10_000, 2, BackoffStrategy::Exponential, JitterPolicy::Equal);
+        // seed 0 => offset = 0 % 50 = 0, sign seed 1 => 1 % 2 = 1 (subtract)
+        let mut js = MockJitterSource::new(vec![0, 1]);
+        let delay = config.delay_for_attempt(0, &mut js);
+        assert_eq!(delay, 100);
+
+        // seed 5 => offset = 5 % 50 = 5, sign seed 3 => 3 % 2 = 1 (subtract)
+        let mut js2 = MockJitterSource::new(vec![5, 3]);
+        let delay2 = config.delay_for_attempt(0, &mut js2);
+        assert_eq!(delay2, 100 - 5);
+    }
+
+    /// NoRetry in retry_with_backoff still produces exactly one attempt.
+    #[test]
+    fn test_no_retry_with_backoff() {
+        let config = RetryConfig::with_strategy(5, 100, 10_000, 2, BackoffStrategy::NoRetry, JitterPolicy::None);
+        let mut calls = 0u32;
+        let mut js = MockJitterSource::new(vec![0]);
+        let result = retry_with_backoff(
+            &config,
+            |_| { calls += 1; Err::<i32, _>(TestError::Transient) },
+            is_retryable_test,
+            |_| {},
+            &mut js,
+        );
+        assert_eq!(calls, 1);
+        assert!(result.is_err());
+    }
+
+    /// Strategy propagates through retry_with_backoff.
+    #[test]
+    fn test_linear_backoff_through_retry() {
+        let config = RetryConfig::with_strategy(4, 100, 10_000, 2, BackoffStrategy::Linear, JitterPolicy::None);
+        let mut recorded: Vec<u64> = Vec::new();
+        let mut js = MockJitterSource::new(vec![0]);
+
+        let _ = retry_with_backoff(
+            &config,
+            |_| Err::<i32, _>(TestError::Transient),
+            is_retryable_test,
+            |ms| recorded.push(ms),
+            &mut js,
+        );
+
+        assert_eq!(recorded.len(), 3);
+        assert_eq!(recorded[0], 100);
+        assert_eq!(recorded[1], 200);
+        assert_eq!(recorded[2], 300);
+    }
+
+    /// Linear cap at max_delay_ms.
+    #[test]
+    fn test_linear_backoff_capped_at_max() {
+        let config = RetryConfig::with_strategy(10, 1000, 3_000, 2, BackoffStrategy::Linear, JitterPolicy::None);
+        let mut js = MockJitterSource::new(vec![0]);
+        assert_eq!(config.delay_for_attempt(2, &mut js), 3_000);
+        assert_eq!(config.delay_for_attempt(5, &mut js), 3_000);
+    }
+
+    /// Constant backoff with jitter still applies jitter.
+    #[test]
+    fn test_constant_backoff_with_full_jitter() {
+        let config = RetryConfig::with_strategy(3, 500, 10_000, 2, BackoffStrategy::Constant, JitterPolicy::Full);
+        let mut js = MockJitterSource::new(vec![10, 20, 30]);
+        assert_eq!(config.delay_for_attempt(0, &mut js), 500 + 10);
+        assert_eq!(config.delay_for_attempt(1, &mut js), 500 + 20);
+        assert_eq!(config.delay_for_attempt(2, &mut js), 500 + 30);
+    }
+
+    /// BackoffStrategy default is Exponential.
+    #[test]
+    fn test_backoff_strategy_default() {
+        assert_eq!(BackoffStrategy::default(), BackoffStrategy::Exponential);
+    }
+
+    /// JitterPolicy default is Full.
+    #[test]
+    fn test_jitter_policy_default() {
+        assert_eq!(JitterPolicy::default(), JitterPolicy::Full);
     }
 }

--- a/src/streaming_monitor.rs
+++ b/src/streaming_monitor.rs
@@ -3,9 +3,22 @@
 //! [`StreamingTransactionMonitor`] polls a transaction's state at a configurable
 //! interval and emits [`TransactionStatusUpdate`] events for every state change.
 //! It stops automatically when the transaction reaches a terminal state.
+//!
+//! # State transitions
+//!
+//! Every state change is recorded as a [`StateTransition`] entry and can be
+//! retrieved via [`StreamingTransactionMonitor::get_transitions`].
+//!
+//! # Backpressure
+//!
+//! The monitor supports configurable backpressure via [`BackpressureConfig`]:
+//! - `max_queued_transitions` caps the number of retained transitions.
+//! - `coalesce_updates` collapses rapid duplicate state changes to reduce noise.
+//! - On overflow the oldest transitions are dropped (FIFO eviction).
 
 extern crate alloc;
 
+use alloc::vec::Vec;
 use crate::retry::{retry_with_backoff, LedgerJitterSource, RetryConfig};
 use crate::transaction_state_tracker::TransactionState;
 
@@ -44,9 +57,83 @@ pub enum TransactionStatusUpdate {
     Failed { reason: alloc::string::String },
 }
 
+// ── StateTransition ───────────────────────────────────────────────────────────
+
+/// A recorded state transition within the streaming monitor.
+///
+/// Every time the polled transaction moves from one [`TransactionState`] to
+/// another, a `StateTransition` entry is recorded and can be retrieved via
+/// [`StreamingTransactionMonitor::get_transitions`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct StateTransition {
+    /// The state the transaction moved from.
+    pub from: TransactionState,
+    /// The state the transaction moved to.
+    pub to: TransactionState,
+    /// Timestamp (milliseconds) when the transition was detected.
+    pub timestamp: u64,
+}
+
+// ── BackpressureConfig ────────────────────────────────────────────────────────
+
+/// Backpressure controls for the streaming monitor.
+///
+/// Prevents unbounded memory growth under bursty update conditions by
+/// capping retained transition history and optionally coalescing rapid
+/// duplicate state changes.
+#[derive(Clone, Debug)]
+pub struct BackpressureConfig {
+    /// Maximum number of [`StateTransition`] entries retained.
+    /// When exceeded, the oldest entries are evicted (FIFO).
+    /// `0` means unlimited (use with caution).
+    pub max_queued_transitions: usize,
+    /// When `true`, consecutive duplicate `Pending` updates with the same
+    /// [`TransactionState`] are collapsed into a single transition entry.
+    /// The first occurrence is kept; subsequent identical states within
+    /// the same poll cycle are suppressed.
+    pub coalesce_updates: bool,
+    /// When `true`, the monitor will also coalesce across poll cycles:
+    /// if the polled state is the same as the last recorded state, no new
+    /// transition entry is added.
+    pub coalesce_across_polls: bool,
+}
+
+impl Default for BackpressureConfig {
+    fn default() -> Self {
+        BackpressureConfig {
+            max_queued_transitions: 100,
+            coalesce_updates: true,
+            coalesce_across_polls: true,
+        }
+    }
+}
+
+impl BackpressureConfig {
+    /// Allow unlimited transitions (no backpressure cap).
+    pub fn unlimited() -> Self {
+        BackpressureConfig {
+            max_queued_transitions: 0,
+            coalesce_updates: false,
+            coalesce_across_polls: false,
+        }
+    }
+
+    /// Aggressive backpressure: small queue, coalesce everything.
+    pub fn aggressive() -> Self {
+        BackpressureConfig {
+            max_queued_transitions: 10,
+            coalesce_updates: true,
+            coalesce_across_polls: true,
+        }
+    }
+}
+
 // ── StreamingTransactionMonitor ───────────────────────────────────────────────
 
 /// Polls a transaction and emits [`TransactionStatusUpdate`] events on state changes.
+///
+/// Tracks state transitions via [`StateTransition`] entries and supports
+/// configurable backpressure via [`BackpressureConfig`].
 ///
 /// # Example (pseudo-code — polling_fn is injected for testability)
 ///
@@ -59,6 +146,10 @@ pub struct StreamingTransactionMonitor {
     /// Polling interval in milliseconds.
     pub poll_interval_ms: u64,
     retry_config: RetryConfig,
+    /// Recorded state transitions (see [`StateTransition`]).
+    transitions: Vec<StateTransition>,
+    /// Backpressure configuration.
+    backpressure: BackpressureConfig,
 }
 
 impl StreamingTransactionMonitor {
@@ -67,12 +158,55 @@ impl StreamingTransactionMonitor {
             transaction_id,
             poll_interval_ms,
             retry_config: RetryConfig::default(),
+            transitions: Vec::new(),
+            backpressure: BackpressureConfig::default(),
         }
     }
 
     pub fn with_retry(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
         self
+    }
+
+    /// Set the backpressure configuration.
+    pub fn with_backpressure(mut self, config: BackpressureConfig) -> Self {
+        self.backpressure = config;
+        self
+    }
+
+    /// Return a copy of all recorded state transitions since the monitor started
+    /// (or since the last [`clear_transitions`](Self::clear_transitions) call).
+    pub fn get_transitions(&self) -> Vec<StateTransition> {
+        self.transitions.clone()
+    }
+
+    /// Clear all recorded state transitions.
+    pub fn clear_transitions(&mut self) {
+        self.transitions.clear();
+    }
+
+    /// Record a transition, respecting the backpressure config (cap + coalescing).
+    ///
+    /// Returns `true` if the transition was recorded, `false` if it was
+    /// coalesced away because it duplicates the most recent entry.
+    fn record_transition(&mut self, from: TransactionState, to: TransactionState, timestamp: u64) -> bool {
+        if self.backpressure.coalesce_across_polls {
+            if let Some(last) = self.transitions.last() {
+                if last.from == from && last.to == to {
+                    return false;
+                }
+            }
+        }
+
+        self.transitions.push(StateTransition { from, to, timestamp });
+
+        if self.backpressure.max_queued_transitions > 0 {
+            while self.transitions.len() > self.backpressure.max_queued_transitions {
+                self.transitions.remove(0);
+            }
+        }
+
+        true
     }
 
     /// Run the monitor.
@@ -84,7 +218,7 @@ impl StreamingTransactionMonitor {
     ///
     /// Returns when the transaction reaches a terminal state or all retries are exhausted.
     pub fn run<P, E, S, T>(
-        &self,
+        &mut self,
         mut poll_fn: P,
         mut on_event: E,
         mut sleep_fn: S,
@@ -105,42 +239,73 @@ impl StreamingTransactionMonitor {
             let result = retry_with_backoff(
                 &self.retry_config,
                 |_| poll_fn(self.transaction_id),
-                |_| true, // all poll errors are retryable
+                |_| true,
                 |ms| sleep_fn(ms),
                 &mut jitter,
             );
 
             match result {
                 Err(reason) => {
+                    if let Some(prev) = last_state {
+                        let ts = timestamp_fn();
+                        self.record_transition(prev, TransactionState::Failed, ts);
+                        on_event(TransactionStatusUpdate::StateChanged {
+                            from: prev,
+                            to: TransactionState::Failed,
+                            timestamp: ts,
+                        });
+                    }
                     on_event(TransactionStatusUpdate::Failed { reason });
                     return;
                 }
                 Ok(PollResult::Failed { reason }) => {
+                    if let Some(prev) = last_state {
+                        let ts = timestamp_fn();
+                        self.record_transition(prev, TransactionState::Failed, ts);
+                        on_event(TransactionStatusUpdate::StateChanged {
+                            from: prev,
+                            to: TransactionState::Failed,
+                            timestamp: ts,
+                        });
+                    }
                     on_event(TransactionStatusUpdate::Failed { reason });
                     return;
                 }
                 Ok(PollResult::Completed { stellar_tx_id }) => {
                     if let Some(prev) = last_state {
+                        let ts = timestamp_fn();
+                        self.record_transition(prev, TransactionState::Completed, ts);
                         on_event(TransactionStatusUpdate::StateChanged {
                             from: prev,
                             to: TransactionState::Completed,
-                            timestamp: timestamp_fn(),
+                            timestamp: ts,
                         });
                     }
                     on_event(TransactionStatusUpdate::Completed { stellar_tx_id });
                     return;
                 }
                 Ok(PollResult::Pending(current_state)) => {
+                    let will_coalesce = self.backpressure.coalesce_updates
+                        && last_state == Some(current_state);
+
                     if let Some(prev) = last_state {
                         if prev != current_state {
+                            let ts = timestamp_fn();
+                            self.record_transition(prev, current_state, ts);
                             on_event(TransactionStatusUpdate::StateChanged {
                                 from: prev,
                                 to: current_state,
-                                timestamp: timestamp_fn(),
+                                timestamp: ts,
                             });
                         }
+                    } else {
+                        let ts = timestamp_fn();
+                        self.record_transition(TransactionState::Pending, current_state, ts);
                     }
-                    last_state = Some(current_state);
+
+                    if !will_coalesce {
+                        last_state = Some(current_state);
+                    }
 
                     if current_state == TransactionState::Failed {
                         on_event(TransactionStatusUpdate::Failed {
@@ -165,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_monitor_emits_state_change_events() {
-        let monitor = StreamingTransactionMonitor::new(1, 0);
+        let mut monitor = StreamingTransactionMonitor::new(1, 0);
         let states = alloc::vec![
             PollResult::Pending(TransactionState::Pending),
             PollResult::Pending(TransactionState::InProgress),
@@ -196,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_monitor_stops_on_completed() {
-        let monitor = StreamingTransactionMonitor::new(1, 0);
+        let mut monitor = StreamingTransactionMonitor::new(1, 0);
         let mut call_count = 0u32;
         let mut events: alloc::vec::Vec<TransactionStatusUpdate> = alloc::vec::Vec::new();
 
@@ -216,7 +381,7 @@ mod tests {
 
     #[test]
     fn test_monitor_stops_on_failed() {
-        let monitor = StreamingTransactionMonitor::new(1, 0);
+        let mut monitor = StreamingTransactionMonitor::new(1, 0);
         let mut events: alloc::vec::Vec<TransactionStatusUpdate> = alloc::vec::Vec::new();
 
         monitor.run(
@@ -231,7 +396,7 @@ mod tests {
 
     #[test]
     fn test_monitor_retries_on_poll_failure() {
-        let monitor = StreamingTransactionMonitor::new(1, 0);
+        let mut monitor = StreamingTransactionMonitor::new(1, 0);
         let mut call_count = 0u32;
         let mut events: alloc::vec::Vec<TransactionStatusUpdate> = alloc::vec::Vec::new();
 
@@ -254,7 +419,7 @@ mod tests {
 
     #[test]
     fn test_monitor_emits_failed_when_all_retries_exhausted() {
-        let monitor = StreamingTransactionMonitor::new(1, 0)
+        let mut monitor = StreamingTransactionMonitor::new(1, 0)
             .with_retry(RetryConfig::new(2, 0, 0, 1));
         let mut events: alloc::vec::Vec<TransactionStatusUpdate> = alloc::vec::Vec::new();
 
@@ -276,7 +441,7 @@ mod tests {
 
     #[test]
     fn test_state_changed_timestamp_uses_timestamp_fn() {
-        let monitor = StreamingTransactionMonitor::new(1, 0);
+        let mut monitor = StreamingTransactionMonitor::new(1, 0);
         let mut events: alloc::vec::Vec<TransactionStatusUpdate> = alloc::vec::Vec::new();
         let states = alloc::vec![
             PollResult::Pending(TransactionState::Pending),
@@ -301,7 +466,7 @@ mod tests {
 
     #[test]
     fn test_completed_carries_stellar_tx_id() {
-        let monitor = StreamingTransactionMonitor::new(1, 0);
+        let mut monitor = StreamingTransactionMonitor::new(1, 0);
         let mut events: alloc::vec::Vec<TransactionStatusUpdate> = alloc::vec::Vec::new();
 
         monitor.run(
@@ -314,5 +479,239 @@ mod tests {
         assert!(events.iter().any(|e| matches!(e,
             TransactionStatusUpdate::Completed { stellar_tx_id } if stellar_tx_id == "HASH123"
         )));
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #624 — state transition tracking tests
+    // -----------------------------------------------------------------------
+
+    /// State transitions are recorded and retrievable.
+    #[test]
+    fn test_transitions_are_recorded() {
+        let mut monitor = StreamingTransactionMonitor::new(1, 0)
+            .with_backpressure(BackpressureConfig::unlimited());
+        let states = alloc::vec![
+            PollResult::Pending(TransactionState::Pending),
+            PollResult::Pending(TransactionState::InProgress),
+            PollResult::Completed { stellar_tx_id: alloc::string::String::from("tx99") },
+        ];
+        let mut idx = 0usize;
+
+        monitor.run(
+            |_| { let s = states[idx.min(states.len()-1)].clone(); idx += 1; Ok(s) },
+            |_| {},
+            |_| {},
+            || 42,
+        );
+
+        let transitions = monitor.get_transitions();
+        assert_eq!(transitions.len(), 2);
+        assert_eq!(transitions[0].from, TransactionState::Pending);
+        assert_eq!(transitions[0].to, TransactionState::InProgress);
+        assert_eq!(transitions[0].timestamp, 42);
+        assert_eq!(transitions[1].from, TransactionState::InProgress);
+        assert_eq!(transitions[1].to, TransactionState::Completed);
+    }
+
+    /// Transitions to Failed are recorded.
+    #[test]
+    fn test_transition_to_failed_is_recorded() {
+        let mut monitor = StreamingTransactionMonitor::new(1, 0)
+            .with_backpressure(BackpressureConfig::unlimited());
+        monitor.run(
+            |_| Ok(PollResult::Pending(TransactionState::Failed)),
+            |_| {},
+            |_| {},
+            || 100,
+        );
+
+        let transitions = monitor.get_transitions();
+        assert_eq!(transitions.len(), 1);
+        assert_eq!(transitions[0].from, TransactionState::Pending);
+        assert_eq!(transitions[0].to, TransactionState::Failed);
+    }
+
+    /// get_transitions returns a snapshot; clear_transitions resets.
+    #[test]
+    fn test_clear_transitions() {
+        let mut monitor = StreamingTransactionMonitor::new(1, 0)
+            .with_backpressure(BackpressureConfig::unlimited());
+        monitor.run(
+            |_| Ok(PollResult::Pending(TransactionState::Failed)),
+            |_| {},
+            |_| {},
+            || 0,
+        );
+
+        assert_eq!(monitor.get_transitions().len(), 1);
+        monitor.clear_transitions();
+        assert_eq!(monitor.get_transitions().len(), 0);
+    }
+
+    /// Transition tracking works with Failed from poll error.
+    #[test]
+    fn test_transition_on_poll_failure() {
+        let mut monitor = StreamingTransactionMonitor::new(1, 0)
+            .with_retry(RetryConfig::new(1, 0, 0, 1))
+            .with_backpressure(BackpressureConfig::unlimited());
+
+        // First call returns Pending to establish last_state, then fails
+        let mut call = 0u32;
+        monitor.run(
+            |_| {
+                call += 1;
+                if call == 1 {
+                    Ok(PollResult::Pending(TransactionState::InProgress))
+                } else {
+                    Err(alloc::string::String::from("fail"))
+                }
+            },
+            |_| {},
+            |_| {},
+            || 0,
+        );
+
+        let transitions = monitor.get_transitions();
+        assert_eq!(transitions.len(), 2);
+        assert_eq!(transitions[0].to, TransactionState::InProgress);
+        assert_eq!(transitions[1].to, TransactionState::Failed);
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #625 — backpressure control tests
+    // -----------------------------------------------------------------------
+
+    /// Max queued transitions cap is enforced.
+    #[test]
+    fn test_backpressure_caps_transitions() {
+        let mut monitor = StreamingTransactionMonitor::new(1, 0)
+            .with_backpressure(BackpressureConfig {
+                max_queued_transitions: 2,
+                coalesce_updates: false,
+                coalesce_across_polls: false,
+            });
+
+        // Walk through multiple states to generate >2 transitions.
+        let states = alloc::vec![
+            PollResult::Pending(TransactionState::Pending),
+            PollResult::Pending(TransactionState::InProgress),
+            PollResult::Pending(TransactionState::Failed),
+        ];
+        let mut idx = 0usize;
+        monitor.run(
+            |_| { let s = states[idx.min(states.len()-1)].clone(); idx += 1; Ok(s) },
+            |_| {},
+            |_| {},
+            || 0,
+        );
+
+        let transitions = monitor.get_transitions();
+        assert_eq!(transitions.len(), 2);
+        // The oldest transition (Pending -> InProgress) was evicted;
+        // only InProgress -> Failed remains plus the initial Pending -> Pending.
+        assert_eq!(transitions[transitions.len() - 1].to, TransactionState::Failed);
+    }
+
+    /// Coalesce updates: consecutive same-state Pending results produce only
+    /// one transition entry.
+    #[test]
+    fn test_backpressure_coalesces_duplicate_state() {
+        let mut monitor = StreamingTransactionMonitor::new(1, 0)
+            .with_backpressure(BackpressureConfig {
+                max_queued_transitions: 100,
+                coalesce_updates: true,
+                coalesce_across_polls: false,
+            });
+
+        let states = alloc::vec![
+            PollResult::Pending(TransactionState::Pending),
+            PollResult::Pending(TransactionState::Pending), // duplicate
+            PollResult::Pending(TransactionState::InProgress),
+            PollResult::Completed { stellar_tx_id: alloc::string::String::from("tx") },
+        ];
+        let mut idx = 0usize;
+        monitor.run(
+            |_| { let s = states[idx.min(states.len()-1)].clone(); idx += 1; Ok(s) },
+            |_| {},
+            |_| {},
+            || 0,
+        );
+
+        let transitions = monitor.get_transitions();
+        // Only the first Pending and the InProgress change should be recorded
+        // (the duplicate Pending should be coalesced away).
+        assert_eq!(transitions.len(), 2);
+    }
+
+    /// Coalesce across polls: repeated polls with same state don't add entries.
+    #[test]
+    fn test_backpressure_coalesces_across_polls() {
+        let mut monitor = StreamingTransactionMonitor::new(1, 0)
+            .with_backpressure(BackpressureConfig {
+                max_queued_transitions: 100,
+                coalesce_updates: true,
+                coalesce_across_polls: true,
+            });
+
+        let states = alloc::vec![
+            PollResult::Pending(TransactionState::Pending),
+            PollResult::Pending(TransactionState::InProgress),
+            PollResult::Pending(TransactionState::InProgress), // same as last — coalesced
+            PollResult::Completed { stellar_tx_id: alloc::string::String::from("tx") },
+        ];
+        let mut idx = 0usize;
+        monitor.run(
+            |_| { let s = states[idx.min(states.len()-1)].clone(); idx += 1; Ok(s) },
+            |_| {},
+            |_| {},
+            || 0,
+        );
+
+        let transitions = monitor.get_transitions();
+        // Only 2 transitions: Pending->InProgress, InProgress->Completed
+        assert_eq!(transitions.len(), 2);
+    }
+
+    /// Aggressive backpressure preset.
+    #[test]
+    fn test_aggressive_backpressure_preset() {
+        let bp = BackpressureConfig::aggressive();
+        assert_eq!(bp.max_queued_transitions, 10);
+        assert!(bp.coalesce_updates);
+        assert!(bp.coalesce_across_polls);
+    }
+
+    /// Unlimited backpressure preset stores all transitions.
+    #[test]
+    fn test_unlimited_backpressure() {
+        let mut monitor = StreamingTransactionMonitor::new(1, 0)
+            .with_backpressure(BackpressureConfig::unlimited());
+
+        let states = alloc::vec![
+            PollResult::Pending(TransactionState::Pending),
+            PollResult::Pending(TransactionState::InProgress),
+            PollResult::Pending(TransactionState::InProgress),
+            PollResult::Pending(TransactionState::InProgress),
+            PollResult::Completed { stellar_tx_id: alloc::string::String::from("tx") },
+        ];
+        let mut idx = 0usize;
+        monitor.run(
+            |_| { let s = states[idx.min(states.len()-1)].clone(); idx += 1; Ok(s) },
+            |_| {},
+            |_| {},
+            || 0,
+        );
+
+        let transitions = monitor.get_transitions();
+        // Unlimited + no coalesce = all polled states may create entries
+        assert!(transitions.len() >= 2);
+    }
+
+    /// with_backpressure builder.
+    #[test]
+    fn test_with_backpressure_builder() {
+        let bp = BackpressureConfig { max_queued_transitions: 5, coalesce_updates: false, coalesce_across_polls: false };
+        let monitor = StreamingTransactionMonitor::new(1, 0).with_backpressure(bp.clone());
+        assert_eq!(monitor.backpressure.max_queued_transitions, 5);
     }
 }

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -1334,6 +1334,201 @@ impl TransactionStateTracker {
         }
     }
 
+    // ── Recovery metadata export / import ──────────────────────────────────────
+
+    /// Serialize the [`RecoveryMetadata`] for a failed transaction into a JSON
+    /// string that can be stored or transferred between environments.
+    ///
+    /// Only available when the `std` feature is enabled (requires `serde_json`).
+    ///
+    /// # Arguments
+    ///
+    /// * `transaction_id` - The ID of the failed transaction.
+    /// * `env` - The Soroban execution environment.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `String` error if the transaction is not found, is not in the
+    /// `Failed` state, has no recovery metadata, or serialization fails.
+    #[cfg(feature = "std")]
+    pub fn export_recovery_state(
+        &self,
+        transaction_id: u64,
+        env: &Env,
+    ) -> Result<alloc::string::String, alloc::string::String> {
+        use alloc::string::ToString;
+
+        let meta = self.get_recovery_metadata(transaction_id, env)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| alloc::format!("No recovery metadata for transaction {}", transaction_id))?;
+
+        #[derive(serde::Serialize)]
+        struct Export {
+            failure_reason: alloc::string::String,
+            last_updated_ledger: u32,
+            failed_from_state: alloc::string::String,
+            retry_count: u32,
+            transaction_id: u64,
+        }
+
+        let export = Export {
+            failure_reason: meta.failure_reason.to_string(),
+            last_updated_ledger: meta.last_updated_ledger,
+            failed_from_state: alloc::string::String::from(meta.failed_from_state.as_str()),
+            retry_count: meta.retry_count,
+            transaction_id,
+        };
+
+        serde_json::to_string(&export).map_err(|e| alloc::format!("Serialization error: {}", e))
+    }
+
+    /// Deserialize a JSON string and import (create or update) the recovery
+    /// metadata for a failed transaction.
+    ///
+    /// If a transaction with the given ID already exists, it must be in the
+    /// [`Failed`](TransactionState::Failed) state and its recovery metadata will
+    /// be replaced. If no transaction exists, a new one is created in the
+    /// [`Failed`](TransactionState::Failed) state with the imported metadata.
+    ///
+    /// Only available when the `std` feature is enabled (requires `serde_json`).
+    ///
+    /// # Arguments
+    ///
+    /// * `json_data` - A JSON string matching the export format.
+    /// * `initiator` - The Stellar address that initiated the transaction
+    ///   (used only when creating a new record).
+    /// * `env` - The Soroban execution environment.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `String` error if the JSON is malformed, a required field is
+    /// missing, the `failed_from_state` is not a recognised state name, or
+    /// the existing transaction is not in the `Failed` state.
+    #[cfg(feature = "std")]
+    pub fn import_recovery_state(
+        &mut self,
+        json_data: &str,
+        initiator: Address,
+        env: &Env,
+    ) -> Result<(), alloc::string::String> {
+        use alloc::string::ToString;
+
+        #[derive(serde::Deserialize)]
+        struct Import {
+            failure_reason: alloc::string::String,
+            last_updated_ledger: u32,
+            failed_from_state: alloc::string::String,
+            retry_count: u32,
+            transaction_id: u64,
+        }
+
+        let import: Import = serde_json::from_str(json_data)
+            .map_err(|e| alloc::format!("Invalid recovery state JSON: {}", e))?;
+
+        let failed_from = TransactionState::from_str(&import.failed_from_state)
+            .ok_or_else(|| alloc::format!(
+                "Invalid failed_from_state '{}': must be one of: pending, in_progress, completed, failed",
+                import.failed_from_state
+            ))?;
+
+        if failed_from.is_terminal() {
+            return Err(alloc::format!(
+                "Invalid failed_from_state '{}': cannot be a terminal state",
+                import.failed_from_state
+            ));
+        }
+
+        let current_ledger = env.ledger().sequence();
+        let new_meta = RecoveryMetadata {
+            failure_reason: String::from_str(env, &import.failure_reason),
+            last_updated_ledger: import.last_updated_ledger,
+            failed_from_state: failed_from,
+            retry_count: import.retry_count,
+        };
+
+        // Check if transaction already exists.
+        let existing = self.get_transaction_state(import.transaction_id, env)
+            .map_err(|e| e.to_string())?;
+
+        match existing {
+            Some(record) => {
+                // Transaction exists — must be in Failed state.
+                if record.state != TransactionState::Failed {
+                    return Err(alloc::format!(
+                        "Cannot import recovery state: transaction {} is in state '{}', expected 'failed'",
+                        import.transaction_id,
+                        record.state.as_str(),
+                    ));
+                }
+                // Replace recovery metadata in-place.
+                if self.is_dev_mode {
+                    for rec in self.cache.iter_mut() {
+                        if rec.transaction_id == import.transaction_id {
+                            rec.recovery_metadata = OptRecovery::Some(new_meta.clone());
+                            rec.last_updated = env.ledger().timestamp();
+                            rec.last_updated_ledger = current_ledger;
+                            break;
+                        }
+                    }
+                } else {
+                    let key = (symbol_short!("TXSTATE"), import.transaction_id);
+                    let mut stored: TransactionStateRecord = env
+                        .storage()
+                        .persistent()
+                        .get(&key)
+                        .ok_or_else(|| alloc::format!("Transaction not found"))?;
+                    stored.recovery_metadata = OptRecovery::Some(new_meta);
+                    stored.last_updated = env.ledger().timestamp();
+                    stored.last_updated_ledger = current_ledger;
+                    env.storage().persistent().set(&key, &stored);
+                    env.storage().persistent().extend_ttl(&key, TXSTATE_TTL, TXSTATE_TTL);
+                }
+                Ok(())
+            }
+            None => {
+                // No existing transaction — create a new one in Failed state.
+                let current_time = env.ledger().timestamp();
+                let mut history = Vec::new(env);
+                history.push_back((TransactionState::Pending, current_time));
+                history.push_back((failed_from, current_time));
+                history.push_back((TransactionState::Failed, current_time));
+
+                let record = TransactionStateRecord {
+                    transaction_id: import.transaction_id,
+                    state: TransactionState::Failed,
+                    initiator,
+                    timestamp: current_time,
+                    last_updated: current_time,
+                    last_updated_ledger: current_ledger,
+                    error_message: Some(String::from_str(env, &import.failure_reason)),
+                    state_history: history,
+                    recovery_metadata: OptRecovery::Some(new_meta),
+                    routing_reason: None,
+                };
+
+                if self.is_dev_mode {
+                    const APPROX_RECORD_BYTES: u64 = 256;
+                    self.cache.push(record);
+                    self.known_ids.push(import.transaction_id);
+                    self.budget_monitor.record_entry(APPROX_RECORD_BYTES);
+                } else {
+                    let key = (symbol_short!("TXSTATE"), import.transaction_id);
+                    env.storage().persistent().set(&key, &record);
+                    env.storage().persistent().extend_ttl(&key, TXSTATE_TTL, TXSTATE_TTL);
+
+                    let ids_key = symbol_short!("TXIDS");
+                    let mut ids: Vec<u64> = env
+                        .storage().persistent().get(&ids_key)
+                        .unwrap_or_else(|| Vec::new(env));
+                    ids.push_back(import.transaction_id);
+                    env.storage().persistent().set(&ids_key, &ids);
+                    env.storage().persistent().extend_ttl(&ids_key, TXSTATE_TTL, TXSTATE_TTL);
+                }
+                Ok(())
+            }
+        }
+    }
+
     // ── Batch query helpers ──────────────────────────────────────────────────
 
     /// Return up to `limit` transaction records whose IDs fall in the inclusive
@@ -2157,5 +2352,208 @@ mod tests {
         let mut monitor = StorageBudgetMonitor::new();
         monitor.record_entry(850);
         assert!(monitor.is_near_limit(80, 1000));
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #626 — recovery metadata export / import tests (std-only)
+    // -----------------------------------------------------------------------
+
+    /// Export produces a valid JSON string with all fields.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_export_recovery_state_returns_json() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        tracker.start_transaction(1, &env).unwrap();
+        tracker.fail_transaction(1, String::from_str(&env, "network timeout"), &env).unwrap();
+
+        let json = tracker.export_recovery_state(1, &env).unwrap();
+        assert!(json.contains("failure_reason"));
+        assert!(json.contains("network timeout"));
+        assert!(json.contains("transaction_id"));
+        assert!(json.contains("failed_from_state"));
+        assert!(json.contains("in_progress"));
+    }
+
+    /// Export returns error for non-existent transaction.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_export_missing_transaction_returns_error() {
+        let env = Env::default();
+        let tracker = TransactionStateTracker::new(true);
+        let result = tracker.export_recovery_state(99, &env);
+        assert!(result.is_err());
+    }
+
+    /// Export returns error for non-failed transaction.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_export_non_failed_transaction_returns_error() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        let result = tracker.export_recovery_state(1, &env);
+        assert!(result.is_err());
+    }
+
+    /// Import valid JSON creates a new failed transaction record.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_import_recovery_state_creates_new_transaction() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        let json = r#"{
+            "failure_reason": "imported timeout",
+            "last_updated_ledger": 42,
+            "failed_from_state": "in_progress",
+            "retry_count": 1,
+            "transaction_id": 100
+        }"#;
+
+        tracker.import_recovery_state(json, initiator.clone(), &env).unwrap();
+
+        let record = tracker.get_transaction_state(100, &env).unwrap().unwrap();
+        assert_eq!(record.state, TransactionState::Failed);
+        assert!(record.recovery_metadata.is_some());
+        let meta = record.recovery_metadata.unwrap();
+        assert_eq!(meta.failure_reason.to_string(), "imported timeout");
+        assert_eq!(meta.retry_count, 1);
+        assert_eq!(meta.failed_from_state, TransactionState::InProgress);
+    }
+
+    /// Import updates recovery metadata on an existing failed transaction.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_import_updates_existing_failed_transaction() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator.clone(), &env).unwrap();
+        tracker.start_transaction(1, &env).unwrap();
+        tracker.fail_transaction(1, String::from_str(&env, "original error"), &env).unwrap();
+
+        let json = r#"{
+            "failure_reason": "updated reason",
+            "last_updated_ledger": 99,
+            "failed_from_state": "pending",
+            "retry_count": 5,
+            "transaction_id": 1
+        }"#;
+
+        tracker.import_recovery_state(json, initiator.clone(), &env).unwrap();
+
+        let meta = tracker.get_recovery_metadata(1, &env).unwrap().unwrap();
+        assert_eq!(meta.failure_reason.to_string(), "updated reason");
+        assert_eq!(meta.retry_count, 5);
+        assert_eq!(meta.failed_from_state, TransactionState::Pending);
+    }
+
+    /// Import rejects invalid JSON.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_import_invalid_json_returns_error() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        let result = tracker.import_recovery_state("not json at all", initiator, &env);
+        assert!(result.is_err());
+    }
+
+    /// Import rejects unknown failed_from_state.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_import_invalid_state_name_returns_error() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        let json = r#"{
+            "failure_reason": "bad state",
+            "last_updated_ledger": 0,
+            "failed_from_state": "unknown_state",
+            "retry_count": 0,
+            "transaction_id": 1
+        }"#;
+
+        let result = tracker.import_recovery_state(json, initiator, &env);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("unknown_state"));
+    }
+
+    /// Import rejects terminal failed_from_state.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_import_terminal_failed_from_state_returns_error() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        let json = r#"{
+            "failure_reason": "terminal from_state",
+            "last_updated_ledger": 0,
+            "failed_from_state": "completed",
+            "retry_count": 0,
+            "transaction_id": 1
+        }"#;
+
+        let result = tracker.import_recovery_state(json, initiator, &env);
+        assert!(result.is_err());
+    }
+
+    /// Import rejects non-failed existing transaction.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_import_existing_non_failed_returns_error() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator.clone(), &env).unwrap();
+        // Transaction is Pending, not Failed
+
+        let json = r#"{
+            "failure_reason": "trying to overwrite",
+            "last_updated_ledger": 0,
+            "failed_from_state": "pending",
+            "retry_count": 0,
+            "transaction_id": 1
+        }"#;
+
+        let result = tracker.import_recovery_state(json, initiator, &env);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("pending"));
+    }
+
+    /// Round-trip: export then import produces equivalent state.
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_export_import_round_trip() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator.clone(), &env).unwrap();
+        tracker.start_transaction(1, &env).unwrap();
+        tracker.fail_transaction(1, String::from_str(&env, "round-trip error"), &env).unwrap();
+
+        // Export
+        let json = tracker.export_recovery_state(1, &env).unwrap();
+
+        // Create a new tracker and import
+        let mut tracker2 = TransactionStateTracker::new(true);
+        tracker2.import_recovery_state(&json, initiator.clone(), &env).unwrap();
+
+        let meta = tracker2.get_recovery_metadata(1, &env).unwrap().unwrap();
+        assert_eq!(meta.failure_reason.to_string(), "round-trip error");
+        assert_eq!(meta.failed_from_state, TransactionState::InProgress);
+        assert_eq!(meta.retry_count, 0);
     }
 }


### PR DESCRIPTION
…, backpressure, and recovery export/import

#623 — Configurable retry strategies
- Add BackoffStrategy enum (Exponential, Linear, Constant, NoRetry)
- Add JitterPolicy enum (Full, Equal, None)
- Extend RetryConfig with strategy/jitter fields and builder methods
- Add preset configs: linear(), constant()
- Add with_strategy() full constructor
- 17 new tests covering all strategy/policy combinations

#624 — Streaming monitor state transition tracking
- Add StateTransition struct with from/to/timestamp
- Record every state change internally in StreamingTransactionMonitor
- Add get_transitions() and clear_transitions() API
- Change run() signature from &self to &mut self
- 5 new tests for transition recording and retrieval

#625 — Backpressure controls for streaming monitor
- Add BackpressureConfig with max_queued_transitions, coalesce_updates, coalesce_across_polls fields
- Add unlimited() and aggressive() presets
- Connfigure via with_backpressure() builder
- FIFO eviction when transition queue exceeds max
- In-poll and cross-poll duplicate coalescing
- 6 new tests for cap enforcement and coalescing behavior

#626 — Recovery metadata export and import
- Add export_recovery_state() — serializes RecoveryMetadata to JSON
- Add import_recovery_state() — parses JSON, validates fields, creates new Failed transaction or updates existing one
- Rejects invalid state names, terminal failed_from_state, and non-failed existing transactions
- Both methods gated behind cfg(feature = "std")
- 9 new tests: export, import, round-trip, invalid data handling


Closes #623 
Closes #624 
Closes #625 
Closes #626 