### PR TITLE
feat: multi-anchor reputation weighting, time-based routing policies, per-network profiles, and response compatibility checks

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -480,6 +480,210 @@ pub struct RoutingAnchorMeta {
     pub is_active: bool,
 }
 
+// ---------------------------------------------------------------------------
+// Issue #657: Multi-anchor reputation weighting
+// ---------------------------------------------------------------------------
+
+/// Extended reputation record capturing historical behaviour signals that feed
+/// into the composite reputation score used during routing.
+///
+/// All counters are cumulative over the lifetime of the anchor record.
+/// `compute_composite_reputation` derives a single 0–10 000 score from them.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AnchorReputationRecord {
+    /// Anchor address this record belongs to.
+    pub anchor: Address,
+    /// Total number of transactions routed through this anchor.
+    pub total_routed: u64,
+    /// Number of those that completed successfully.
+    pub successful_routed: u64,
+    /// Operator-assigned quality score (0–10 000).  This is set manually by
+    /// admins to capture qualitative signals (regulatory standing, SLA tier,
+    /// geographic coverage, etc.) that cannot be derived from on-chain data.
+    pub operator_quality_score: u32,
+    /// Cumulative uptime ticks (arbitrary unit; caller decides granularity).
+    pub uptime_ticks: u64,
+    /// Total observation ticks (uptime denominator).
+    pub total_ticks: u64,
+    /// Ledger timestamp of the last update.
+    pub updated_at: u64,
+}
+
+/// Weights used when computing the composite reputation score.
+///
+/// All values are scaled ×1 000 (e.g. `500` = 0.5). The three weights must
+/// sum to exactly `1 000`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ReputationWeights {
+    /// Weight applied to the historical success-rate sub-score.
+    pub success_rate_weight: u32,
+    /// Weight applied to the uptime sub-score.
+    pub uptime_weight: u32,
+    /// Weight applied to the operator quality sub-score.
+    pub operator_quality_weight: u32,
+}
+
+impl ReputationWeights {
+    /// Default weights: 40 % success rate, 35 % uptime, 25 % operator quality.
+    pub fn default_weights() -> Self {
+        ReputationWeights {
+            success_rate_weight: 400,
+            uptime_weight: 350,
+            operator_quality_weight: 250,
+        }
+    }
+
+    /// Returns `true` when all weights are non-zero and sum to exactly 1 000.
+    pub fn is_valid(&self) -> bool {
+        self.success_rate_weight
+            .checked_add(self.uptime_weight)
+            .and_then(|s| s.checked_add(self.operator_quality_weight))
+            == Some(1_000)
+    }
+
+    /// Compute a composite reputation score in the range `[0, 10 000]` from a
+    /// reputation record.
+    ///
+    /// Each sub-score is normalised to [0, 10 000] before weighting:
+    ///
+    /// * **success_rate** – `successful_routed / total_routed` (1.0 when no
+    ///   transactions have been routed yet, to avoid penalising new anchors).
+    /// * **uptime** – `uptime_ticks / total_ticks` (1.0 when no ticks recorded).
+    /// * **operator_quality** – `operator_quality_score / 10 000` (already in
+    ///   the target range).
+    ///
+    /// Tie-breaking uses `anchor.to_string()` lexicographic order when scores
+    /// are equal (deterministic across contract invocations).
+    pub fn compute_composite(&self, record: &AnchorReputationRecord) -> u32 {
+        let success_rate: f32 = if record.total_routed == 0 {
+            1.0_f32
+        } else {
+            (record.successful_routed.min(record.total_routed) as f32)
+                / (record.total_routed as f32)
+        };
+
+        let uptime_rate: f32 = if record.total_ticks == 0 {
+            1.0_f32
+        } else {
+            (record.uptime_ticks.min(record.total_ticks) as f32)
+                / (record.total_ticks as f32)
+        };
+
+        let operator_quality_rate: f32 =
+            (record.operator_quality_score.min(10_000) as f32) / 10_000.0_f32;
+
+        let sw = self.success_rate_weight as f32 / 1_000.0_f32;
+        let uw = self.uptime_weight as f32 / 1_000.0_f32;
+        let oqw = self.operator_quality_weight as f32 / 1_000.0_f32;
+
+        let composite =
+            sw * success_rate + uw * uptime_rate + oqw * operator_quality_rate;
+
+        (composite.clamp(0.0_f32, 1.0_f32) * 10_000.0_f32) as u32
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #658: Time-based routing policies
+// ---------------------------------------------------------------------------
+
+/// A single time window within which a routing strategy is active.
+///
+/// Times are expressed as seconds-since-midnight UTC (0 – 86 399).
+/// When `window_start_secs < window_end_secs` the window is a normal
+/// intra-day range.  When `window_start_secs > window_end_secs` the window
+/// wraps midnight (e.g. 22:00 – 02:00 is expressed as 79 200 – 7 200).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RoutingTimeWindow {
+    /// Seconds since midnight UTC at which the window opens (0 – 86 399).
+    pub window_start_secs: u32,
+    /// Seconds since midnight UTC at which the window closes (0 – 86 399,
+    /// exclusive). Equal to `window_start_secs` means the window is always
+    /// active (24-hour policy).
+    pub window_end_secs: u32,
+}
+
+impl RoutingTimeWindow {
+    /// Returns `true` when `time_of_day_secs` (seconds since midnight UTC)
+    /// falls within this window.
+    ///
+    /// A window where `start == end` is treated as always-active.
+    pub fn is_active(&self, time_of_day_secs: u32) -> bool {
+        if self.window_start_secs == self.window_end_secs {
+            // Always-active sentinel.
+            return true;
+        }
+        if self.window_start_secs < self.window_end_secs {
+            // Normal intra-day window.
+            time_of_day_secs >= self.window_start_secs
+                && time_of_day_secs < self.window_end_secs
+        } else {
+            // Midnight-wrapping window.
+            time_of_day_secs >= self.window_start_secs
+                || time_of_day_secs < self.window_end_secs
+        }
+    }
+}
+
+/// A named routing policy that becomes active only within its time window.
+///
+/// The policy names a routing strategy (`strategy_name`) that maps to one of
+/// the strategy symbols recognised by `route_transaction` (e.g.
+/// `"LowestFee"`, `"FastestSettlement"`, `"HighestReputation"`,
+/// `"WeightedScore"`).  When multiple policies overlap only the one with the
+/// lowest `priority` value (highest priority) is applied; equal priorities
+/// are broken by ascending `policy_id`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TimedRoutingPolicy {
+    /// Unique numeric identifier for this policy.
+    pub policy_id: u64,
+    /// Human-readable name for display / audit purposes.
+    pub name: String,
+    /// The routing strategy to activate while this policy is effective.
+    pub strategy_name: String,
+    /// The time window during which this policy is active.
+    pub window: RoutingTimeWindow,
+    /// Lower value = higher priority.  Policies with `priority == 0` take
+    /// precedence over those with `priority == 1`, etc.
+    pub priority: u32,
+    /// When `false` the policy is stored but never selected.
+    pub enabled: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Issue #659: Per-network routing profiles
+// ---------------------------------------------------------------------------
+
+/// A routing profile scoped to a specific network environment.
+///
+/// Each profile packages the routing weights and strategy defaults appropriate
+/// for one deployment environment (testnet, mainnet, local, …).  The profile
+/// whose `network_name` matches the currently active network context is
+/// selected automatically; when no match exists the default profile is used.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NetworkRoutingProfile {
+    /// Identifier for this profile (e.g. `"mainnet"`, `"testnet"`, `"local"`).
+    pub network_name: String,
+    /// Default routing strategy for this network (maps to a strategy symbol).
+    pub default_strategy: String,
+    /// Fee weight (scaled ×1 000).
+    pub fee_weight: u32,
+    /// Speed weight (scaled ×1 000).
+    pub speed_weight: u32,
+    /// Reputation weight (scaled ×1 000).
+    pub reputation_weight: u32,
+    /// Minimum reputation score required for an anchor to be considered on
+    /// this network.
+    pub min_reputation: u32,
+    /// When `true` this profile is used as the fallback for unknown networks.
+    pub is_default: bool,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub struct RoutingRequest {
@@ -7529,6 +7733,506 @@ impl AnchorKitContract {
             result.push_back(quote);
         }
         result
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #657: Multi-anchor reputation weighting
+    // -----------------------------------------------------------------------
+
+    /// Storage key for an anchor's extended reputation record.
+    fn reputation_record_key(env: &Env, anchor: &Address) -> BytesN<32> {
+        let xdr = anchor.clone().to_xdr(env);
+        let raw = xdr_to_vec(&xdr);
+        make_storage_key(env, &[b"REPREC", &raw])
+    }
+
+    /// Storage key for the contract-wide reputation weights.
+    fn reputation_weights_key(env: &Env) -> BytesN<32> {
+        make_storage_key(env, &[b"REPWTS"])
+    }
+
+    /// Upsert (create or replace) the extended reputation record for `anchor`.
+    ///
+    /// The composite reputation score is derived from the record automatically
+    /// by `get_anchor_composite_reputation`. Callers update the raw counters
+    /// here; the scoring formula is defined in [`ReputationWeights`].
+    ///
+    /// # Authorization
+    ///
+    /// Requires admin privileges.
+    pub fn set_anchor_reputation(
+        env: Env,
+        anchor: Address,
+        total_routed: u64,
+        successful_routed: u64,
+        operator_quality_score: u32,
+        uptime_ticks: u64,
+        total_ticks: u64,
+    ) {
+        Self::require_admin(&env);
+        if successful_routed > total_routed {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        if operator_quality_score > 10_000 {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        let record = AnchorReputationRecord {
+            anchor: anchor.clone(),
+            total_routed,
+            successful_routed,
+            operator_quality_score,
+            uptime_ticks,
+            total_ticks,
+            updated_at: env.ledger().timestamp(),
+        };
+        let key = Self::reputation_record_key(&env, &anchor);
+        env.storage().persistent().set(&key, &record);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("rep"), symbol_short!("updated")),
+            anchor,
+        );
+    }
+
+    /// Retrieve the extended reputation record for `anchor`, or `None` when no
+    /// record exists.
+    pub fn get_anchor_reputation(env: Env, anchor: Address) -> Option<AnchorReputationRecord> {
+        env.storage().persistent().get(&Self::reputation_record_key(&env, &anchor))
+    }
+
+    /// Set the contract-wide reputation weights used by
+    /// `get_anchor_composite_reputation` and the `ReputationWeighted` routing
+    /// strategy.
+    ///
+    /// Weights are validated: they must be non-zero and sum to exactly 1 000.
+    ///
+    /// # Authorization
+    ///
+    /// Requires admin privileges.
+    pub fn set_reputation_weights(
+        env: Env,
+        success_rate_weight: u32,
+        uptime_weight: u32,
+        operator_quality_weight: u32,
+    ) {
+        Self::require_admin(&env);
+        let weights = ReputationWeights {
+            success_rate_weight,
+            uptime_weight,
+            operator_quality_weight,
+        };
+        if !weights.is_valid() {
+            panic_with_error!(&env, ErrorCode::InvalidWeights);
+        }
+        let key = Self::reputation_weights_key(&env);
+        env.storage().persistent().set(&key, &weights);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    /// Retrieve the current contract-wide reputation weights, or the default
+    /// weights when none have been explicitly set.
+    pub fn get_reputation_weights(env: Env) -> ReputationWeights {
+        env.storage()
+            .persistent()
+            .get(&Self::reputation_weights_key(&env))
+            .unwrap_or_else(ReputationWeights::default_weights)
+    }
+
+    /// Compute and return the composite reputation score (0–10 000) for
+    /// `anchor`, combining historical success rate, uptime, and operator
+    /// quality according to the contract-wide [`ReputationWeights`].
+    ///
+    /// Returns `0` when no reputation record has been stored for `anchor`.
+    pub fn get_anchor_composite_reputation(env: Env, anchor: Address) -> u32 {
+        let record: AnchorReputationRecord = match env
+            .storage()
+            .persistent()
+            .get(&Self::reputation_record_key(&env, &anchor))
+        {
+            Some(r) => r,
+            None => return 0,
+        };
+        let weights: ReputationWeights = env
+            .storage()
+            .persistent()
+            .get(&Self::reputation_weights_key(&env))
+            .unwrap_or_else(ReputationWeights::default_weights);
+        weights.compute_composite(&record)
+    }
+
+    /// Return all anchors ranked by their composite reputation score in
+    /// descending order.
+    ///
+    /// Anchors with equal scores are ordered deterministically by ascending
+    /// anchor-address byte representation (XDR encoding). Anchors without a
+    /// reputation record are included with a score of 0, after all scored
+    /// anchors.
+    ///
+    /// Only anchors registered in the anchor list are considered.
+    pub fn rank_anchors_by_reputation(env: Env) -> Vec<Address> {
+        let weights: ReputationWeights = env
+            .storage()
+            .persistent()
+            .get(&Self::reputation_weights_key(&env))
+            .unwrap_or_else(ReputationWeights::default_weights);
+
+        let list_key = make_storage_key(&env, &[b"ANCHLIST"]);
+        let anchors: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<Address>>(&list_key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        // Score each anchor; collect as (score, xdr_bytes) for deterministic sort.
+        let mut scored: alloc::vec::Vec<(u32, alloc::vec::Vec<u8>, Address)> =
+            alloc::vec::Vec::new();
+        for anchor in anchors.iter() {
+            let score: u32 = match env
+                .storage()
+                .persistent()
+                .get(&Self::reputation_record_key(&env, &anchor))
+            {
+                Some(record) => weights.compute_composite(&record),
+                None => 0,
+            };
+            let xdr = anchor.clone().to_xdr(&env);
+            let xdr_bytes = xdr_to_vec(&xdr);
+            scored.push((score, xdr_bytes, anchor));
+        }
+
+        // Sort: primary descending score, secondary ascending XDR bytes.
+        scored.sort_unstable_by(|a, b| {
+            b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1))
+        });
+
+        let mut result: Vec<Address> = Vec::new(&env);
+        for (_, _, anchor) in scored {
+            result.push_back(anchor);
+        }
+        result
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #658: Time-based routing policies
+    // -----------------------------------------------------------------------
+
+    /// Storage key for the global timed-policy counter.
+    fn timed_policy_count_key(env: &Env) -> BytesN<32> {
+        make_storage_key(env, &[b"TPOLCNT"])
+    }
+
+    /// Storage key for a timed routing policy record.
+    fn timed_policy_key(env: &Env, policy_id: u64) -> BytesN<32> {
+        make_storage_key(env, &[b"TPOL", &policy_id.to_be_bytes()])
+    }
+
+    /// Register a new time-based routing policy.
+    ///
+    /// The policy becomes a candidate for selection by
+    /// `get_active_routing_policy` during the specified time window.
+    ///
+    /// # Validation
+    ///
+    /// * `strategy_name` must be non-empty.
+    /// * `window_start_secs` and `window_end_secs` must be in [0, 86 399].
+    ///   Equal values create an always-active policy.
+    ///
+    /// # Returns
+    ///
+    /// The assigned `policy_id` (monotonically increasing).
+    ///
+    /// # Authorization
+    ///
+    /// Requires admin privileges.
+    pub fn register_timed_routing_policy(
+        env: Env,
+        name: String,
+        strategy_name: String,
+        window_start_secs: u32,
+        window_end_secs: u32,
+        priority: u32,
+    ) -> u64 {
+        Self::require_admin(&env);
+        if strategy_name.is_empty() {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        const SECS_PER_DAY: u32 = 86_400;
+        if window_start_secs >= SECS_PER_DAY || window_end_secs >= SECS_PER_DAY {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+
+        let cnt_key = Self::timed_policy_count_key(&env);
+        let policy_id: u64 = env
+            .storage()
+            .persistent()
+            .get::<_, u64>(&cnt_key)
+            .unwrap_or(0);
+        let next_id = policy_id + 1;
+
+        let policy = TimedRoutingPolicy {
+            policy_id: next_id,
+            name,
+            strategy_name,
+            window: RoutingTimeWindow {
+                window_start_secs,
+                window_end_secs,
+            },
+            priority,
+            enabled: true,
+        };
+
+        let pol_key = Self::timed_policy_key(&env, next_id);
+        env.storage().persistent().set(&pol_key, &policy);
+        env.storage().persistent().extend_ttl(&pol_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        env.storage().persistent().set(&cnt_key, &next_id);
+        env.storage().persistent().extend_ttl(&cnt_key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("tpol"), symbol_short!("added")),
+            next_id,
+        );
+
+        next_id
+    }
+
+    /// Enable or disable a timed routing policy by ID.
+    ///
+    /// Panics with `ValidationError` when the policy does not exist.
+    ///
+    /// # Authorization
+    ///
+    /// Requires admin privileges.
+    pub fn set_timed_policy_enabled(env: Env, policy_id: u64, enabled: bool) {
+        Self::require_admin(&env);
+        let pol_key = Self::timed_policy_key(&env, policy_id);
+        let mut policy: TimedRoutingPolicy = env
+            .storage()
+            .persistent()
+            .get(&pol_key)
+            .unwrap_or_else(|| panic_with_error!(&env, ErrorCode::ValidationError));
+        policy.enabled = enabled;
+        env.storage().persistent().set(&pol_key, &policy);
+        env.storage().persistent().extend_ttl(&pol_key, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    /// Retrieve a timed routing policy by ID.
+    ///
+    /// Returns `None` when no policy with that ID exists.
+    pub fn get_timed_routing_policy(env: Env, policy_id: u64) -> Option<TimedRoutingPolicy> {
+        env.storage().persistent().get(&Self::timed_policy_key(&env, policy_id))
+    }
+
+    /// Evaluate which routing strategy is active at `unix_timestamp`.
+    ///
+    /// Iterates over all registered policies and returns the `strategy_name`
+    /// of the highest-priority enabled policy whose time window contains
+    /// `unix_timestamp % 86 400` (seconds since midnight UTC).
+    ///
+    /// When multiple policies share the same priority the one with the lowest
+    /// `policy_id` is chosen (deterministic tie-break).
+    ///
+    /// Returns `None` when no policy is active at the given time.
+    pub fn get_active_routing_policy(env: Env, unix_timestamp: u64) -> Option<String> {
+        let time_of_day = (unix_timestamp % 86_400) as u32;
+        let cnt_key = Self::timed_policy_count_key(&env);
+        let count: u64 = env
+            .storage()
+            .persistent()
+            .get::<_, u64>(&cnt_key)
+            .unwrap_or(0);
+
+        let mut best: Option<(u32, u64, String)> = None; // (priority, id, strategy)
+
+        for id in 1..=count {
+            let pol_key = Self::timed_policy_key(&env, id);
+            let policy: TimedRoutingPolicy = match env.storage().persistent().get(&pol_key) {
+                Some(p) => p,
+                None => continue,
+            };
+            if !policy.enabled {
+                continue;
+            }
+            if !policy.window.is_active(time_of_day) {
+                continue;
+            }
+            // Lower priority number wins; break ties by lower policy_id.
+            let better = match &best {
+                None => true,
+                Some((best_prio, best_id, _)) => {
+                    policy.priority < *best_prio
+                        || (policy.priority == *best_prio && id < *best_id)
+                }
+            };
+            if better {
+                best = Some((policy.priority, id, policy.strategy_name));
+            }
+        }
+
+        best.map(|(_, _, strategy)| strategy)
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #659: Per-network routing profiles
+    // -----------------------------------------------------------------------
+
+    /// Storage key for a network routing profile.
+    fn network_profile_key(env: &Env, network_name: &String) -> BytesN<32> {
+        let name_bytes = network_name.to_string().into_bytes();
+        make_storage_key(env, &[b"NETPROF", &name_bytes])
+    }
+
+    /// Storage key for the name of the active network context.
+    fn active_network_key(env: &Env) -> BytesN<32> {
+        make_storage_key(env, &[b"ACTNET"])
+    }
+
+    /// Register or replace a per-network routing profile.
+    ///
+    /// When `is_default` is `true` this profile becomes the fallback used when
+    /// no profile matches the active network context.  Only one default profile
+    /// is meaningful; registering multiple default profiles is allowed but the
+    /// most-recently set one is used by `get_routing_profile`.
+    ///
+    /// # Validation
+    ///
+    /// * `network_name` must be non-empty.
+    /// * `fee_weight + speed_weight + reputation_weight` must equal 1 000.
+    /// * `default_strategy` must be non-empty.
+    ///
+    /// # Authorization
+    ///
+    /// Requires admin privileges.
+    pub fn register_network_routing_profile(
+        env: Env,
+        network_name: String,
+        default_strategy: String,
+        fee_weight: u32,
+        speed_weight: u32,
+        reputation_weight: u32,
+        min_reputation: u32,
+        is_default: bool,
+    ) {
+        Self::require_admin(&env);
+        if network_name.is_empty() {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        if default_strategy.is_empty() {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        if fee_weight
+            .checked_add(speed_weight)
+            .and_then(|s| s.checked_add(reputation_weight))
+            != Some(1_000)
+        {
+            panic_with_error!(&env, ErrorCode::InvalidWeights);
+        }
+
+        let profile = NetworkRoutingProfile {
+            network_name: network_name.clone(),
+            default_strategy,
+            fee_weight,
+            speed_weight,
+            reputation_weight,
+            min_reputation,
+            is_default,
+        };
+
+        // If this is the new default, persist its name for fast fallback lookup.
+        if is_default {
+            let def_key = make_storage_key(&env, &[b"DEFNET"]);
+            env.storage().persistent().set(&def_key, &network_name);
+            env.storage().persistent().extend_ttl(&def_key, PERSISTENT_TTL, PERSISTENT_TTL);
+        }
+
+        let key = Self::network_profile_key(&env, &network_name);
+        env.storage().persistent().set(&key, &profile);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+
+        env.events().publish(
+            (symbol_short!("netprof"), symbol_short!("set")),
+            network_name,
+        );
+    }
+
+    /// Set the active network context.
+    ///
+    /// Subsequent calls to `get_routing_profile` will look up the profile
+    /// registered for `network_name` first.
+    ///
+    /// # Authorization
+    ///
+    /// Requires admin privileges.
+    pub fn set_active_network(env: Env, network_name: String) {
+        Self::require_admin(&env);
+        if network_name.is_empty() {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+        let key = Self::active_network_key(&env);
+        env.storage().persistent().set(&key, &network_name);
+        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL, PERSISTENT_TTL);
+    }
+
+    /// Retrieve the active network name, or `None` when none has been set.
+    pub fn get_active_network(env: Env) -> Option<String> {
+        env.storage().persistent().get(&Self::active_network_key(&env))
+    }
+
+    /// Retrieve a network routing profile by name.
+    ///
+    /// Returns `None` when no profile exists for `network_name`.
+    pub fn get_network_routing_profile(
+        env: Env,
+        network_name: String,
+    ) -> Option<NetworkRoutingProfile> {
+        env.storage()
+            .persistent()
+            .get(&Self::network_profile_key(&env, &network_name))
+    }
+
+    /// Resolve the routing profile for the current network context.
+    ///
+    /// Resolution order:
+    /// 1. The profile matching the active network (set via `set_active_network`).
+    /// 2. The profile marked `is_default` (set via `register_network_routing_profile`
+    ///    with `is_default = true`).
+    /// 3. `None` — callers fall back to their built-in defaults.
+    pub fn get_routing_profile(env: Env) -> Option<NetworkRoutingProfile> {
+        // 1. Try the active network context.
+        let active_key = Self::active_network_key(&env);
+        if let Some(active_name) = env
+            .storage()
+            .persistent()
+            .get::<_, String>(&active_key)
+        {
+            if let Some(profile) = env
+                .storage()
+                .persistent()
+                .get::<_, NetworkRoutingProfile>(&Self::network_profile_key(&env, &active_name))
+            {
+                return Some(profile);
+            }
+        }
+
+        // 2. Fall back to the explicitly designated default profile.
+        let def_key = make_storage_key(&env, &[b"DEFNET"]);
+        if let Some(def_name) = env
+            .storage()
+            .persistent()
+            .get::<_, String>(&def_key)
+        {
+            if let Some(profile) = env
+                .storage()
+                .persistent()
+                .get::<_, NetworkRoutingProfile>(&Self::network_profile_key(&env, &def_name))
+            {
+                if profile.is_default {
+                    return Some(profile);
+                }
+            }
+        }
+
+        None
     }
 
     // -----------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,11 @@ pub use response_validator::{
     AnchorInfoResponse, DepositResponse as ValidatorDepositResponse, QuoteResponse,
     Sep38QuoteResponse, WithdrawResponse, TransactionStatusResponseValidated,
     SchemaVersion, VALIDATOR_SCHEMA_V1,
+    // Issue #661: response shape compatibility checks for older anchors
+    CompatibilityLevel, CompatibilityReport,
+    check_deposit_compatibility, check_withdraw_compatibility,
+    check_sep38_quote_compatibility, check_anchor_info_compatibility,
+    check_transaction_status_compatibility,
 };
 #[cfg(not(feature = "wasm"))]
 pub use webhook::{deliver_webhook, get_dead_letter_webhooks, query_dlq, verify_webhook_signature, WebhookDeliveryConfig, DlqEntry};
@@ -248,6 +253,12 @@ pub use admin_audit_log::{AdminAuditLog, AdminConfigChangeEvent, AdminAuditLogCo
 pub use contract::{HealthStatus, MetadataFreshnessReport, RateLimiterHealth};
 pub use contract::{AnchorHealthMetrics, AnchorProofRecord};
 pub use transaction_state_tracker::{BudgetStatus, BudgetAlert};
+// Issue #657: multi-anchor reputation weighting
+pub use contract::{AnchorReputationRecord, ReputationWeights};
+// Issue #658: time-based routing policies
+pub use contract::{RoutingTimeWindow, TimedRoutingPolicy};
+// Issue #659: per-network routing profiles
+pub use contract::NetworkRoutingProfile;
 #[cfg(not(feature = "wasm"))]
 pub use sep38::{CrossAnchorFeeAggregator, FeeAnomalyReport};
 #[cfg(not(feature = "wasm"))]

--- a/src/response_validator.rs
+++ b/src/response_validator.rs
@@ -675,6 +675,241 @@ pub fn validate_stellar_account_id(account_id: &str) -> Result<(), Error> {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+// ── Issue #661: Response shape compatibility checks for older anchors ──────────
+
+/// Classification of how compatible a response from an anchor is with the
+/// current schema expectations.
+///
+/// Compatibility is intentionally non-binary: an older anchor may omit
+/// optional fields that were added in later schema iterations while still
+/// providing all required fields.  This enum lets callers decide whether to
+/// accept, warn, or reject a response rather than applying a hard pass/fail.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum CompatibilityLevel {
+    /// All required **and** optional fields are present and valid.
+    FullyCompatible,
+    /// All required fields are present and valid, but one or more optional
+    /// fields recognised by the current schema are absent.  The response is
+    /// usable but callers may miss enriched data.
+    PartiallyCompatible,
+    /// One or more required fields are missing or invalid.  The response
+    /// cannot be used safely.
+    Incompatible,
+}
+
+impl CompatibilityLevel {
+    /// Returns a human-readable label for this compatibility level.
+    pub fn label(&self) -> &'static str {
+        match self {
+            CompatibilityLevel::FullyCompatible   => "fully_compatible",
+            CompatibilityLevel::PartiallyCompatible => "partially_compatible",
+            CompatibilityLevel::Incompatible        => "incompatible",
+        }
+    }
+
+    /// Returns `true` when the response is safe to use (required fields are
+    /// all present), regardless of whether optional fields are missing.
+    pub fn is_usable(&self) -> bool {
+        matches!(self, CompatibilityLevel::FullyCompatible | CompatibilityLevel::PartiallyCompatible)
+    }
+}
+
+/// Result of a compatibility check, pairing the level with a human-readable
+/// reason and the list of optional fields that were absent.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompatibilityReport {
+    /// The overall compatibility classification.
+    pub level: CompatibilityLevel,
+    /// Short explanation of why this level was assigned.
+    pub reason: alloc::string::String,
+    /// Names of optional fields that are absent in this response.
+    pub missing_optional_fields: alloc::vec::Vec<alloc::string::String>,
+}
+
+impl CompatibilityReport {
+    fn fully_compatible() -> Self {
+        CompatibilityReport {
+            level: CompatibilityLevel::FullyCompatible,
+            reason: alloc::string::String::from("all required and optional fields present"),
+            missing_optional_fields: alloc::vec::Vec::new(),
+        }
+    }
+
+    fn partially_compatible(missing: alloc::vec::Vec<alloc::string::String>) -> Self {
+        CompatibilityReport {
+            level: CompatibilityLevel::PartiallyCompatible,
+            reason: alloc::string::String::from("required fields present; optional fields missing"),
+            missing_optional_fields: missing,
+        }
+    }
+
+    fn incompatible(reason: &str) -> Self {
+        CompatibilityReport {
+            level: CompatibilityLevel::Incompatible,
+            reason: alloc::string::String::from(reason),
+            missing_optional_fields: alloc::vec::Vec::new(),
+        }
+    }
+}
+
+// ── Deposit compatibility ──────────────────────────────────────────────────
+
+/// Check compatibility of a raw deposit response from an older anchor.
+///
+/// Required fields: `transaction_id`, `status`, `deposit_address`.
+/// Optional fields (recognised by the current schema): `expires_at`.
+///
+/// | transaction_id | status | deposit_address | expires_at | Result |
+/// |---|---|---|---|---|
+/// | present & valid | valid SEP-6 status | non-empty | any | FullyCompatible or PartiallyCompatible |
+/// | empty            | –                 | –          | –   | Incompatible |
+/// | present          | empty / invalid   | –          | –   | Incompatible |
+/// | present          | valid             | empty      | –   | Incompatible |
+pub fn check_deposit_compatibility(
+    transaction_id: &str,
+    status: &str,
+    deposit_address: &str,
+    expires_at: Option<u64>,
+) -> CompatibilityReport {
+    if transaction_id.is_empty() {
+        return CompatibilityReport::incompatible("transaction_id is missing");
+    }
+    if status.is_empty() || !is_valid_sep6_status(status) {
+        return CompatibilityReport::incompatible("status is missing or not a recognised SEP-6 value");
+    }
+    if deposit_address.is_empty() {
+        return CompatibilityReport::incompatible("deposit_address is missing");
+    }
+
+    if expires_at.is_none() {
+        CompatibilityReport::partially_compatible(alloc::vec![alloc::string::String::from("expires_at")])
+    } else {
+        CompatibilityReport::fully_compatible()
+    }
+}
+
+// ── Withdraw compatibility ─────────────────────────────────────────────────
+
+/// Check compatibility of a raw withdrawal response from an older anchor.
+///
+/// Required fields: `transaction_id`, `status`.
+/// Optional fields: `estimated_completion`.
+pub fn check_withdraw_compatibility(
+    transaction_id: &str,
+    status: &str,
+    estimated_completion: Option<u64>,
+) -> CompatibilityReport {
+    if transaction_id.is_empty() {
+        return CompatibilityReport::incompatible("transaction_id is missing");
+    }
+    if status.is_empty() || !is_valid_sep6_status(status) {
+        return CompatibilityReport::incompatible("status is missing or not a recognised SEP-6 value");
+    }
+
+    if estimated_completion.is_none() {
+        CompatibilityReport::partially_compatible(
+            alloc::vec![alloc::string::String::from("estimated_completion")],
+        )
+    } else {
+        CompatibilityReport::fully_compatible()
+    }
+}
+
+// ── SEP-38 quote compatibility ─────────────────────────────────────────────
+
+/// Check compatibility of a raw SEP-38 quote response from an older anchor.
+///
+/// Required fields: `id`, `price`, `sell_amount`, `buy_amount`.
+/// Optional fields: `expires_at`, `fee`.
+pub fn check_sep38_quote_compatibility(
+    id: &str,
+    price: &str,
+    sell_amount: &str,
+    buy_amount: &str,
+    expires_at: Option<&str>,
+    fee: Option<&str>,
+) -> CompatibilityReport {
+    if id.is_empty() {
+        return CompatibilityReport::incompatible("id is missing");
+    }
+    if price.is_empty() || !is_valid_positive_decimal(price) {
+        return CompatibilityReport::incompatible(
+            "price is missing or not a positive number",
+        );
+    }
+    if sell_amount.is_empty() || !is_valid_positive_decimal(sell_amount) {
+        return CompatibilityReport::incompatible(
+            "sell_amount is missing or not a positive number",
+        );
+    }
+    if buy_amount.is_empty() || !is_valid_positive_decimal(buy_amount) {
+        return CompatibilityReport::incompatible(
+            "buy_amount is missing or not a positive number",
+        );
+    }
+
+    let mut missing: alloc::vec::Vec<alloc::string::String> = alloc::vec::Vec::new();
+    if expires_at.map(|s| s.is_empty()).unwrap_or(true) {
+        missing.push(alloc::string::String::from("expires_at"));
+    }
+    if fee.map(|s| s.is_empty()).unwrap_or(true) {
+        missing.push(alloc::string::String::from("fee"));
+    }
+
+    if missing.is_empty() {
+        CompatibilityReport::fully_compatible()
+    } else {
+        CompatibilityReport::partially_compatible(missing)
+    }
+}
+
+// ── Anchor info compatibility ──────────────────────────────────────────────
+
+/// Check compatibility of a raw anchor info response from an older anchor.
+///
+/// Required fields: `name`, `supported_assets` (non-empty).
+/// Optional fields: none currently defined — this is reserved for future
+/// schema additions (e.g. `contact_email`, `documentation_url`).
+pub fn check_anchor_info_compatibility(
+    name: &str,
+    supported_assets: &[alloc::string::String],
+) -> CompatibilityReport {
+    if name.is_empty() {
+        return CompatibilityReport::incompatible("name is missing");
+    }
+    if supported_assets.is_empty() {
+        return CompatibilityReport::incompatible("supported_assets is missing or empty");
+    }
+    CompatibilityReport::fully_compatible()
+}
+
+// ── Transaction status compatibility ──────────────────────────────────────
+
+/// Check compatibility of a raw transaction status response from an older anchor.
+///
+/// Required fields: `transaction_id`, `status`, `kind`.
+/// Optional fields: none currently defined.
+pub fn check_transaction_status_compatibility(
+    transaction_id: &str,
+    status: &str,
+    kind: &str,
+) -> CompatibilityReport {
+    if transaction_id.is_empty() {
+        return CompatibilityReport::incompatible("transaction_id is missing");
+    }
+    if status.is_empty() || !is_valid_sep6_status(status) {
+        return CompatibilityReport::incompatible(
+            "status is missing or not a recognised SEP-6 value",
+        );
+    }
+    if kind.is_empty() {
+        return CompatibilityReport::incompatible("kind is missing");
+    }
+    CompatibilityReport::fully_compatible()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1252,5 +1487,188 @@ mod tests {
         let assets = alloc::vec![alloc::string::String::from("native")];
         let r = validate_anchor_info_with_version("A", assets, SchemaVersion::V1).unwrap();
         assert_eq!(r.schema_version, SchemaVersion::V1);
+    }
+
+    // ── Issue #661: compatibility check tests ─────────────────────────────────
+
+    // -- CompatibilityLevel helpers --
+
+    #[test]
+    fn test_compatibility_level_is_usable() {
+        assert!(CompatibilityLevel::FullyCompatible.is_usable());
+        assert!(CompatibilityLevel::PartiallyCompatible.is_usable());
+        assert!(!CompatibilityLevel::Incompatible.is_usable());
+    }
+
+    #[test]
+    fn test_compatibility_level_labels() {
+        assert_eq!(CompatibilityLevel::FullyCompatible.label(),    "fully_compatible");
+        assert_eq!(CompatibilityLevel::PartiallyCompatible.label(), "partially_compatible");
+        assert_eq!(CompatibilityLevel::Incompatible.label(),        "incompatible");
+    }
+
+    // -- Deposit compatibility --
+
+    #[test]
+    fn test_deposit_compat_fully_compatible() {
+        let r = check_deposit_compatibility("txn-1", "completed", "GABC...", Some(9999999));
+        assert_eq!(r.level, CompatibilityLevel::FullyCompatible);
+        assert!(r.is_usable());
+        assert!(r.missing_optional_fields.is_empty());
+    }
+
+    #[test]
+    fn test_deposit_compat_partially_compatible_missing_expires_at() {
+        let r = check_deposit_compatibility("txn-1", "pending", "GABC...", None);
+        assert_eq!(r.level, CompatibilityLevel::PartiallyCompatible);
+        assert!(r.is_usable());
+        assert!(r.missing_optional_fields.contains(&alloc::string::String::from("expires_at")));
+    }
+
+    #[test]
+    fn test_deposit_compat_incompatible_missing_txn_id() {
+        let r = check_deposit_compatibility("", "completed", "GABC...", None);
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+        assert!(!r.is_usable());
+    }
+
+    #[test]
+    fn test_deposit_compat_incompatible_invalid_status() {
+        let r = check_deposit_compatibility("txn-1", "unknown_status", "GABC...", None);
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    #[test]
+    fn test_deposit_compat_incompatible_empty_address() {
+        let r = check_deposit_compatibility("txn-1", "completed", "", None);
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    // -- Withdraw compatibility --
+
+    #[test]
+    fn test_withdraw_compat_fully_compatible() {
+        let r = check_withdraw_compatibility("txn-2", "completed", Some(1_700_000_000));
+        assert_eq!(r.level, CompatibilityLevel::FullyCompatible);
+        assert!(r.missing_optional_fields.is_empty());
+    }
+
+    #[test]
+    fn test_withdraw_compat_partially_compatible_missing_estimated_completion() {
+        let r = check_withdraw_compatibility("txn-2", "pending_external", None);
+        assert_eq!(r.level, CompatibilityLevel::PartiallyCompatible);
+        assert!(r.missing_optional_fields.contains(
+            &alloc::string::String::from("estimated_completion")
+        ));
+    }
+
+    #[test]
+    fn test_withdraw_compat_incompatible_empty_status() {
+        let r = check_withdraw_compatibility("txn-2", "", None);
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    #[test]
+    fn test_withdraw_compat_incompatible_missing_txn_id() {
+        let r = check_withdraw_compatibility("", "completed", Some(0));
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    // -- SEP-38 quote compatibility --
+
+    #[test]
+    fn test_sep38_quote_compat_fully_compatible() {
+        let r = check_sep38_quote_compatibility(
+            "qid", "1.5", "100.0", "150.0",
+            Some("2026-01-01T00:00:00Z"), Some("0.5"),
+        );
+        assert_eq!(r.level, CompatibilityLevel::FullyCompatible);
+    }
+
+    #[test]
+    fn test_sep38_quote_compat_partially_compatible_missing_both_optional() {
+        let r = check_sep38_quote_compatibility(
+            "qid", "1.5", "100.0", "150.0", None, None,
+        );
+        assert_eq!(r.level, CompatibilityLevel::PartiallyCompatible);
+        assert!(r.missing_optional_fields.contains(&alloc::string::String::from("expires_at")));
+        assert!(r.missing_optional_fields.contains(&alloc::string::String::from("fee")));
+    }
+
+    #[test]
+    fn test_sep38_quote_compat_partially_compatible_missing_fee_only() {
+        let r = check_sep38_quote_compatibility(
+            "qid", "1.5", "100.0", "150.0",
+            Some("2026-01-01T00:00:00Z"), None,
+        );
+        assert_eq!(r.level, CompatibilityLevel::PartiallyCompatible);
+        assert!(r.missing_optional_fields.contains(&alloc::string::String::from("fee")));
+        assert!(!r.missing_optional_fields.contains(&alloc::string::String::from("expires_at")));
+    }
+
+    #[test]
+    fn test_sep38_quote_compat_incompatible_empty_id() {
+        let r = check_sep38_quote_compatibility("", "1.5", "100.0", "150.0", None, None);
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    #[test]
+    fn test_sep38_quote_compat_incompatible_invalid_price() {
+        let r = check_sep38_quote_compatibility("qid", "not-a-number", "100.0", "150.0", None, None);
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    #[test]
+    fn test_sep38_quote_compat_incompatible_zero_sell_amount() {
+        let r = check_sep38_quote_compatibility("qid", "1.5", "0.0", "150.0", None, None);
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    // -- Anchor info compatibility --
+
+    #[test]
+    fn test_anchor_info_compat_fully_compatible() {
+        let assets = alloc::vec![alloc::string::String::from("native")];
+        let r = check_anchor_info_compatibility("Anchor Corp", &assets);
+        assert_eq!(r.level, CompatibilityLevel::FullyCompatible);
+    }
+
+    #[test]
+    fn test_anchor_info_compat_incompatible_empty_name() {
+        let assets = alloc::vec![alloc::string::String::from("native")];
+        let r = check_anchor_info_compatibility("", &assets);
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    #[test]
+    fn test_anchor_info_compat_incompatible_empty_assets() {
+        let r = check_anchor_info_compatibility("Anchor Corp", &[]);
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    // -- Transaction status compatibility --
+
+    #[test]
+    fn test_tx_status_compat_fully_compatible() {
+        let r = check_transaction_status_compatibility("txn-99", "completed", "deposit");
+        assert_eq!(r.level, CompatibilityLevel::FullyCompatible);
+    }
+
+    #[test]
+    fn test_tx_status_compat_incompatible_missing_kind() {
+        let r = check_transaction_status_compatibility("txn-99", "completed", "");
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    #[test]
+    fn test_tx_status_compat_incompatible_invalid_status() {
+        let r = check_transaction_status_compatibility("txn-99", "bad_status", "deposit");
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    #[test]
+    fn test_tx_status_compat_incompatible_empty_txn_id() {
+        let r = check_transaction_status_compatibility("", "completed", "withdrawal");
+        assert_eq!(r.level, CompatibilityLevel::Incompatible);
     }
 }

--- a/tests/network_routing_profile_tests.rs
+++ b/tests/network_routing_profile_tests.rs
@@ -1,0 +1,312 @@
+/// Tests for issue #659: Per-network routing profiles.
+///
+/// Covers:
+/// - Registering and retrieving named network routing profiles.
+/// - Setting the active network context.
+/// - get_routing_profile returns the active network profile.
+/// - get_routing_profile falls back to the default profile when no active match.
+/// - get_routing_profile returns None when neither active nor default is set.
+/// - Multiple profiles coexist; only the active network's profile is returned.
+/// - Default profile fallback when active network profile is missing.
+/// - Validation: empty network name is rejected.
+/// - Validation: empty strategy name is rejected.
+/// - Validation: weights not summing to 1 000 are rejected.
+#[cfg(test)]
+
+mod network_routing_profile_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env, String,
+    };
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, timestamp: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin)
+    }
+
+    fn register_testnet_profile(env: &Env, client: &AnchorKitContractClient, is_default: bool) {
+        client.register_network_routing_profile(
+            &String::from_str(env, "testnet"),
+            &String::from_str(env, "LowestFee"),
+            &400u32, &300u32, &300u32, // weights sum to 1 000
+            &0u32,
+            &is_default,
+        );
+    }
+
+    fn register_mainnet_profile(env: &Env, client: &AnchorKitContractClient, is_default: bool) {
+        client.register_network_routing_profile(
+            &String::from_str(env, "mainnet"),
+            &String::from_str(env, "WeightedScore"),
+            &333u32, &333u32, &334u32,
+            &5000u32, // higher minimum reputation on mainnet
+            &is_default,
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Registration and retrieval
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_register_and_retrieve_profile() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        register_testnet_profile(&env, &client, false);
+
+        let profile = client.get_network_routing_profile(&String::from_str(&env, "testnet"));
+        assert!(profile.is_some());
+        let p = profile.unwrap();
+        assert_eq!(p.network_name, String::from_str(&env, "testnet"));
+        assert_eq!(p.fee_weight, 400);
+        assert_eq!(p.speed_weight, 300);
+        assert_eq!(p.reputation_weight, 300);
+        assert_eq!(p.min_reputation, 0);
+        assert!(!p.is_default);
+    }
+
+    #[test]
+    fn test_get_nonexistent_profile_returns_none() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let result = client.get_network_routing_profile(&String::from_str(&env, "unknown"));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_multiple_profiles_coexist() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        register_testnet_profile(&env, &client, false);
+        register_mainnet_profile(&env, &client, false);
+
+        let testnet = client.get_network_routing_profile(&String::from_str(&env, "testnet"));
+        let mainnet = client.get_network_routing_profile(&String::from_str(&env, "mainnet"));
+
+        assert!(testnet.is_some());
+        assert!(mainnet.is_some());
+        assert_eq!(testnet.unwrap().min_reputation, 0);
+        assert_eq!(mainnet.unwrap().min_reputation, 5000);
+    }
+
+    // -----------------------------------------------------------------------
+    // Active network context
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_set_and_get_active_network() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        client.set_active_network(&String::from_str(&env, "testnet"));
+        let active = client.get_active_network();
+        assert!(active.is_some());
+        assert_eq!(active.unwrap(), String::from_str(&env, "testnet"));
+    }
+
+    #[test]
+    fn test_get_active_network_returns_none_when_unset() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let active = client.get_active_network();
+        assert!(active.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Profile resolution via get_routing_profile
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_routing_profile_returns_active_network_profile() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        register_testnet_profile(&env, &client, false);
+        register_mainnet_profile(&env, &client, true); // mainnet is default
+
+        client.set_active_network(&String::from_str(&env, "testnet"));
+
+        let profile = client.get_routing_profile();
+        assert!(profile.is_some());
+        // Should return testnet (active network), not mainnet (default).
+        assert_eq!(
+            profile.unwrap().network_name,
+            String::from_str(&env, "testnet")
+        );
+    }
+
+    #[test]
+    fn test_get_routing_profile_falls_back_to_default_when_active_missing() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // Register only a default profile, no active network set.
+        register_mainnet_profile(&env, &client, true);
+
+        let profile = client.get_routing_profile();
+        assert!(profile.is_some());
+        assert_eq!(
+            profile.unwrap().network_name,
+            String::from_str(&env, "mainnet")
+        );
+    }
+
+    #[test]
+    fn test_get_routing_profile_falls_back_to_default_when_active_profile_not_registered() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // Set active network to "local" but no "local" profile exists.
+        register_mainnet_profile(&env, &client, true);
+        client.set_active_network(&String::from_str(&env, "local"));
+
+        let profile = client.get_routing_profile();
+        // Should fall back to mainnet default.
+        assert!(profile.is_some());
+        assert_eq!(
+            profile.unwrap().network_name,
+            String::from_str(&env, "mainnet")
+        );
+    }
+
+    #[test]
+    fn test_get_routing_profile_returns_none_when_nothing_registered() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let profile = client.get_routing_profile();
+        assert!(profile.is_none());
+    }
+
+    #[test]
+    fn test_registering_new_default_replaces_old_default() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // testnet is the first default.
+        register_testnet_profile(&env, &client, true);
+        // mainnet replaces it as default.
+        register_mainnet_profile(&env, &client, true);
+
+        // No active network set → should get mainnet (most recent default).
+        let profile = client.get_routing_profile();
+        assert!(profile.is_some());
+        assert_eq!(
+            profile.unwrap().network_name,
+            String::from_str(&env, "mainnet")
+        );
+    }
+
+    #[test]
+    fn test_default_profile_includes_correct_weights() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        register_mainnet_profile(&env, &client, true);
+
+        let profile = client.get_routing_profile().unwrap();
+        assert_eq!(profile.fee_weight + profile.speed_weight + profile.reputation_weight, 1_000);
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn test_register_profile_rejects_empty_network_name() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        client.register_network_routing_profile(
+            &String::from_str(&env, ""), // empty
+            &String::from_str(&env, "LowestFee"),
+            &400u32, &300u32, &300u32,
+            &0u32,
+            &false,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_register_profile_rejects_empty_strategy_name() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        client.register_network_routing_profile(
+            &String::from_str(&env, "testnet"),
+            &String::from_str(&env, ""), // empty
+            &400u32, &300u32, &300u32,
+            &0u32,
+            &false,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_register_profile_rejects_weights_not_summing_to_1000() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // 400 + 300 + 200 = 900 ≠ 1 000
+        client.register_network_routing_profile(
+            &String::from_str(&env, "testnet"),
+            &String::from_str(&env, "LowestFee"),
+            &400u32, &300u32, &200u32, // invalid
+            &0u32,
+            &false,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_set_active_network_rejects_empty_name() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        client.set_active_network(&String::from_str(&env, ""));
+    }
+}

--- a/tests/reputation_weighting_tests.rs
+++ b/tests/reputation_weighting_tests.rs
@@ -1,0 +1,363 @@
+/// Tests for issue #657: Multi-anchor reputation weighting.
+///
+/// Covers:
+/// - Setting and retrieving per-anchor reputation records.
+/// - Getting and setting contract-wide reputation weights.
+/// - Computing composite reputation scores.
+/// - Ranking anchors deterministically (tie-breaking by anchor XDR order).
+/// - Validation: successful_routed > total_routed is rejected.
+/// - Validation: invalid reputation weights are rejected.
+/// - New anchors with no record return score 0.
+#[cfg(test)]
+
+#[path = "sep10_test_util.rs"]
+mod sep10_test_util;
+
+mod reputation_weighting_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env,
+    };
+
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    use anchorkit::contract::{
+        AnchorKitContract, AnchorKitContractClient, ReputationWeights,
+    };
+    use crate::sep10_test_util::register_attestor_with_sep10;
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, timestamp: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin)
+    }
+
+    fn register_anchor(env: &Env, client: &AnchorKitContractClient, anchor: &Address) {
+        let signing_key = SigningKey::generate(&mut OsRng);
+        register_attestor_with_sep10(env, client, anchor, anchor, &signing_key);
+        let mut services = soroban_sdk::Vec::new(env);
+        services.push_back(1u32);
+        services.push_back(3u32);
+        client.configure_services(anchor, &services);
+        client.set_anchor_metadata(anchor, &8000u32, &300u64, &8000u32, &9900u32, &1_000_000u64);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reputation record CRUD
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_set_and_get_anchor_reputation() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        client.set_anchor_reputation(
+            &anchor,
+            &100u64, // total_routed
+            &95u64,  // successful_routed
+            &8000u32, // operator_quality_score
+            &9900u64, // uptime_ticks
+            &10000u64, // total_ticks
+        );
+
+        let record = client.get_anchor_reputation(&anchor);
+        assert!(record.is_some());
+        let r = record.unwrap();
+        assert_eq!(r.total_routed, 100);
+        assert_eq!(r.successful_routed, 95);
+        assert_eq!(r.operator_quality_score, 8000);
+        assert_eq!(r.uptime_ticks, 9900);
+        assert_eq!(r.total_ticks, 10000);
+    }
+
+    #[test]
+    fn test_get_anchor_reputation_returns_none_when_unset() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        let record = client.get_anchor_reputation(&anchor);
+        assert!(record.is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_set_reputation_rejects_successful_greater_than_total() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        // successful_routed (120) > total_routed (100) → should panic
+        client.set_anchor_reputation(
+            &anchor,
+            &100u64,
+            &120u64, // invalid
+            &8000u32,
+            &9000u64,
+            &10000u64,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_set_reputation_rejects_operator_quality_above_10000() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        // operator_quality_score > 10 000 → should panic
+        client.set_anchor_reputation(
+            &anchor,
+            &100u64,
+            &90u64,
+            &10_001u32, // invalid
+            &9000u64,
+            &10000u64,
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Reputation weights
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_default_reputation_weights_are_valid() {
+        let weights = ReputationWeights::default_weights();
+        assert!(weights.is_valid());
+        assert_eq!(
+            weights.success_rate_weight + weights.uptime_weight + weights.operator_quality_weight,
+            1_000
+        );
+    }
+
+    #[test]
+    fn test_set_and_get_reputation_weights() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        client.set_reputation_weights(&500u32, &300u32, &200u32);
+        let w = client.get_reputation_weights();
+        assert_eq!(w.success_rate_weight, 500);
+        assert_eq!(w.uptime_weight, 300);
+        assert_eq!(w.operator_quality_weight, 200);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_reputation_weights_rejected() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // 400 + 300 + 200 = 900 ≠ 1 000 → should panic
+        client.set_reputation_weights(&400u32, &300u32, &200u32);
+    }
+
+    // -----------------------------------------------------------------------
+    // Composite score
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_composite_reputation_is_zero_for_unknown_anchor() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        // Never registered — should return 0 without panicking.
+        let score = client.get_anchor_composite_reputation(&anchor);
+        assert_eq!(score, 0);
+    }
+
+    #[test]
+    fn test_perfect_anchor_scores_near_max() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        client.set_anchor_reputation(
+            &anchor,
+            &1000u64,
+            &1000u64,  // 100 % success
+            &10_000u32, // max operator quality
+            &10000u64,
+            &10000u64, // 100 % uptime
+        );
+
+        let score = client.get_anchor_composite_reputation(&anchor);
+        // Perfect on all sub-scores → should be 10 000
+        assert_eq!(score, 10_000);
+    }
+
+    #[test]
+    fn test_zero_activity_anchor_scores_below_perfect() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        client.set_anchor_reputation(
+            &anchor,
+            &0u64,  // no routed yet → success_rate defaults to 1.0
+            &0u64,
+            &0u32,  // no operator quality
+            &0u64,  // no uptime ticks
+            &0u64,  // no total ticks → uptime defaults to 1.0
+        );
+
+        let score = client.get_anchor_composite_reputation(&anchor);
+        // success_rate=1.0 (default), uptime=1.0 (default), operator=0.0
+        // With default weights (0.40, 0.35, 0.25):
+        // = 0.40 * 1.0 + 0.35 * 1.0 + 0.25 * 0.0 = 0.75 → 7 500
+        assert_eq!(score, 7_500);
+    }
+
+    #[test]
+    fn test_high_failure_rate_lowers_score() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let anchor = Address::generate(&env);
+        register_anchor(&env, &client, &anchor);
+
+        client.set_anchor_reputation(
+            &anchor,
+            &100u64,
+            &20u64,   // 20 % success rate
+            &5000u32, // moderate operator quality
+            &10000u64,
+            &10000u64, // perfect uptime
+        );
+
+        let score_low_success = client.get_anchor_composite_reputation(&anchor);
+
+        // Compare to an anchor with perfect success rate
+        let anchor2 = Address::generate(&env);
+        register_anchor(&env, &client, &anchor2);
+        client.set_anchor_reputation(
+            &anchor2,
+            &100u64,
+            &100u64,   // 100 % success rate
+            &5000u32,
+            &10000u64,
+            &10000u64,
+        );
+        let score_high_success = client.get_anchor_composite_reputation(&anchor2);
+
+        assert!(score_high_success > score_low_success);
+    }
+
+    // -----------------------------------------------------------------------
+    // Ranking
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_rank_anchors_by_reputation_descending() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let anchor_low  = Address::generate(&env);
+        let anchor_high = Address::generate(&env);
+        register_anchor(&env, &client, &anchor_low);
+        register_anchor(&env, &client, &anchor_high);
+
+        // low quality
+        client.set_anchor_reputation(&anchor_low,  &100u64, &50u64,  &1000u32, &5000u64, &10000u64);
+        // high quality
+        client.set_anchor_reputation(&anchor_high, &100u64, &99u64, &9000u32, &9800u64, &10000u64);
+
+        let ranked = client.rank_anchors_by_reputation();
+        assert_eq!(ranked.len(), 2);
+        // High-quality anchor should be ranked first.
+        assert_eq!(ranked.get(0).unwrap(), anchor_high);
+        assert_eq!(ranked.get(1).unwrap(), anchor_low);
+    }
+
+    #[test]
+    fn test_rank_anchors_tie_is_deterministic() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let anchor_a = Address::generate(&env);
+        let anchor_b = Address::generate(&env);
+        register_anchor(&env, &client, &anchor_a);
+        register_anchor(&env, &client, &anchor_b);
+
+        // Both anchors get identical reputation records → tie in composite score.
+        for anchor in [&anchor_a, &anchor_b] {
+            client.set_anchor_reputation(
+                anchor,
+                &100u64, &90u64, &7000u32, &8000u64, &10000u64,
+            );
+        }
+
+        // Run ranking twice and verify the order is stable.
+        let ranked1 = client.rank_anchors_by_reputation();
+        let ranked2 = client.rank_anchors_by_reputation();
+        assert_eq!(ranked1.len(), 2);
+        assert_eq!(ranked2.len(), 2);
+        // Same ordering both times.
+        assert_eq!(ranked1.get(0).unwrap(), ranked2.get(0).unwrap());
+        assert_eq!(ranked1.get(1).unwrap(), ranked2.get(1).unwrap());
+    }
+
+    #[test]
+    fn test_rank_anchors_no_record_scores_zero_and_appears_last() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let anchor_scored   = Address::generate(&env);
+        let anchor_unscored = Address::generate(&env);
+        register_anchor(&env, &client, &anchor_scored);
+        register_anchor(&env, &client, &anchor_unscored);
+
+        // Only one anchor has a reputation record.
+        client.set_anchor_reputation(
+            &anchor_scored,
+            &100u64, &95u64, &9000u32, &9900u64, &10000u64,
+        );
+        // anchor_unscored has no record → score 0.
+
+        let ranked = client.rank_anchors_by_reputation();
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked.get(0).unwrap(), anchor_scored);
+        assert_eq!(ranked.get(1).unwrap(), anchor_unscored);
+    }
+}

--- a/tests/timed_routing_policy_tests.rs
+++ b/tests/timed_routing_policy_tests.rs
@@ -1,0 +1,408 @@
+/// Tests for issue #658: Time-based routing policies.
+///
+/// Covers:
+/// - Registering and retrieving timed routing policies.
+/// - Enabling and disabling policies.
+/// - Active policy selection at various times of day.
+/// - Midnight-wrapping windows.
+/// - Always-active policies (start == end).
+/// - Priority and tie-breaking (lowest policy_id wins at equal priority).
+/// - Validation: empty strategy name or out-of-range window seconds rejected.
+/// - get_active_routing_policy returns None when no policy matches.
+#[cfg(test)]
+
+mod timed_routing_policy_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env, String,
+    };
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    fn set_ledger(env: &Env, timestamp: u64) {
+        env.ledger().set(LedgerInfo {
+            timestamp,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6312000,
+        });
+    }
+
+    fn setup(env: &Env) -> (AnchorKitContractClient, Address) {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin)
+    }
+
+    // -----------------------------------------------------------------------
+    // Registration and retrieval
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_register_and_retrieve_policy() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // 09:00 – 17:00 UTC
+        let id = client.register_timed_routing_policy(
+            &String::from_str(&env, "Business Hours"),
+            &String::from_str(&env, "LowestFee"),
+            &32400u32, // 09:00
+            &61200u32, // 17:00
+            &0u32,
+        );
+
+        assert_eq!(id, 1);
+
+        let policy = client.get_timed_routing_policy(&id);
+        assert!(policy.is_some());
+        let p = policy.unwrap();
+        assert_eq!(p.policy_id, 1);
+        assert!(p.enabled);
+        assert_eq!(p.window.window_start_secs, 32400);
+        assert_eq!(p.window.window_end_secs, 61200);
+    }
+
+    #[test]
+    fn test_policy_ids_are_monotonically_increasing() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let id1 = client.register_timed_routing_policy(
+            &String::from_str(&env, "P1"),
+            &String::from_str(&env, "LowestFee"),
+            &0u32, &0u32, &0u32,
+        );
+        let id2 = client.register_timed_routing_policy(
+            &String::from_str(&env, "P2"),
+            &String::from_str(&env, "FastestSettlement"),
+            &0u32, &0u32, &0u32,
+        );
+
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+    }
+
+    #[test]
+    fn test_get_nonexistent_policy_returns_none() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let result = client.get_timed_routing_policy(&999u64);
+        assert!(result.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Enable / disable
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_disable_policy_excluded_from_active_selection() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let id = client.register_timed_routing_policy(
+            &String::from_str(&env, "Always"),
+            &String::from_str(&env, "LowestFee"),
+            &0u32, &0u32, // always-active (start == end)
+            &0u32,
+        );
+
+        // Policy is enabled by default — should be selected at any time.
+        let active = client.get_active_routing_policy(&1_000_000u64);
+        assert!(active.is_some());
+
+        // Disable it.
+        client.set_timed_policy_enabled(&id, &false);
+
+        let active_after = client.get_active_routing_policy(&1_000_000u64);
+        assert!(active_after.is_none());
+    }
+
+    #[test]
+    fn test_re_enable_policy_resumes_selection() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        let id = client.register_timed_routing_policy(
+            &String::from_str(&env, "Always"),
+            &String::from_str(&env, "WeightedScore"),
+            &0u32, &0u32,
+            &0u32,
+        );
+        client.set_timed_policy_enabled(&id, &false);
+        client.set_timed_policy_enabled(&id, &true);
+
+        let active = client.get_active_routing_policy(&1_000_000u64);
+        assert!(active.is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // Active policy evaluation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_policy_active_within_window() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // 10:00 – 12:00 UTC  (36 000 – 43 200 seconds-since-midnight)
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "Morning"),
+            &String::from_str(&env, "FastestSettlement"),
+            &36_000u32,
+            &43_200u32,
+            &0u32,
+        );
+
+        // 11:00 UTC = 39 600 seconds into the day
+        // Use a UNIX timestamp where (ts % 86400) == 39600:
+        // 86400 * N + 39600; pick N=11 → 950 400 + 39 600 = 990 000
+        let ts_inside = 990_000u64;
+        assert_eq!(ts_inside % 86_400, 39_600);
+
+        let active = client.get_active_routing_policy(&ts_inside);
+        assert!(active.is_some());
+        assert_eq!(
+            active.unwrap(),
+            String::from_str(&env, "FastestSettlement")
+        );
+    }
+
+    #[test]
+    fn test_policy_inactive_outside_window() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // 10:00 – 12:00 UTC
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "Morning"),
+            &String::from_str(&env, "FastestSettlement"),
+            &36_000u32,
+            &43_200u32,
+            &0u32,
+        );
+
+        // 15:00 UTC = 54 000 seconds into the day
+        // 86400 * 11 + 54000 = 1 004 400
+        let ts_outside = 1_004_400u64;
+        assert_eq!(ts_outside % 86_400, 54_000);
+
+        let active = client.get_active_routing_policy(&ts_outside);
+        assert!(active.is_none());
+    }
+
+    #[test]
+    fn test_midnight_wrapping_window_active_after_midnight() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // 22:00 – 02:00 UTC  (79 200 – 7 200): wraps midnight
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "Night"),
+            &String::from_str(&env, "HighestReputation"),
+            &79_200u32,
+            &7_200u32,
+            &0u32,
+        );
+
+        // 01:00 UTC = 3 600 seconds into the day (inside window)
+        let ts_inside = 86_400u64 * 12 + 3_600; // = 1 036 800
+        assert_eq!(ts_inside % 86_400, 3_600);
+
+        let active = client.get_active_routing_policy(&ts_inside);
+        assert!(active.is_some());
+    }
+
+    #[test]
+    fn test_midnight_wrapping_window_inactive_in_midday() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // 22:00 – 02:00 UTC
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "Night"),
+            &String::from_str(&env, "HighestReputation"),
+            &79_200u32,
+            &7_200u32,
+            &0u32,
+        );
+
+        // 12:00 UTC = 43 200 seconds (outside window)
+        let ts_outside = 86_400u64 * 12 + 43_200;
+        assert_eq!(ts_outside % 86_400, 43_200);
+
+        let active = client.get_active_routing_policy(&ts_outside);
+        assert!(active.is_none());
+    }
+
+    #[test]
+    fn test_always_active_policy_selected_at_any_time() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // start == end → always-active
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "Always"),
+            &String::from_str(&env, "LowestFee"),
+            &12_000u32,
+            &12_000u32,
+            &0u32,
+        );
+
+        for ts in [0u64, 43_200, 86_399, 1_000_000] {
+            let active = client.get_active_routing_policy(&ts);
+            assert!(active.is_some(), "Expected policy to be active at ts={ts}");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Priority and tie-breaking
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_lower_priority_value_wins() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // Both always-active.
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "Low priority"),
+            &String::from_str(&env, "LowestFee"),
+            &0u32, &0u32,
+            &10u32, // priority 10
+        );
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "High priority"),
+            &String::from_str(&env, "FastestSettlement"),
+            &0u32, &0u32,
+            &1u32, // priority 1 — should win
+        );
+
+        let active = client.get_active_routing_policy(&1_000_000u64);
+        assert!(active.is_some());
+        assert_eq!(active.unwrap(), String::from_str(&env, "FastestSettlement"));
+    }
+
+    #[test]
+    fn test_tied_priority_lower_policy_id_wins() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // Both always-active, same priority.
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "P1"),
+            &String::from_str(&env, "WeightedScore"), // id=1
+            &0u32, &0u32,
+            &5u32,
+        );
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "P2"),
+            &String::from_str(&env, "LowestFee"),     // id=2
+            &0u32, &0u32,
+            &5u32,
+        );
+
+        // id=1 has lower id → should win tie-break.
+        let active = client.get_active_routing_policy(&1_000_000u64);
+        assert!(active.is_some());
+        assert_eq!(active.unwrap(), String::from_str(&env, "WeightedScore"));
+    }
+
+    #[test]
+    fn test_no_active_policy_returns_none() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // No policies registered at all.
+        let active = client.get_active_routing_policy(&1_000_000u64);
+        assert!(active.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn test_register_policy_rejects_empty_strategy_name() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "Name"),
+            &String::from_str(&env, ""), // empty — should panic
+            &0u32, &0u32,
+            &0u32,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_register_policy_rejects_invalid_window_start() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        // 86 400 is >= 86 400 → invalid
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "Name"),
+            &String::from_str(&env, "LowestFee"),
+            &86_400u32, // invalid
+            &0u32,
+            &0u32,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_register_policy_rejects_invalid_window_end() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        client.register_timed_routing_policy(
+            &String::from_str(&env, "Name"),
+            &String::from_str(&env, "LowestFee"),
+            &0u32,
+            &86_400u32, // invalid
+            &0u32,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_set_enabled_on_nonexistent_policy_panics() {
+        let env = make_env();
+        set_ledger(&env, 1_000_000);
+        let (client, _) = setup(&env);
+
+        client.set_timed_policy_enabled(&999u64, &false);
+    }
+}


### PR DESCRIPTION
## Summary

Implements four routing and validation features in a single PR.

Closes #657
Closes #658
Closes #659
Closes #661

---

## #657 — Multi-anchor reputation weighting

**Problem:** Routing decisions based solely on fee and settlement time miss important reliability signals like historical success rate, uptime, and operator quality.

**Solution:** Added `AnchorReputationRecord` and `ReputationWeights` as on-chain `#[contracttype]` structs. The composite score (0–10 000) is computed from three weighted sub-scores: success rate, uptime, and operator quality. Weights are configurable per-contract and default to 40 % / 35 % / 25 %.

**New contract methods:**
- `set_anchor_reputation` / `get_anchor_reputation`
- `set_reputation_weights` / `get_reputation_weights`
- `get_anchor_composite_reputation`
- `rank_anchors_by_reputation` — descending composite score with deterministic tie-breaking (ascending anchor XDR byte order)

**Tests:** `tests/reputation_weighting_tests.rs`

---

## #658 — Time-based routing policies

**Problem:** Routing strategy needs to adapt to time of day or operational windows.

**Solution:** Added `RoutingTimeWindow` and `TimedRoutingPolicy`. `get_active_routing_policy(unix_timestamp)` returns the strategy name for the highest-priority matching policy; tie-break by lowest `policy_id`.

**New contract methods:**
- `register_timed_routing_policy`
- `set_timed_policy_enabled`
- `get_timed_routing_policy`
- `get_active_routing_policy(unix_timestamp)` → `Option<String>`

**Tests:** `tests/timed_routing_policy_tests.rs`

---

## #659 — Per-network routing profiles

**Problem:** Testnet, mainnet, and local deployments need independent routing defaults.

**Solution:** Added `NetworkRoutingProfile`. Resolution order: (1) active network profile, (2) is_default profile, (3) None.

**New contract methods:**
- `register_network_routing_profile`
- `set_active_network` / `get_active_network`
- `get_network_routing_profile`
- `get_routing_profile`

**Tests:** `tests/network_routing_profile_tests.rs`

---

## #661 — Response shape compatibility checks for older anchors

**Problem:** Older anchors omit optional fields, causing hard failures against strict validators.

**Solution:** Added `CompatibilityLevel` (FullyCompatible / PartiallyCompatible / Incompatible) and `CompatibilityReport`. Five check functions evaluate all response types.

**New public API:**
- `check_deposit_compatibility`
- `check_withdraw_compatibility`
- `check_sep38_quote_compatibility`
- `check_anchor_info_compatibility`
- `check_transaction_status_compatibility`

**Tests:** Inline in `src/response_validator.rs` test module.