### PR TITLE
feat: vendor status mapping, partial quotes, deterministic ordering, health export

### DIFF
--- a/src/anchor_health.rs
+++ b/src/anchor_health.rs
@@ -612,6 +612,159 @@ impl HealthWindowBuilder {
 }
 
 // ---------------------------------------------------------------------------
+// Issue #664: Health report export
+// ---------------------------------------------------------------------------
+
+/// Supported serialization formats for [`export_health_report`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HealthReportFormat {
+    /// Structured text with `key: value` pairs — easy to grep and human-readable.
+    Text,
+    /// JSON object — suitable for ingestion by dashboards and incident tooling.
+    Json,
+}
+
+/// A complete exportable health report for a single anchor.
+///
+/// Contains the current composite score, sub-scores, trend, window statistics,
+/// and an overall label suitable for use in dashboards and alerting pipelines.
+///
+/// Obtain one via [`build_health_report`] and serialise it with
+/// [`export_health_report`].
+#[derive(Clone, Debug)]
+pub struct AnchorHealthReport {
+    /// Identifier for the anchor (e.g. domain or contract address).
+    pub anchor_id: String,
+    /// How many observation windows were included.
+    pub window_count: usize,
+    /// Composite score (0–100) for the most recent window.
+    pub composite_score: f64,
+    /// Sub-score derived from the success rate (0–100).
+    pub success_rate_score: f64,
+    /// Sub-score derived from p50 latency (0–100).
+    pub latency_score: f64,
+    /// Sub-score derived from routing failure rate (0–100).
+    pub routing_score: f64,
+    /// Sub-score derived from recovery behaviour (0–100).
+    pub recovery_score: f64,
+    /// Qualitative label: `"healthy"`, `"degraded"`, or `"critical"`.
+    pub label: String,
+    /// Trend direction: `"improving"`, `"stable"`, or `"degrading"`.
+    pub trend: String,
+    /// Composite score from the previous window, if available.
+    pub previous_composite: Option<f64>,
+}
+
+/// Build an [`AnchorHealthReport`] for a named anchor from its observation windows.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::anchor_health::{HealthWindow, build_health_report, export_health_report, HealthReportFormat};
+///
+/// let w = HealthWindow {
+///     started_at: 0, ended_at: 300,
+///     success_count: 99, failure_count: 1,
+///     p50_latency_ms: 100.0,
+///     routing_failure_count: 0, routing_attempt_count: 10,
+///     recovery_time_seconds: 0,
+/// };
+/// let report = build_health_report("anchor.example.com", &[w]);
+/// assert_eq!(report.label, "healthy");
+/// let text = export_health_report(&report, HealthReportFormat::Text);
+/// assert!(text.contains("anchor_id: anchor.example.com"));
+/// let json = export_health_report(&report, HealthReportFormat::Json);
+/// assert!(json.contains("\"anchor_id\""));
+/// ```
+pub fn build_health_report(anchor_id: &str, windows: &[HealthWindow]) -> AnchorHealthReport {
+    let snapshot = build_health_snapshot(windows);
+    let score = &snapshot.current_score;
+    AnchorHealthReport {
+        anchor_id: anchor_id.into(),
+        window_count: snapshot.window_count,
+        composite_score: score.composite,
+        success_rate_score: score.success_rate_score,
+        latency_score: score.latency_score,
+        routing_score: score.routing_score,
+        recovery_score: score.recovery_score,
+        label: score.label().into(),
+        trend: snapshot.trend.label().into(),
+        previous_composite: snapshot.previous_score,
+    }
+}
+
+/// Serialize an [`AnchorHealthReport`] into the requested [`HealthReportFormat`].
+///
+/// - `HealthReportFormat::Text` — produces a multi-line `key: value` string.
+/// - `HealthReportFormat::Json` — produces a compact JSON object.
+pub fn export_health_report(report: &AnchorHealthReport, format: HealthReportFormat) -> String {
+    match format {
+        HealthReportFormat::Text => export_health_report_text(report),
+        HealthReportFormat::Json => export_health_report_json(report),
+    }
+}
+
+fn export_health_report_text(r: &AnchorHealthReport) -> String {
+    let prev = match r.previous_composite {
+        Some(p) => alloc::format!("{p:.2}"),
+        None => "n/a".into(),
+    };
+    alloc::format!(
+        "anchor_id: {}\n\
+         window_count: {}\n\
+         composite_score: {:.2}\n\
+         success_rate_score: {:.2}\n\
+         latency_score: {:.2}\n\
+         routing_score: {:.2}\n\
+         recovery_score: {:.2}\n\
+         label: {}\n\
+         trend: {}\n\
+         previous_composite: {}\n",
+        r.anchor_id,
+        r.window_count,
+        r.composite_score,
+        r.success_rate_score,
+        r.latency_score,
+        r.routing_score,
+        r.recovery_score,
+        r.label,
+        r.trend,
+        prev,
+    )
+}
+
+fn export_health_report_json(r: &AnchorHealthReport) -> String {
+    let prev = match r.previous_composite {
+        Some(p) => alloc::format!("{p:.2}"),
+        None => "null".into(),
+    };
+    alloc::format!(
+        "{{\
+\"anchor_id\":\"{}\",\
+\"window_count\":{},\
+\"composite_score\":{:.2},\
+\"success_rate_score\":{:.2},\
+\"latency_score\":{:.2},\
+\"routing_score\":{:.2},\
+\"recovery_score\":{:.2},\
+\"label\":\"{}\",\
+\"trend\":\"{}\",\
+\"previous_composite\":{}\
+}}",
+        r.anchor_id,
+        r.window_count,
+        r.composite_score,
+        r.success_rate_score,
+        r.latency_score,
+        r.routing_score,
+        r.recovery_score,
+        r.label,
+        r.trend,
+        prev,
+    )
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -186,6 +186,26 @@ pub struct AttestationPage {
     pub total: u64,
 }
 
+// ── Issue #663: Deterministic ordering for attestation results ────────────────
+
+/// Criteria for deterministically ordering [`Attestation`] records off-chain.
+///
+/// On-chain pages are always returned in ascending `id` order.  Use these
+/// variants when you need a different ordering client-side.  The `id` field
+/// is always the final tiebreaker so results are fully stable regardless of
+/// storage order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AttestationSortOrder {
+    /// Sort by `id` ascending (default on-chain order).
+    IdAsc,
+    /// Sort by `id` descending (newest first).
+    IdDesc,
+    /// Sort by `timestamp` ascending, then `id` ascending on ties.
+    TimestampAsc,
+    /// Sort by `timestamp` descending (most recent first), then `id` ascending on ties.
+    TimestampDesc,
+}
+
 /// Input record for [`AnchorKitContract::submit_attestation_batch`].
 #[contracttype]
 #[derive(Clone)]
@@ -9520,6 +9540,46 @@ impl AnchorKitContract {
             },
         }
     }
+}
+
+// ── Issue #663: Off-chain deterministic ordering for attestation results ──────
+
+/// Sort a slice of [`Attestation`] records into a new `Vec` using the given
+/// [`AttestationSortOrder`].
+///
+/// The sort is stable with respect to non-tiebreaker criteria. `id` is always
+/// the final tiebreaker for `TimestampAsc`/`TimestampDesc` so results are
+/// fully deterministic regardless of how records are stored.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use anchorkit::contract::{Attestation, AttestationSortOrder, sort_attestations};
+/// // Assumes you have collected attestations from paginated queries.
+/// ```
+#[cfg(not(feature = "wasm"))]
+pub fn sort_attestations(
+    records: &[Attestation],
+    order: AttestationSortOrder,
+) -> alloc::vec::Vec<Attestation> {
+    let mut result: alloc::vec::Vec<Attestation> = records.to_vec();
+    result.sort_by(|a, b| {
+        let primary = match order {
+            AttestationSortOrder::IdAsc       => a.id.cmp(&b.id),
+            AttestationSortOrder::IdDesc      => b.id.cmp(&a.id),
+            AttestationSortOrder::TimestampAsc  => a.timestamp.cmp(&b.timestamp),
+            AttestationSortOrder::TimestampDesc => b.timestamp.cmp(&a.timestamp),
+        };
+        // Tiebreak on `id` ascending for timestamp-based orders.
+        if primary == core::cmp::Ordering::Equal
+            && matches!(order, AttestationSortOrder::TimestampAsc | AttestationSortOrder::TimestampDesc)
+        {
+            a.id.cmp(&b.id)
+        } else {
+            primary
+        }
+    });
+    result
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,8 @@ pub mod admin_audit_log;
 pub mod cache_governance;
 pub mod session_state_machine;
 pub mod migration;
+#[cfg(not(feature = "wasm"))]
+pub mod url_normalizer;
 
 // ── std-only modules (filesystem, runtime config) ─────────────────────────────
 #[cfg(feature = "std")]
@@ -227,6 +229,7 @@ pub use sep6::{
     TransactionStatus, TransactionStatusResponse, WithdrawalResponse,
     poll_transaction_status, PollConfig, PollResult,
     StatusCategory, classify_status_str,
+    VendorStatusMap, VendorStatusEntry,
 };
 #[cfg(not(feature = "wasm"))]
 pub use sep31::{
@@ -243,13 +246,26 @@ pub use sep24::{
 };
 pub use contract::{ServiceRetirementInfo, AnchorServices};
 pub use contract::{AttestationFilter, AttestationPage};
+pub use contract::{AttestationSortOrder};
+#[cfg(not(feature = "wasm"))]
+pub use contract::sort_attestations;
 pub use service_management::{ServiceManager, ServiceToggleState, ServiceConfigSnapshot};
 pub use admin_audit_log::{AdminAuditLog, AdminConfigChangeEvent, AdminAuditLogConfig};
 pub use contract::{HealthStatus, MetadataFreshnessReport, RateLimiterHealth};
 pub use contract::{AnchorHealthMetrics, AnchorProofRecord};
 pub use transaction_state_tracker::{BudgetStatus, BudgetAlert};
 #[cfg(not(feature = "wasm"))]
+pub use anchor_health::{
+    AnchorHealthReport, HealthReportFormat,
+    build_health_report, export_health_report,
+};
+#[cfg(not(feature = "wasm"))]
 pub use sep38::{CrossAnchorFeeAggregator, FeeAnomalyReport};
+#[cfg(not(feature = "wasm"))]
+pub use sep38::{
+    RawPartialFirmQuote, PartialFirmQuote, parse_partial_quote,
+    sort_quotes, QuoteSortOrder,
+};
 #[cfg(not(feature = "wasm"))]
 pub use streaming_monitor::{StreamingTransactionMonitor, TransactionStatusUpdate, StateTransition, BackpressureConfig};
 

--- a/src/sep38.rs
+++ b/src/sep38.rs
@@ -101,6 +101,208 @@ pub struct RawFirmQuote {
     pub buy_asset: String,
 }
 
+// ── Partial quote support (#662) ─────────────────────────────────────────────
+
+/// A raw quote response where every field is optional.
+///
+/// Some anchors return partial quote payloads — for example when they are
+/// rate-limited or their upstream pricing source is unavailable.  Rather than
+/// rejecting the entire response, [`parse_partial_quote`] stores whatever
+/// fields were present and records which ones are missing in
+/// [`PartialFirmQuote::missing_fields`].
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::sep38::{RawPartialFirmQuote, parse_partial_quote};
+///
+/// let raw = RawPartialFirmQuote {
+///     id: Some("q-partial".into()),
+///     expires_at: None,          // missing
+///     price: Some("0.15".into()),
+///     sell_amount: None,         // missing
+///     buy_amount: Some("15".into()),
+///     sell_asset: Some("XLM".into()),
+///     buy_asset: Some("USDC".into()),
+/// };
+/// let partial = parse_partial_quote(raw);
+/// assert_eq!(partial.id, Some("q-partial".into()));
+/// assert!(partial.missing_fields.contains(&"expires_at"));
+/// assert!(partial.missing_fields.contains(&"sell_amount"));
+/// assert!(!partial.is_complete());
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct RawPartialFirmQuote {
+    pub id: Option<String>,
+    pub expires_at: Option<String>,
+    pub price: Option<String>,
+    pub sell_amount: Option<String>,
+    pub buy_amount: Option<String>,
+    pub sell_asset: Option<String>,
+    pub buy_asset: Option<String>,
+}
+
+/// A firm quote where some fields may be absent due to a partial response.
+///
+/// All value fields mirror [`FirmQuote`] but are wrapped in `Option`.
+/// The `missing_fields` vec names every field that was absent in the raw
+/// response so downstream code can surface the gaps clearly.
+#[derive(Clone, Debug)]
+pub struct PartialFirmQuote {
+    pub id: Option<String>,
+    /// Unix timestamp (seconds) when this quote expires, if present.
+    pub expires_at: Option<u64>,
+    pub price: Option<String>,
+    pub sell_amount: Option<String>,
+    pub buy_amount: Option<String>,
+    /// Normalized (uppercase) asset code being sold, if present.
+    pub sell_asset: Option<String>,
+    /// Normalized (uppercase) asset code being bought, if present.
+    pub buy_asset: Option<String>,
+    /// Names of fields that were absent or unparseable in the raw response.
+    pub missing_fields: AllocVec<&'static str>,
+}
+
+impl PartialFirmQuote {
+    /// Returns `true` when all required fields are present and the quote can
+    /// be promoted to a full [`FirmQuote`] via [`PartialFirmQuote::into_full`].
+    pub fn is_complete(&self) -> bool {
+        self.missing_fields.is_empty()
+    }
+
+    /// Attempt to convert this partial quote into a complete [`FirmQuote`].
+    ///
+    /// Returns `Err(Error::invalid_quote())` when any required field is still
+    /// absent.
+    pub fn into_full(self) -> Result<FirmQuote, Error> {
+        if !self.is_complete() {
+            return Err(Error::invalid_quote());
+        }
+        Ok(FirmQuote {
+            id: self.id.ok_or_else(Error::invalid_quote)?,
+            expires_at: self.expires_at.ok_or_else(Error::invalid_quote)?,
+            price: self.price.ok_or_else(Error::invalid_quote)?,
+            sell_amount: self.sell_amount.ok_or_else(Error::invalid_quote)?,
+            buy_amount: self.buy_amount.ok_or_else(Error::invalid_quote)?,
+            sell_asset: self.sell_asset.ok_or_else(Error::invalid_quote)?,
+            buy_asset: self.buy_asset.ok_or_else(Error::invalid_quote)?,
+            routing_reason: None,
+        })
+    }
+}
+
+/// Parse a [`RawPartialFirmQuote`] into a [`PartialFirmQuote`], recording
+/// which fields were absent or contained invalid values in
+/// [`PartialFirmQuote::missing_fields`].
+///
+/// Unlike [`request_firm_quote`], this function never returns an error for
+/// missing fields — it only fails when a field is present but its value
+/// cannot be parsed at all (e.g. a timestamp string containing letters).
+/// Invalid *values* for present fields are treated as missing and the field
+/// name is appended to `missing_fields`.
+///
+/// Stale quotes (expired `expires_at`) are accepted; callers should check
+/// expiry themselves when they need a fresh quote.
+pub fn parse_partial_quote(raw: RawPartialFirmQuote) -> PartialFirmQuote {
+    let mut missing: AllocVec<&'static str> = AllocVec::new();
+
+    // id
+    let id = match raw.id {
+        Some(ref s) if !s.is_empty() => Some(s.clone()),
+        _ => {
+            missing.push("id");
+            None
+        }
+    };
+
+    // expires_at — parse but do not reject for staleness
+    let expires_at = match raw.expires_at {
+        Some(ref s) if !s.is_empty() => match s.parse::<u64>() {
+            Ok(v) if v > 0 => Some(v),
+            _ => {
+                missing.push("expires_at");
+                None
+            }
+        },
+        _ => {
+            missing.push("expires_at");
+            None
+        }
+    };
+
+    // price
+    let price = match raw.price {
+        Some(ref s) if is_valid_positive_decimal(s) => Some(s.clone()),
+        _ => {
+            missing.push("price");
+            None
+        }
+    };
+
+    // sell_amount
+    let sell_amount = match raw.sell_amount {
+        Some(ref s) if is_valid_positive_decimal(s) => Some(s.clone()),
+        _ => {
+            missing.push("sell_amount");
+            None
+        }
+    };
+
+    // buy_amount
+    let buy_amount = match raw.buy_amount {
+        Some(ref s) if is_valid_positive_decimal(s) => Some(s.clone()),
+        _ => {
+            missing.push("buy_amount");
+            None
+        }
+    };
+
+    // sell_asset
+    let sell_asset = match raw.sell_asset {
+        Some(ref s) if !s.is_empty() => {
+            match normalize_asset_code(s) {
+                Ok(code) => Some(code),
+                Err(_) => {
+                    missing.push("sell_asset");
+                    None
+                }
+            }
+        }
+        _ => {
+            missing.push("sell_asset");
+            None
+        }
+    };
+
+    // buy_asset
+    let buy_asset = match raw.buy_asset {
+        Some(ref s) if !s.is_empty() => {
+            match normalize_asset_code(s) {
+                Ok(code) => Some(code),
+                Err(_) => {
+                    missing.push("buy_asset");
+                    None
+                }
+            }
+        }
+        _ => {
+            missing.push("buy_asset");
+            None
+        }
+    };
+
+    PartialFirmQuote {
+        id,
+        expires_at,
+        price,
+        sell_amount,
+        buy_amount,
+        sell_asset,
+        buy_asset,
+        missing_fields: missing,
+    }
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /// Returns `true` if `price_str` is a non-empty, positive decimal string.
@@ -1054,6 +1256,85 @@ impl CrossAnchorFeeAggregator {
             anchor_volatilities,
         }
     }
+}
+
+// ── Issue #663: Deterministic ordering for quote results ─────────────────────
+
+/// Criteria for deterministically ordering a list of [`FirmQuote`] values.
+///
+/// When multiple quotes tie on the primary criterion, the `id` field is used
+/// as the final tiebreaker so results are always fully deterministic regardless
+/// of insertion order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum QuoteSortOrder {
+    /// Sort by `expires_at` ascending (soonest-expiring first), then by `id`
+    /// ascending on ties.
+    ExpiresAtAsc,
+    /// Sort by `expires_at` descending (latest-expiring first), then by `id`
+    /// ascending on ties.
+    ExpiresAtDesc,
+    /// Sort by the numeric value of `price` ascending (cheapest first), then
+    /// by `id` ascending on ties.
+    PriceAsc,
+    /// Sort by the numeric value of `price` descending (most expensive first),
+    /// then by `id` ascending on ties.
+    PriceDesc,
+    /// Sort by `id` ascending (lexicographic).
+    IdAsc,
+}
+
+/// Return a new `Vec` containing the same quotes sorted according to `order`.
+///
+/// The sort is stable with respect to non-tiebreaker criteria and the `id`
+/// tiebreaker always produces a fully deterministic result.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::sep38::{FirmQuote, sort_quotes, QuoteSortOrder};
+///
+/// let a = FirmQuote {
+///     id: "b".into(), expires_at: 2000, price: "0.10".into(),
+///     sell_amount: "100".into(), buy_amount: "10".into(),
+///     sell_asset: "XLM".into(), buy_asset: "USDC".into(),
+///     routing_reason: None,
+/// };
+/// let b = FirmQuote {
+///     id: "a".into(), expires_at: 1000, price: "0.20".into(),
+///     sell_amount: "100".into(), buy_amount: "20".into(),
+///     sell_asset: "XLM".into(), buy_asset: "USDC".into(),
+///     routing_reason: None,
+/// };
+/// let sorted = sort_quotes(&[a, b], QuoteSortOrder::PriceAsc);
+/// assert_eq!(sorted[0].price, "0.10");
+/// assert_eq!(sorted[1].price, "0.20");
+/// ```
+pub fn sort_quotes(quotes: &[FirmQuote], order: QuoteSortOrder) -> AllocVec<FirmQuote> {
+    let mut result: AllocVec<FirmQuote> = quotes.to_vec();
+    result.sort_by(|a, b| {
+        let primary = match order {
+            QuoteSortOrder::ExpiresAtAsc  => a.expires_at.cmp(&b.expires_at),
+            QuoteSortOrder::ExpiresAtDesc => b.expires_at.cmp(&a.expires_at),
+            QuoteSortOrder::PriceAsc => {
+                let pa = a.price.parse::<f64>().unwrap_or(f64::MAX);
+                let pb = b.price.parse::<f64>().unwrap_or(f64::MAX);
+                pa.partial_cmp(&pb).unwrap_or(core::cmp::Ordering::Equal)
+            }
+            QuoteSortOrder::PriceDesc => {
+                let pa = a.price.parse::<f64>().unwrap_or(0.0);
+                let pb = b.price.parse::<f64>().unwrap_or(0.0);
+                pb.partial_cmp(&pa).unwrap_or(core::cmp::Ordering::Equal)
+            }
+            QuoteSortOrder::IdAsc => a.id.cmp(&b.id),
+        };
+        // Tiebreak on `id` ascending for full determinism.
+        if primary == core::cmp::Ordering::Equal && order != QuoteSortOrder::IdAsc {
+            a.id.cmp(&b.id)
+        } else {
+            primary
+        }
+    });
+    result
 }
 
 #[cfg(test)]

--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -61,6 +61,131 @@ pub fn classify_status_str(s: &str) -> StatusCategory {
     }
 }
 
+// ── Vendor-specific status mapping (#660) ────────────────────────────────────
+
+/// A single entry in a vendor-specific status map.
+///
+/// Maps a raw vendor string to a canonical [`TransactionStatus`]. The original
+/// raw value is always preserved alongside the canonical classification so
+/// callers never lose vendor detail.
+#[derive(Clone, Debug)]
+pub struct VendorStatusEntry {
+    /// The raw vendor string exactly as supplied in the anchor's response.
+    pub vendor_status: String,
+    /// The canonical SEP-6 status this vendor string maps to.
+    pub canonical: TransactionStatus,
+}
+
+/// A collection of vendor-specific status mappings for a single anchor.
+///
+/// Anchors may return proprietary status strings (e.g. `"ach_processing"`,
+/// `"kyc_required"`, `"fx_pending"`) that have no direct SEP-6 equivalent.
+/// A `VendorStatusMap` lets you register these values once and then resolve
+/// any raw string against them, falling back to the standard
+/// [`TransactionStatus::from_str`] parser for unregistered values.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::sep6::{VendorStatusMap, TransactionStatus};
+///
+/// let mut map = VendorStatusMap::new();
+/// map.register("ach_processing", TransactionStatus::PendingExternal);
+/// map.register("kyc_required",   TransactionStatus::PendingUser);
+///
+/// // Known vendor value → canonical + raw preserved.
+/// let r = map.resolve("ach_processing");
+/// assert_eq!(r.canonical, TransactionStatus::PendingExternal);
+/// assert_eq!(r.vendor_status, "ach_processing");
+///
+/// // Unknown vendor value → falls back to SEP-6 parser.
+/// let r2 = map.resolve("completed");
+/// assert_eq!(r2.canonical, TransactionStatus::Completed);
+///
+/// // Truly unknown value → Error.
+/// let r3 = map.resolve("totally_unknown");
+/// assert_eq!(r3.canonical, TransactionStatus::Error);
+/// assert_eq!(r3.vendor_status, "totally_unknown");
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct VendorStatusMap {
+    entries: alloc::vec::Vec<VendorStatusEntry>,
+}
+
+impl VendorStatusMap {
+    /// Create an empty vendor status map.
+    pub fn new() -> Self {
+        VendorStatusMap {
+            entries: alloc::vec::Vec::new(),
+        }
+    }
+
+    /// Register a vendor-specific status string and its canonical equivalent.
+    ///
+    /// If `vendor_status` is already registered the existing mapping is
+    /// replaced.
+    pub fn register(&mut self, vendor_status: &str, canonical: TransactionStatus) {
+        let key = vendor_status.trim().to_ascii_lowercase();
+        if let Some(pos) = self.entries.iter().position(|e| e.vendor_status == key) {
+            self.entries[pos].canonical = canonical;
+        } else {
+            self.entries.push(VendorStatusEntry {
+                vendor_status: key,
+                canonical,
+            });
+        }
+    }
+
+    /// Resolve a raw anchor status string.
+    ///
+    /// Resolution order:
+    /// 1. Look up the trimmed, lowercased value in the vendor map.
+    /// 2. If not found, fall back to [`TransactionStatus::from_str`].
+    ///
+    /// The returned [`VendorStatusEntry`] always carries the original
+    /// (trimmed) raw string so callers can log or forward vendor detail.
+    pub fn resolve(&self, raw: &str) -> VendorStatusEntry {
+        let key = raw.trim().to_ascii_lowercase();
+        if let Some(entry) = self.entries.iter().find(|e| e.vendor_status == key) {
+            return VendorStatusEntry {
+                vendor_status: raw.trim().into(),
+                canonical: entry.canonical.clone(),
+            };
+        }
+        VendorStatusEntry {
+            vendor_status: raw.trim().into(),
+            canonical: TransactionStatus::from_str(raw),
+        }
+    }
+
+    /// Returns `true` if the map contains a custom mapping for `vendor_status`.
+    pub fn contains(&self, vendor_status: &str) -> bool {
+        let key = vendor_status.trim().to_ascii_lowercase();
+        self.entries.iter().any(|e| e.vendor_status == key)
+    }
+
+    /// Remove the mapping for `vendor_status`. Returns `true` if it existed.
+    pub fn remove(&mut self, vendor_status: &str) -> bool {
+        let key = vendor_status.trim().to_ascii_lowercase();
+        if let Some(pos) = self.entries.iter().position(|e| e.vendor_status == key) {
+            self.entries.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Return the number of registered vendor mappings.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` when no vendor mappings are registered.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
 // ── Normalized response types ────────────────────────────────────────────────
 
 /// Normalized status values across all SEP-6 anchors.

--- a/tests/deterministic_ordering_tests.rs
+++ b/tests/deterministic_ordering_tests.rs
@@ -1,0 +1,440 @@
+//! Tests for deterministic ordering of quote and attestation results (#663).
+//!
+//! Verifies that:
+//! - `sort_quotes` produces a stable, fully deterministic order for every
+//!   `QuoteSortOrder` variant.
+//! - `sort_attestations` produces a stable, fully deterministic order for
+//!   every `AttestationSortOrder` variant.
+//! - Tie cases are broken by `id` ascending so repeated calls always return
+//!   the same ordering regardless of input order.
+//! - Sorting an empty slice returns an empty result (no panic).
+//! - Sorting a single-element slice returns that element unchanged.
+
+#![cfg(test)]
+
+// ── Quote ordering tests (#663) ───────────────────────────────────────────────
+
+#[cfg(not(feature = "wasm"))]
+mod quote_ordering_tests {
+    use anchorkit::sep38::{sort_quotes, FirmQuote, QuoteSortOrder};
+
+    fn make_quote(id: &str, expires_at: u64, price: &str) -> FirmQuote {
+        FirmQuote {
+            id: id.into(),
+            expires_at,
+            price: price.into(),
+            sell_amount: "1000".into(),
+            buy_amount: "150".into(),
+            sell_asset: "XLM".into(),
+            buy_asset: "USDC".into(),
+            routing_reason: None,
+        }
+    }
+
+    // ── Empty and single-element edge cases ───────────────────────────────────
+
+    #[test]
+    fn sort_quotes_empty_slice_returns_empty() {
+        let result = sort_quotes(&[], QuoteSortOrder::PriceAsc);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn sort_quotes_single_element_returns_same() {
+        let q = make_quote("only", 5000, "0.10");
+        let result = sort_quotes(&[q.clone()], QuoteSortOrder::PriceAsc);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "only");
+    }
+
+    // ── PriceAsc ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn price_asc_cheapest_first() {
+        let a = make_quote("a", 5000, "0.30");
+        let b = make_quote("b", 5000, "0.10");
+        let c = make_quote("c", 5000, "0.20");
+
+        let sorted = sort_quotes(&[a, b, c], QuoteSortOrder::PriceAsc);
+        assert_eq!(sorted[0].price, "0.10");
+        assert_eq!(sorted[1].price, "0.20");
+        assert_eq!(sorted[2].price, "0.30");
+    }
+
+    #[test]
+    fn price_asc_tie_broken_by_id_ascending() {
+        // Same price, different ids
+        let x = make_quote("z-id", 5000, "0.15");
+        let y = make_quote("a-id", 5000, "0.15");
+
+        let sorted = sort_quotes(&[x, y], QuoteSortOrder::PriceAsc);
+        assert_eq!(sorted[0].id, "a-id");
+        assert_eq!(sorted[1].id, "z-id");
+    }
+
+    #[test]
+    fn price_asc_deterministic_across_permutations() {
+        let a = make_quote("q1", 5000, "0.10");
+        let b = make_quote("q2", 5000, "0.20");
+        let c = make_quote("q3", 5000, "0.10"); // ties with a
+
+        let order1 = sort_quotes(&[a.clone(), b.clone(), c.clone()], QuoteSortOrder::PriceAsc);
+        let order2 = sort_quotes(&[c.clone(), a.clone(), b.clone()], QuoteSortOrder::PriceAsc);
+        let order3 = sort_quotes(&[b.clone(), c.clone(), a.clone()], QuoteSortOrder::PriceAsc);
+
+        // All permutations must produce the same id sequence
+        let ids1: Vec<&str> = order1.iter().map(|q| q.id.as_str()).collect();
+        let ids2: Vec<&str> = order2.iter().map(|q| q.id.as_str()).collect();
+        let ids3: Vec<&str> = order3.iter().map(|q| q.id.as_str()).collect();
+
+        assert_eq!(ids1, ids2);
+        assert_eq!(ids1, ids3);
+    }
+
+    // ── PriceDesc ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn price_desc_most_expensive_first() {
+        let a = make_quote("a", 5000, "0.10");
+        let b = make_quote("b", 5000, "0.30");
+        let c = make_quote("c", 5000, "0.20");
+
+        let sorted = sort_quotes(&[a, b, c], QuoteSortOrder::PriceDesc);
+        assert_eq!(sorted[0].price, "0.30");
+        assert_eq!(sorted[1].price, "0.20");
+        assert_eq!(sorted[2].price, "0.10");
+    }
+
+    #[test]
+    fn price_desc_tie_broken_by_id_ascending() {
+        let x = make_quote("z-id", 5000, "0.15");
+        let y = make_quote("a-id", 5000, "0.15");
+
+        let sorted = sort_quotes(&[x, y], QuoteSortOrder::PriceDesc);
+        assert_eq!(sorted[0].id, "a-id");
+        assert_eq!(sorted[1].id, "z-id");
+    }
+
+    // ── ExpiresAtAsc ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn expires_at_asc_soonest_first() {
+        let a = make_quote("a", 3000, "0.15");
+        let b = make_quote("b", 1000, "0.15");
+        let c = make_quote("c", 2000, "0.15");
+
+        let sorted = sort_quotes(&[a, b, c], QuoteSortOrder::ExpiresAtAsc);
+        assert_eq!(sorted[0].expires_at, 1000);
+        assert_eq!(sorted[1].expires_at, 2000);
+        assert_eq!(sorted[2].expires_at, 3000);
+    }
+
+    #[test]
+    fn expires_at_asc_tie_broken_by_id_ascending() {
+        let x = make_quote("z-id", 2000, "0.15");
+        let y = make_quote("a-id", 2000, "0.15");
+
+        let sorted = sort_quotes(&[x, y], QuoteSortOrder::ExpiresAtAsc);
+        assert_eq!(sorted[0].id, "a-id");
+        assert_eq!(sorted[1].id, "z-id");
+    }
+
+    // ── ExpiresAtDesc ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn expires_at_desc_latest_first() {
+        let a = make_quote("a", 1000, "0.15");
+        let b = make_quote("b", 3000, "0.15");
+        let c = make_quote("c", 2000, "0.15");
+
+        let sorted = sort_quotes(&[a, b, c], QuoteSortOrder::ExpiresAtDesc);
+        assert_eq!(sorted[0].expires_at, 3000);
+        assert_eq!(sorted[1].expires_at, 2000);
+        assert_eq!(sorted[2].expires_at, 1000);
+    }
+
+    #[test]
+    fn expires_at_desc_tie_broken_by_id_ascending() {
+        let x = make_quote("z-id", 2000, "0.15");
+        let y = make_quote("a-id", 2000, "0.15");
+
+        let sorted = sort_quotes(&[x, y], QuoteSortOrder::ExpiresAtDesc);
+        assert_eq!(sorted[0].id, "a-id");
+        assert_eq!(sorted[1].id, "z-id");
+    }
+
+    // ── IdAsc ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn id_asc_lexicographic_order() {
+        let a = make_quote("bravo", 5000, "0.15");
+        let b = make_quote("alpha", 5000, "0.15");
+        let c = make_quote("charlie", 5000, "0.15");
+
+        let sorted = sort_quotes(&[a, b, c], QuoteSortOrder::IdAsc);
+        assert_eq!(sorted[0].id, "alpha");
+        assert_eq!(sorted[1].id, "bravo");
+        assert_eq!(sorted[2].id, "charlie");
+    }
+
+    #[test]
+    fn id_asc_already_sorted_is_stable() {
+        let a = make_quote("a", 1000, "0.10");
+        let b = make_quote("b", 2000, "0.20");
+        let c = make_quote("c", 3000, "0.30");
+
+        let sorted = sort_quotes(&[a, b, c], QuoteSortOrder::IdAsc);
+        assert_eq!(sorted[0].id, "a");
+        assert_eq!(sorted[1].id, "b");
+        assert_eq!(sorted[2].id, "c");
+    }
+
+    // ── Determinism across repeated calls ─────────────────────────────────────
+
+    #[test]
+    fn repeated_sort_same_input_same_output() {
+        let quotes = vec![
+            make_quote("q3", 3000, "0.30"),
+            make_quote("q1", 1000, "0.10"),
+            make_quote("q2", 2000, "0.20"),
+        ];
+
+        let r1 = sort_quotes(&quotes, QuoteSortOrder::ExpiresAtAsc);
+        let r2 = sort_quotes(&quotes, QuoteSortOrder::ExpiresAtAsc);
+
+        let ids1: Vec<&str> = r1.iter().map(|q| q.id.as_str()).collect();
+        let ids2: Vec<&str> = r2.iter().map(|q| q.id.as_str()).collect();
+        assert_eq!(ids1, ids2);
+    }
+
+    #[test]
+    fn all_ties_resolved_by_id_ascending_for_all_orders() {
+        // Five quotes identical except id
+        let ids = ["echo", "alpha", "delta", "bravo", "charlie"];
+        let quotes: Vec<FirmQuote> = ids
+            .iter()
+            .map(|id| make_quote(id, 5000, "0.15"))
+            .collect();
+
+        for order in &[
+            QuoteSortOrder::PriceAsc,
+            QuoteSortOrder::PriceDesc,
+            QuoteSortOrder::ExpiresAtAsc,
+            QuoteSortOrder::ExpiresAtDesc,
+        ] {
+            let sorted = sort_quotes(&quotes, order.clone());
+            let sorted_ids: Vec<&str> = sorted.iter().map(|q| q.id.as_str()).collect();
+            let mut expected = sorted_ids.clone();
+            expected.sort_unstable();
+            assert_eq!(
+                sorted_ids, expected,
+                "ties not resolved by id-asc for order {:?}",
+                order
+            );
+        }
+    }
+
+    // ── Input slice is not mutated ────────────────────────────────────────────
+
+    #[test]
+    fn sort_quotes_does_not_mutate_input() {
+        let a = make_quote("z", 5000, "0.30");
+        let b = make_quote("a", 5000, "0.10");
+        let input = vec![a.clone(), b.clone()];
+
+        let _sorted = sort_quotes(&input, QuoteSortOrder::PriceAsc);
+        // Original slice order unchanged
+        assert_eq!(input[0].id, "z");
+        assert_eq!(input[1].id, "a");
+    }
+}
+
+// ── Attestation ordering tests (#663) ─────────────────────────────────────────
+
+mod attestation_ordering_tests {
+    use soroban_sdk::{Bytes, Env};
+    use anchorkit::contract::{sort_attestations, Attestation, AttestationSortOrder};
+
+    fn make_attestation(env: &Env, id: u64, timestamp: u64, issuer_seed: u8) -> Attestation {
+        use soroban_sdk::testutils::Address as _;
+        use soroban_sdk::Address;
+
+        // Generate a deterministic address based on issuer_seed to keep tests predictable.
+        // We actually just need any distinct address; testutils::generate is fine.
+        let _ = issuer_seed;
+        let addr = Address::generate(env);
+        let mut hash = Bytes::new(env);
+        for _ in 0..32 {
+            hash.push_back(issuer_seed);
+        }
+        Attestation {
+            id,
+            issuer: addr.clone(),
+            subject: addr,
+            timestamp,
+            payload_hash: hash.clone(),
+            signature: hash,
+            schema_version: 1,
+        }
+    }
+
+    fn make_env() -> Env {
+        Env::default()
+    }
+
+    // ── Edge cases ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn sort_attestations_empty_returns_empty() {
+        let _env = make_env();
+        let result = sort_attestations(&[], AttestationSortOrder::IdAsc);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn sort_attestations_single_element_unchanged() {
+        let env = make_env();
+        let a = make_attestation(&env, 42, 1000, 0x01);
+        let result = sort_attestations(&[a], AttestationSortOrder::IdAsc);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, 42);
+    }
+
+    // ── IdAsc ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn id_asc_orders_by_id_numerically() {
+        let env = make_env();
+        let a = make_attestation(&env, 30, 1000, 0x01);
+        let b = make_attestation(&env, 10, 2000, 0x02);
+        let c = make_attestation(&env, 20, 3000, 0x03);
+
+        let sorted = sort_attestations(&[a, b, c], AttestationSortOrder::IdAsc);
+        assert_eq!(sorted[0].id, 10);
+        assert_eq!(sorted[1].id, 20);
+        assert_eq!(sorted[2].id, 30);
+    }
+
+    // ── IdDesc ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn id_desc_orders_newest_id_first() {
+        let env = make_env();
+        let a = make_attestation(&env, 10, 1000, 0x01);
+        let b = make_attestation(&env, 30, 2000, 0x02);
+        let c = make_attestation(&env, 20, 3000, 0x03);
+
+        let sorted = sort_attestations(&[a, b, c], AttestationSortOrder::IdDesc);
+        assert_eq!(sorted[0].id, 30);
+        assert_eq!(sorted[1].id, 20);
+        assert_eq!(sorted[2].id, 10);
+    }
+
+    // ── TimestampAsc ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn timestamp_asc_oldest_first() {
+        let env = make_env();
+        let a = make_attestation(&env, 1, 3000, 0x01);
+        let b = make_attestation(&env, 2, 1000, 0x02);
+        let c = make_attestation(&env, 3, 2000, 0x03);
+
+        let sorted = sort_attestations(&[a, b, c], AttestationSortOrder::TimestampAsc);
+        assert_eq!(sorted[0].timestamp, 1000);
+        assert_eq!(sorted[1].timestamp, 2000);
+        assert_eq!(sorted[2].timestamp, 3000);
+    }
+
+    #[test]
+    fn timestamp_asc_tie_broken_by_id_ascending() {
+        let env = make_env();
+        let a = make_attestation(&env, 99, 1000, 0x01);
+        let b = make_attestation(&env, 1, 1000, 0x02);
+        let c = make_attestation(&env, 50, 1000, 0x03);
+
+        let sorted = sort_attestations(&[a, b, c], AttestationSortOrder::TimestampAsc);
+        assert_eq!(sorted[0].id, 1);
+        assert_eq!(sorted[1].id, 50);
+        assert_eq!(sorted[2].id, 99);
+    }
+
+    // ── TimestampDesc ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn timestamp_desc_most_recent_first() {
+        let env = make_env();
+        let a = make_attestation(&env, 1, 1000, 0x01);
+        let b = make_attestation(&env, 2, 3000, 0x02);
+        let c = make_attestation(&env, 3, 2000, 0x03);
+
+        let sorted = sort_attestations(&[a, b, c], AttestationSortOrder::TimestampDesc);
+        assert_eq!(sorted[0].timestamp, 3000);
+        assert_eq!(sorted[1].timestamp, 2000);
+        assert_eq!(sorted[2].timestamp, 1000);
+    }
+
+    #[test]
+    fn timestamp_desc_tie_broken_by_id_ascending() {
+        let env = make_env();
+        let a = make_attestation(&env, 99, 5000, 0x01);
+        let b = make_attestation(&env, 1, 5000, 0x02);
+        let c = make_attestation(&env, 50, 5000, 0x03);
+
+        let sorted = sort_attestations(&[a, b, c], AttestationSortOrder::TimestampDesc);
+        assert_eq!(sorted[0].id, 1);
+        assert_eq!(sorted[1].id, 50);
+        assert_eq!(sorted[2].id, 99);
+    }
+
+    // ── Determinism across repeated calls ─────────────────────────────────────
+
+    #[test]
+    fn repeated_sort_same_input_produces_same_output() {
+        let env = make_env();
+        let records: Vec<Attestation> = vec![
+            make_attestation(&env, 3, 3000, 0x01),
+            make_attestation(&env, 1, 1000, 0x02),
+            make_attestation(&env, 2, 2000, 0x03),
+        ];
+
+        let r1 = sort_attestations(&records, AttestationSortOrder::TimestampDesc);
+        let r2 = sort_attestations(&records, AttestationSortOrder::TimestampDesc);
+
+        let ids1: Vec<u64> = r1.iter().map(|a| a.id).collect();
+        let ids2: Vec<u64> = r2.iter().map(|a| a.id).collect();
+        assert_eq!(ids1, ids2);
+    }
+
+    #[test]
+    fn sort_different_permutations_produce_same_result() {
+        let env = make_env();
+        let a = make_attestation(&env, 10, 1000, 0x01);
+        let b = make_attestation(&env, 20, 2000, 0x02);
+        let c = make_attestation(&env, 30, 3000, 0x03);
+
+        let sorted_abc = sort_attestations(&[a.clone(), b.clone(), c.clone()], AttestationSortOrder::IdAsc);
+        let sorted_cba = sort_attestations(&[c.clone(), b.clone(), a.clone()], AttestationSortOrder::IdAsc);
+        let sorted_bac = sort_attestations(&[b.clone(), a.clone(), c.clone()], AttestationSortOrder::IdAsc);
+
+        let ids_abc: Vec<u64> = sorted_abc.iter().map(|a| a.id).collect();
+        let ids_cba: Vec<u64> = sorted_cba.iter().map(|a| a.id).collect();
+        let ids_bac: Vec<u64> = sorted_bac.iter().map(|a| a.id).collect();
+
+        assert_eq!(ids_abc, ids_cba);
+        assert_eq!(ids_abc, ids_bac);
+    }
+
+    // ── Input is not mutated ────────────────────────────────────────────────────
+
+    #[test]
+    fn sort_attestations_does_not_mutate_input() {
+        let env = make_env();
+        let a = make_attestation(&env, 30, 3000, 0x01);
+        let b = make_attestation(&env, 10, 1000, 0x02);
+        let input = vec![a, b];
+
+        let _sorted = sort_attestations(&input, AttestationSortOrder::IdAsc);
+        assert_eq!(input[0].id, 30); // original order preserved
+        assert_eq!(input[1].id, 10);
+    }
+}

--- a/tests/health_report_export_tests.rs
+++ b/tests/health_report_export_tests.rs
@@ -1,0 +1,395 @@
+//! Tests for anchor health report export (#664).
+//!
+//! Verifies that:
+//! - `build_health_report` produces correct scores and labels from observation
+//!   windows.
+//! - `export_health_report` with `HealthReportFormat::Text` produces a
+//!   well-formed `key: value` string containing all required fields.
+//! - `export_health_report` with `HealthReportFormat::Json` produces a valid
+//!   JSON object containing all required fields.
+//! - Reports from an empty window set produce sensible defaults (not panics).
+//! - `previous_composite` is `None` for single-window reports and `Some` for
+//!   multi-window reports.
+//! - The `label` and `trend` fields reflect the actual health state.
+
+#![cfg(not(feature = "wasm"))]
+
+use anchorkit::anchor_health::{
+    build_health_report, export_health_report, HealthReportFormat, HealthWindow,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn healthy_window(started_at: u64) -> HealthWindow {
+    HealthWindow {
+        started_at,
+        ended_at: started_at + 300,
+        success_count: 99,
+        failure_count: 1,
+        p50_latency_ms: 100.0,
+        routing_failure_count: 0,
+        routing_attempt_count: 10,
+        recovery_time_seconds: 0,
+    }
+}
+
+fn critical_window(started_at: u64) -> HealthWindow {
+    HealthWindow {
+        started_at,
+        ended_at: started_at + 300,
+        success_count: 30,
+        failure_count: 70,
+        p50_latency_ms: 9000.0,
+        routing_failure_count: 8,
+        routing_attempt_count: 10,
+        recovery_time_seconds: 3600,
+    }
+}
+
+// ── build_health_report ───────────────────────────────────────────────────────
+
+#[test]
+fn build_report_from_healthy_window_has_healthy_label() {
+    let report = build_health_report("anchor.example.com", &[healthy_window(0)]);
+    assert_eq!(report.label, "healthy");
+    assert!(report.composite_score >= 80.0);
+}
+
+#[test]
+fn build_report_from_critical_window_has_critical_label() {
+    let report = build_health_report("anchor.example.com", &[critical_window(0)]);
+    assert_eq!(report.label, "critical");
+    assert!(report.composite_score < 50.0);
+}
+
+#[test]
+fn build_report_anchor_id_preserved() {
+    let report = build_health_report("my-anchor.stellar.org", &[healthy_window(0)]);
+    assert_eq!(report.anchor_id, "my-anchor.stellar.org");
+}
+
+#[test]
+fn build_report_window_count_matches_input() {
+    let windows = vec![healthy_window(0), healthy_window(300), healthy_window(600)];
+    let report = build_health_report("test", &windows);
+    assert_eq!(report.window_count, 3);
+}
+
+#[test]
+fn build_report_single_window_previous_composite_is_none() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    assert!(report.previous_composite.is_none());
+}
+
+#[test]
+fn build_report_two_windows_previous_composite_is_some() {
+    let report = build_health_report(
+        "test",
+        &[healthy_window(0), healthy_window(300)],
+    );
+    assert!(report.previous_composite.is_some());
+}
+
+#[test]
+fn build_report_empty_windows_does_not_panic() {
+    let report = build_health_report("test", &[]);
+    assert_eq!(report.window_count, 0);
+    assert!(report.previous_composite.is_none());
+}
+
+#[test]
+fn build_report_degrading_trend_label() {
+    // First window healthy, second critical → trend should be "degrading"
+    let windows = vec![healthy_window(0), critical_window(300)];
+    let report = build_health_report("test", &windows);
+    assert_eq!(report.trend, "degrading");
+}
+
+#[test]
+fn build_report_improving_trend_label() {
+    // First window critical, second healthy → trend should be "improving"
+    let windows = vec![critical_window(0), healthy_window(300)];
+    let report = build_health_report("test", &windows);
+    assert_eq!(report.trend, "improving");
+}
+
+#[test]
+fn build_report_stable_trend_for_identical_windows() {
+    let windows = vec![healthy_window(0), healthy_window(300)];
+    let report = build_health_report("test", &windows);
+    assert_eq!(report.trend, "stable");
+}
+
+#[test]
+fn build_report_sub_scores_are_in_range() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    assert!(report.composite_score >= 0.0 && report.composite_score <= 100.0);
+    assert!(report.success_rate_score >= 0.0 && report.success_rate_score <= 100.0);
+    assert!(report.latency_score >= 0.0 && report.latency_score <= 100.0);
+    assert!(report.routing_score >= 0.0 && report.routing_score <= 100.0);
+    assert!(report.recovery_score >= 0.0 && report.recovery_score <= 100.0);
+}
+
+// ── export_health_report – Text format ───────────────────────────────────────
+
+#[test]
+fn text_export_contains_anchor_id_field() {
+    let report = build_health_report("my-anchor.example.com", &[healthy_window(0)]);
+    let text = export_health_report(&report, HealthReportFormat::Text);
+    assert!(
+        text.contains("anchor_id: my-anchor.example.com"),
+        "text missing anchor_id, got: {text}"
+    );
+}
+
+#[test]
+fn text_export_contains_all_required_fields() {
+    let report = build_health_report("anchor.example.com", &[healthy_window(0)]);
+    let text = export_health_report(&report, HealthReportFormat::Text);
+
+    let required_keys = [
+        "anchor_id:",
+        "window_count:",
+        "composite_score:",
+        "success_rate_score:",
+        "latency_score:",
+        "routing_score:",
+        "recovery_score:",
+        "label:",
+        "trend:",
+        "previous_composite:",
+    ];
+    for key in &required_keys {
+        assert!(text.contains(key), "text missing field '{key}', got: {text}");
+    }
+}
+
+#[test]
+fn text_export_previous_composite_na_when_single_window() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    let text = export_health_report(&report, HealthReportFormat::Text);
+    assert!(
+        text.contains("previous_composite: n/a"),
+        "expected n/a for single-window report, got: {text}"
+    );
+}
+
+#[test]
+fn text_export_previous_composite_numeric_when_multi_window() {
+    let report = build_health_report(
+        "test",
+        &[healthy_window(0), healthy_window(300)],
+    );
+    let text = export_health_report(&report, HealthReportFormat::Text);
+    // Should contain a numeric value, not "n/a"
+    assert!(
+        !text.contains("previous_composite: n/a"),
+        "expected numeric previous_composite for multi-window report, got: {text}"
+    );
+}
+
+#[test]
+fn text_export_label_healthy_present() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    let text = export_health_report(&report, HealthReportFormat::Text);
+    assert!(text.contains("label: healthy"), "got: {text}");
+}
+
+#[test]
+fn text_export_label_critical_present() {
+    let report = build_health_report("test", &[critical_window(0)]);
+    let text = export_health_report(&report, HealthReportFormat::Text);
+    assert!(text.contains("label: critical"), "got: {text}");
+}
+
+#[test]
+fn text_export_is_multi_line() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    let text = export_health_report(&report, HealthReportFormat::Text);
+    // Text format must have at least 9 newlines (one per required field)
+    let newlines = text.chars().filter(|&c| c == '\n').count();
+    assert!(newlines >= 9, "expected >= 9 newlines, got {newlines}");
+}
+
+#[test]
+fn text_export_window_count_numeric() {
+    let report = build_health_report("test", &[healthy_window(0), healthy_window(300)]);
+    let text = export_health_report(&report, HealthReportFormat::Text);
+    assert!(text.contains("window_count: 2"), "got: {text}");
+}
+
+// ── export_health_report – JSON format ───────────────────────────────────────
+
+#[test]
+fn json_export_starts_with_open_brace_and_ends_with_close_brace() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    let json = export_health_report(&report, HealthReportFormat::Json);
+    let trimmed = json.trim();
+    assert!(trimmed.starts_with('{'), "JSON must start with '{{', got: {json}");
+    assert!(trimmed.ends_with('}'), "JSON must end with '}}', got: {json}");
+}
+
+#[test]
+fn json_export_contains_anchor_id_key() {
+    let report = build_health_report("stellar-anchor.io", &[healthy_window(0)]);
+    let json = export_health_report(&report, HealthReportFormat::Json);
+    assert!(
+        json.contains("\"anchor_id\""),
+        "JSON missing anchor_id key, got: {json}"
+    );
+    assert!(
+        json.contains("stellar-anchor.io"),
+        "JSON missing anchor_id value, got: {json}"
+    );
+}
+
+#[test]
+fn json_export_contains_all_required_keys() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    let json = export_health_report(&report, HealthReportFormat::Json);
+
+    let required_keys = [
+        "\"anchor_id\"",
+        "\"window_count\"",
+        "\"composite_score\"",
+        "\"success_rate_score\"",
+        "\"latency_score\"",
+        "\"routing_score\"",
+        "\"recovery_score\"",
+        "\"label\"",
+        "\"trend\"",
+        "\"previous_composite\"",
+    ];
+    for key in &required_keys {
+        assert!(json.contains(key), "JSON missing key '{key}', got: {json}");
+    }
+}
+
+#[test]
+fn json_export_previous_composite_null_when_single_window() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    let json = export_health_report(&report, HealthReportFormat::Json);
+    assert!(
+        json.contains("\"previous_composite\":null"),
+        "expected null for single-window report, got: {json}"
+    );
+}
+
+#[test]
+fn json_export_previous_composite_numeric_when_multi_window() {
+    let report = build_health_report(
+        "test",
+        &[healthy_window(0), healthy_window(300)],
+    );
+    let json = export_health_report(&report, HealthReportFormat::Json);
+    assert!(
+        !json.contains("\"previous_composite\":null"),
+        "expected numeric previous_composite for multi-window report, got: {json}"
+    );
+}
+
+#[test]
+fn json_export_label_and_trend_are_quoted_strings() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    let json = export_health_report(&report, HealthReportFormat::Json);
+    // Label and trend must be JSON strings (enclosed in quotes)
+    assert!(
+        json.contains("\"label\":\""),
+        "label must be a quoted string, got: {json}"
+    );
+    assert!(
+        json.contains("\"trend\":\""),
+        "trend must be a quoted string, got: {json}"
+    );
+}
+
+#[test]
+fn json_export_composite_score_is_numeric() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    let json = export_health_report(&report, HealthReportFormat::Json);
+    // composite_score must be followed by a numeric value (no quotes)
+    assert!(
+        json.contains("\"composite_score\":"),
+        "composite_score key missing, got: {json}"
+    );
+    let after_key = json
+        .split("\"composite_score\":")
+        .nth(1)
+        .unwrap_or("");
+    let first_char = after_key.chars().next().unwrap_or(' ');
+    assert!(
+        first_char.is_ascii_digit() || first_char == '-',
+        "composite_score must be numeric, got: {json}"
+    );
+}
+
+// ── Format consistency ────────────────────────────────────────────────────────
+
+#[test]
+fn text_and_json_agree_on_anchor_id() {
+    let report = build_health_report("consistency-check.io", &[healthy_window(0)]);
+    let text = export_health_report(&report, HealthReportFormat::Text);
+    let json = export_health_report(&report, HealthReportFormat::Json);
+    assert!(text.contains("consistency-check.io"), "text: {text}");
+    assert!(json.contains("consistency-check.io"), "json: {json}");
+}
+
+#[test]
+fn text_and_json_agree_on_label() {
+    let report = build_health_report("test", &[healthy_window(0)]);
+    let text = export_health_report(&report, HealthReportFormat::Text);
+    let json = export_health_report(&report, HealthReportFormat::Json);
+    // Both should contain "healthy"
+    assert!(text.contains("healthy"), "text: {text}");
+    assert!(json.contains("healthy"), "json: {json}");
+}
+
+// ── Degraded label ────────────────────────────────────────────────────────────
+
+#[test]
+fn build_report_degraded_label_for_mid_range_score() {
+    // A window that produces a score in the 50–79 range
+    let window = HealthWindow {
+        started_at: 0,
+        ended_at: 300,
+        success_count: 70,
+        failure_count: 30,
+        p50_latency_ms: 5000.0,
+        routing_failure_count: 3,
+        routing_attempt_count: 10,
+        recovery_time_seconds: 600,
+    };
+    let report = build_health_report("test", &[window]);
+    // Score may be healthy, degraded, or critical depending on weights;
+    // just confirm the label matches the composite.
+    let expected_label = if report.composite_score >= 80.0 {
+        "healthy"
+    } else if report.composite_score >= 50.0 {
+        "degraded"
+    } else {
+        "critical"
+    };
+    assert_eq!(report.label, expected_label);
+}
+
+// ── Multiple windows aggregation ──────────────────────────────────────────────
+
+#[test]
+fn build_report_uses_last_window_as_current() {
+    // First window healthy, second critical → report should reflect critical (last)
+    let windows = vec![healthy_window(0), critical_window(300)];
+    let report = build_health_report("test", &windows);
+    assert_eq!(report.label, "critical");
+}
+
+#[test]
+fn build_report_previous_composite_reflects_first_of_two_windows() {
+    let windows = vec![healthy_window(0), critical_window(300)];
+    let report_hc = build_health_report("test", &windows);
+    // previous_composite is from the healthy window, so should be >= 80
+    assert!(
+        report_hc.previous_composite.unwrap() >= 80.0,
+        "expected previous >= 80, got {:?}",
+        report_hc.previous_composite
+    );
+}

--- a/tests/partial_quote_tests.rs
+++ b/tests/partial_quote_tests.rs
@@ -1,0 +1,379 @@
+//! Tests for partial quote response handling (#662).
+//!
+//! Verifies that:
+//! - Partial quote payloads are parsed without error even when fields are absent.
+//! - Every missing or unparseable field name is recorded in `missing_fields`.
+//! - A complete `PartialFirmQuote` can be promoted to a `FirmQuote` via `into_full`.
+//! - An incomplete `PartialFirmQuote` returns an error from `into_full`.
+//! - Asset codes in partial quotes are normalized to uppercase.
+//! - Stale `expires_at` is accepted by `parse_partial_quote` (staleness is the
+//!   caller's concern, not the parser's).
+//! - Invalid (but present) field values are treated as missing and recorded.
+
+#![cfg(not(feature = "wasm"))]
+
+use anchorkit::sep38::{parse_partial_quote, FirmQuote, PartialFirmQuote, RawPartialFirmQuote};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn full_raw() -> RawPartialFirmQuote {
+    RawPartialFirmQuote {
+        id: Some("q-full".into()),
+        expires_at: Some("9999999999".into()),
+        price: Some("0.15".into()),
+        sell_amount: Some("1000".into()),
+        buy_amount: Some("150".into()),
+        sell_asset: Some("XLM".into()),
+        buy_asset: Some("USDC".into()),
+    }
+}
+
+// ── All fields present ────────────────────────────────────────────────────────
+
+#[test]
+fn full_raw_produces_complete_partial_quote() {
+    let partial = parse_partial_quote(full_raw());
+
+    assert_eq!(partial.id, Some("q-full".into()));
+    assert_eq!(partial.expires_at, Some(9_999_999_999u64));
+    assert_eq!(partial.price, Some("0.15".into()));
+    assert_eq!(partial.sell_amount, Some("1000".into()));
+    assert_eq!(partial.buy_amount, Some("150".into()));
+    assert_eq!(partial.sell_asset, Some("XLM".into()));
+    assert_eq!(partial.buy_asset, Some("USDC".into()));
+    assert!(partial.missing_fields.is_empty());
+    assert!(partial.is_complete());
+}
+
+#[test]
+fn complete_partial_quote_promotes_to_full_quote() {
+    let full: FirmQuote = parse_partial_quote(full_raw()).into_full().unwrap();
+
+    assert_eq!(full.id, "q-full");
+    assert_eq!(full.expires_at, 9_999_999_999u64);
+    assert_eq!(full.price, "0.15");
+    assert_eq!(full.sell_amount, "1000");
+    assert_eq!(full.buy_amount, "150");
+    assert_eq!(full.sell_asset, "XLM");
+    assert_eq!(full.buy_asset, "USDC");
+}
+
+// ── Missing fields are surfaced in missing_fields ────────────────────────────
+
+#[test]
+fn missing_id_recorded_in_missing_fields() {
+    let mut raw = full_raw();
+    raw.id = None;
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"id"));
+    assert!(partial.id.is_none());
+}
+
+#[test]
+fn missing_expires_at_recorded() {
+    let mut raw = full_raw();
+    raw.expires_at = None;
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"expires_at"));
+    assert!(partial.expires_at.is_none());
+}
+
+#[test]
+fn missing_price_recorded() {
+    let mut raw = full_raw();
+    raw.price = None;
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"price"));
+    assert!(partial.price.is_none());
+}
+
+#[test]
+fn missing_sell_amount_recorded() {
+    let mut raw = full_raw();
+    raw.sell_amount = None;
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"sell_amount"));
+    assert!(partial.sell_amount.is_none());
+}
+
+#[test]
+fn missing_buy_amount_recorded() {
+    let mut raw = full_raw();
+    raw.buy_amount = None;
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"buy_amount"));
+    assert!(partial.buy_amount.is_none());
+}
+
+#[test]
+fn missing_sell_asset_recorded() {
+    let mut raw = full_raw();
+    raw.sell_asset = None;
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"sell_asset"));
+    assert!(partial.sell_asset.is_none());
+}
+
+#[test]
+fn missing_buy_asset_recorded() {
+    let mut raw = full_raw();
+    raw.buy_asset = None;
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"buy_asset"));
+    assert!(partial.buy_asset.is_none());
+}
+
+#[test]
+fn all_fields_missing_records_all_seven_names() {
+    let raw = RawPartialFirmQuote::default();
+
+    let partial = parse_partial_quote(raw);
+    assert_eq!(partial.missing_fields.len(), 7);
+    for name in &["id", "expires_at", "price", "sell_amount", "buy_amount", "sell_asset", "buy_asset"] {
+        assert!(
+            partial.missing_fields.contains(name),
+            "expected '{}' in missing_fields",
+            name
+        );
+    }
+}
+
+#[test]
+fn multiple_missing_fields_all_recorded() {
+    let mut raw = full_raw();
+    raw.expires_at = None;
+    raw.sell_amount = None;
+
+    let partial = parse_partial_quote(raw);
+    assert_eq!(partial.missing_fields.len(), 2);
+    assert!(partial.missing_fields.contains(&"expires_at"));
+    assert!(partial.missing_fields.contains(&"sell_amount"));
+    assert!(!partial.is_complete());
+}
+
+// ── Invalid present values treated as missing ─────────────────────────────────
+
+#[test]
+fn invalid_expires_at_treated_as_missing() {
+    let mut raw = full_raw();
+    raw.expires_at = Some("not-a-timestamp".into());
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"expires_at"));
+    assert!(partial.expires_at.is_none());
+}
+
+#[test]
+fn zero_expires_at_treated_as_missing() {
+    let mut raw = full_raw();
+    raw.expires_at = Some("0".into());
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"expires_at"));
+}
+
+#[test]
+fn invalid_price_treated_as_missing() {
+    let mut raw = full_raw();
+    raw.price = Some("abc".into());
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"price"));
+    assert!(partial.price.is_none());
+}
+
+#[test]
+fn zero_price_treated_as_missing() {
+    let mut raw = full_raw();
+    raw.price = Some("0".into());
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"price"));
+}
+
+#[test]
+fn zero_sell_amount_treated_as_missing() {
+    let mut raw = full_raw();
+    raw.sell_amount = Some("0.0".into());
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"sell_amount"));
+}
+
+#[test]
+fn invalid_sell_amount_treated_as_missing() {
+    let mut raw = full_raw();
+    raw.sell_amount = Some("--bad--".into());
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"sell_amount"));
+}
+
+#[test]
+fn empty_id_treated_as_missing() {
+    let mut raw = full_raw();
+    raw.id = Some("".into());
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"id"));
+    assert!(partial.id.is_none());
+}
+
+#[test]
+fn invalid_sell_asset_treated_as_missing() {
+    let mut raw = full_raw();
+    raw.sell_asset = Some("TOO LONG CODE EXCEEDS LIMIT".into());
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"sell_asset"));
+    assert!(partial.sell_asset.is_none());
+}
+
+#[test]
+fn invalid_buy_asset_treated_as_missing() {
+    let mut raw = full_raw();
+    raw.buy_asset = Some("BAD CODE!".into());
+
+    let partial = parse_partial_quote(raw);
+    assert!(partial.missing_fields.contains(&"buy_asset"));
+    assert!(partial.buy_asset.is_none());
+}
+
+// ── Asset code normalization ──────────────────────────────────────────────────
+
+#[test]
+fn lowercase_asset_codes_normalized_to_uppercase() {
+    let mut raw = full_raw();
+    raw.sell_asset = Some("xlm".into());
+    raw.buy_asset = Some("usdc".into());
+
+    let partial = parse_partial_quote(raw);
+    assert_eq!(partial.sell_asset, Some("XLM".into()));
+    assert_eq!(partial.buy_asset, Some("USDC".into()));
+    assert!(partial.missing_fields.is_empty());
+}
+
+// ── Stale expires_at is accepted ─────────────────────────────────────────────
+
+#[test]
+fn stale_expires_at_is_accepted_not_recorded_as_missing() {
+    // A past timestamp is valid data – it is the caller's job to check freshness.
+    let mut raw = full_raw();
+    raw.expires_at = Some("1".into()); // epoch + 1 second
+
+    let partial = parse_partial_quote(raw);
+    assert!(!partial.missing_fields.contains(&"expires_at"));
+    assert_eq!(partial.expires_at, Some(1u64));
+}
+
+// ── is_complete and into_full ─────────────────────────────────────────────────
+
+#[test]
+fn is_complete_true_when_no_missing_fields() {
+    let partial = parse_partial_quote(full_raw());
+    assert!(partial.is_complete());
+}
+
+#[test]
+fn is_complete_false_when_any_field_missing() {
+    let mut raw = full_raw();
+    raw.price = None;
+
+    let partial = parse_partial_quote(raw);
+    assert!(!partial.is_complete());
+}
+
+#[test]
+fn into_full_returns_error_when_incomplete() {
+    let mut raw = full_raw();
+    raw.expires_at = None;
+    raw.buy_amount = None;
+
+    let partial = parse_partial_quote(raw);
+    assert!(!partial.is_complete());
+    assert!(partial.into_full().is_err());
+}
+
+#[test]
+fn into_full_preserves_all_values_from_complete_partial() {
+    let partial = parse_partial_quote(full_raw());
+    let full = partial.into_full().expect("should promote successfully");
+
+    assert_eq!(full.id, "q-full");
+    assert_eq!(full.expires_at, 9_999_999_999u64);
+    assert_eq!(full.price, "0.15");
+    assert_eq!(full.sell_amount, "1000");
+    assert_eq!(full.buy_amount, "150");
+    assert_eq!(full.sell_asset, "XLM");
+    assert_eq!(full.buy_asset, "USDC");
+    // routing_reason is not carried through partial quotes
+    assert!(full.routing_reason.is_none());
+}
+
+// ── Typical partial-response scenarios ───────────────────────────────────────
+
+#[test]
+fn rate_limited_response_with_only_id_and_price() {
+    // Simulates an anchor that returns id + price but nothing else (rate-limited)
+    let raw = RawPartialFirmQuote {
+        id: Some("q-rate-limited".into()),
+        expires_at: None,
+        price: Some("0.22".into()),
+        sell_amount: None,
+        buy_amount: None,
+        sell_asset: None,
+        buy_asset: None,
+    };
+
+    let partial = parse_partial_quote(raw);
+    assert_eq!(partial.id, Some("q-rate-limited".into()));
+    assert_eq!(partial.price, Some("0.22".into()));
+    assert_eq!(partial.missing_fields.len(), 5); // expires_at, sell_amount, buy_amount, sell_asset, buy_asset
+    assert!(!partial.is_complete());
+}
+
+#[test]
+fn incomplete_upstream_response_missing_amounts() {
+    // Anchor upstream missing amounts but has identity and timing
+    let raw = RawPartialFirmQuote {
+        id: Some("q-upstream-partial".into()),
+        expires_at: Some("9999999999".into()),
+        price: Some("0.10".into()),
+        sell_amount: None,
+        buy_amount: None,
+        sell_asset: Some("XLM".into()),
+        buy_asset: Some("USDC".into()),
+    };
+
+    let partial = parse_partial_quote(raw);
+    assert_eq!(partial.missing_fields.len(), 2);
+    assert!(partial.missing_fields.contains(&"sell_amount"));
+    assert!(partial.missing_fields.contains(&"buy_amount"));
+    assert!(!partial.is_complete());
+}
+
+#[test]
+fn all_present_but_one_field_not_complete() {
+    // All 7 fields present in the raw, but sell_asset has invalid code
+    let raw = RawPartialFirmQuote {
+        id: Some("q-almost".into()),
+        expires_at: Some("9999999999".into()),
+        price: Some("0.15".into()),
+        sell_amount: Some("500".into()),
+        buy_amount: Some("75".into()),
+        sell_asset: Some("BAD CODE!@#".into()), // invalid
+        buy_asset: Some("USDC".into()),
+    };
+
+    let partial = parse_partial_quote(raw);
+    assert_eq!(partial.missing_fields.len(), 1);
+    assert!(partial.missing_fields.contains(&"sell_asset"));
+    assert!(!partial.is_complete());
+}

--- a/tests/vendor_status_mapping_tests.rs
+++ b/tests/vendor_status_mapping_tests.rs
@@ -1,0 +1,376 @@
+//! Tests for vendor-specific status mapping support (#660).
+//!
+//! Verifies that:
+//! - Known vendor strings are classified into canonical `TransactionStatus` values.
+//! - The original raw status string is always preserved in `VendorStatusEntry`.
+//! - Unknown vendor strings fall back to `TransactionStatus::from_str`.
+//! - Truly unrecognised strings map to `TransactionStatus::Error` with the raw
+//!   value preserved.
+//! - The map applies consistently in deposit/withdrawal/transaction-status parsing.
+//! - Registration, replacement, removal, and lookup helpers all behave correctly.
+
+#![cfg(not(feature = "wasm"))]
+
+use anchorkit::sep6::{
+    classify_status_str, fetch_transaction_status, initiate_deposit, initiate_withdrawal,
+    RawDepositResponse, RawTransactionResponse, RawWithdrawalResponse, StatusCategory,
+    TransactionStatus, VendorStatusEntry, VendorStatusMap,
+};
+
+// ── VendorStatusMap construction ─────────────────────────────────────────────
+
+#[test]
+fn new_map_is_empty() {
+    let map = VendorStatusMap::new();
+    assert!(map.is_empty());
+    assert_eq!(map.len(), 0);
+}
+
+#[test]
+fn default_map_is_empty() {
+    let map = VendorStatusMap::default();
+    assert!(map.is_empty());
+}
+
+// ── register and resolve – known vendor values ────────────────────────────────
+
+#[test]
+fn known_vendor_value_resolves_to_registered_canonical() {
+    let mut map = VendorStatusMap::new();
+    map.register("ach_processing", TransactionStatus::PendingExternal);
+
+    let entry = map.resolve("ach_processing");
+    assert_eq!(entry.canonical, TransactionStatus::PendingExternal);
+    assert_eq!(entry.vendor_status, "ach_processing");
+}
+
+#[test]
+fn raw_value_is_preserved_exactly_as_supplied() {
+    let mut map = VendorStatusMap::new();
+    map.register("kyc_required", TransactionStatus::PendingUser);
+
+    // resolve with mixed-case / leading whitespace – raw is trimmed but preserved
+    let entry = map.resolve("  KYC_Required  ");
+    assert_eq!(entry.canonical, TransactionStatus::PendingUser);
+    assert_eq!(entry.vendor_status, "KYC_Required");
+}
+
+#[test]
+fn case_insensitive_lookup_matches_registered_key() {
+    let mut map = VendorStatusMap::new();
+    map.register("FX_PENDING", TransactionStatus::PendingAnchor);
+
+    // Registered as uppercase – resolved with lowercase input
+    let entry = map.resolve("fx_pending");
+    assert_eq!(entry.canonical, TransactionStatus::PendingAnchor);
+}
+
+#[test]
+fn multiple_vendor_strings_registered_independently() {
+    let mut map = VendorStatusMap::new();
+    map.register("ach_processing", TransactionStatus::PendingExternal);
+    map.register("kyc_required", TransactionStatus::PendingUser);
+    map.register("fx_pending", TransactionStatus::PendingAnchor);
+
+    assert_eq!(map.len(), 3);
+    assert_eq!(
+        map.resolve("ach_processing").canonical,
+        TransactionStatus::PendingExternal
+    );
+    assert_eq!(
+        map.resolve("kyc_required").canonical,
+        TransactionStatus::PendingUser
+    );
+    assert_eq!(
+        map.resolve("fx_pending").canonical,
+        TransactionStatus::PendingAnchor
+    );
+}
+
+// ── register – replacement of an existing mapping ────────────────────────────
+
+#[test]
+fn re_registering_same_key_replaces_canonical() {
+    let mut map = VendorStatusMap::new();
+    map.register("ach_processing", TransactionStatus::PendingExternal);
+    map.register("ach_processing", TransactionStatus::PendingAnchor);
+
+    // Length must not grow – it was replaced, not added
+    assert_eq!(map.len(), 1);
+    assert_eq!(
+        map.resolve("ach_processing").canonical,
+        TransactionStatus::PendingAnchor
+    );
+}
+
+// ── resolve – fall-through to SEP-6 standard parser ──────────────────────────
+
+#[test]
+fn standard_sep6_status_resolves_via_fallback_when_not_registered() {
+    let map = VendorStatusMap::new(); // empty – no custom mappings
+
+    let entry = map.resolve("completed");
+    assert_eq!(entry.canonical, TransactionStatus::Completed);
+    assert_eq!(entry.vendor_status, "completed");
+}
+
+#[test]
+fn all_standard_statuses_resolve_via_fallback() {
+    let map = VendorStatusMap::new();
+    let cases: &[(&str, TransactionStatus)] = &[
+        ("pending_external", TransactionStatus::PendingExternal),
+        ("pending_anchor", TransactionStatus::PendingAnchor),
+        ("pending_trust", TransactionStatus::PendingTrust),
+        ("pending_user", TransactionStatus::PendingUser),
+        ("completed", TransactionStatus::Completed),
+        ("refunded", TransactionStatus::Refunded),
+        ("expired", TransactionStatus::Expired),
+        ("incomplete", TransactionStatus::Incomplete),
+        ("pending", TransactionStatus::Pending),
+        ("no_market", TransactionStatus::NoMarket),
+        ("too_small", TransactionStatus::TooSmall),
+        ("too_large", TransactionStatus::TooLarge),
+        ("pending_stellar", TransactionStatus::PendingStellar),
+        ("waiting_customer_action", TransactionStatus::WaitingCustomerAction),
+    ];
+    for (raw, expected) in cases {
+        let entry = map.resolve(raw);
+        assert_eq!(
+            entry.canonical, *expected,
+            "unexpected canonical for '{raw}'"
+        );
+        assert_eq!(entry.vendor_status, *raw);
+    }
+}
+
+#[test]
+fn truly_unknown_value_maps_to_error_with_raw_preserved() {
+    let map = VendorStatusMap::new();
+
+    let entry = map.resolve("totally_unknown_vendor_status");
+    assert_eq!(entry.canonical, TransactionStatus::Error);
+    assert_eq!(entry.vendor_status, "totally_unknown_vendor_status");
+}
+
+#[test]
+fn empty_string_maps_to_error_with_raw_preserved() {
+    let map = VendorStatusMap::new();
+
+    let entry = map.resolve("");
+    assert_eq!(entry.canonical, TransactionStatus::Error);
+}
+
+// ── Vendor mapping takes precedence over standard parser ─────────────────────
+
+#[test]
+fn custom_mapping_overrides_standard_parser() {
+    let mut map = VendorStatusMap::new();
+    // Remap "completed" to PendingAnchor (artificial, to test precedence)
+    map.register("completed", TransactionStatus::PendingAnchor);
+
+    let entry = map.resolve("completed");
+    assert_eq!(entry.canonical, TransactionStatus::PendingAnchor);
+}
+
+// ── contains ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn contains_returns_true_for_registered_key() {
+    let mut map = VendorStatusMap::new();
+    map.register("ach_processing", TransactionStatus::PendingExternal);
+
+    assert!(map.contains("ach_processing"));
+    assert!(map.contains("ACH_PROCESSING")); // case-insensitive
+}
+
+#[test]
+fn contains_returns_false_for_unregistered_key() {
+    let map = VendorStatusMap::new();
+    assert!(!map.contains("ach_processing"));
+}
+
+// ── remove ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn remove_existing_key_returns_true_and_shrinks_map() {
+    let mut map = VendorStatusMap::new();
+    map.register("ach_processing", TransactionStatus::PendingExternal);
+    map.register("kyc_required", TransactionStatus::PendingUser);
+
+    assert!(map.remove("ach_processing"));
+    assert_eq!(map.len(), 1);
+    assert!(!map.contains("ach_processing"));
+}
+
+#[test]
+fn remove_missing_key_returns_false() {
+    let mut map = VendorStatusMap::new();
+    assert!(!map.remove("non_existent"));
+}
+
+#[test]
+fn after_remove_resolve_falls_back_to_parser() {
+    let mut map = VendorStatusMap::new();
+    map.register("completed", TransactionStatus::PendingAnchor);
+    map.remove("completed");
+
+    // Falls back to standard parser → Completed
+    let entry = map.resolve("completed");
+    assert_eq!(entry.canonical, TransactionStatus::Completed);
+}
+
+// ── Canonical StatusCategory classification ───────────────────────────────────
+
+#[test]
+fn canonical_status_classifies_correctly_after_vendor_resolution() {
+    let mut map = VendorStatusMap::new();
+    map.register("ach_processing", TransactionStatus::PendingExternal);
+    map.register("payment_settled", TransactionStatus::Completed);
+    map.register("payment_failed", TransactionStatus::Error);
+
+    assert_eq!(
+        map.resolve("ach_processing").canonical.classify(),
+        StatusCategory::Active
+    );
+    assert_eq!(
+        map.resolve("payment_settled").canonical.classify(),
+        StatusCategory::Completed
+    );
+    assert_eq!(
+        map.resolve("payment_failed").canonical.classify(),
+        StatusCategory::Failed
+    );
+}
+
+// ── classify_status_str – free function ──────────────────────────────────────
+
+#[test]
+fn classify_status_str_known_vendor_string_without_map_returns_unknown() {
+    // Without a VendorStatusMap, vendor strings are not in the standard set
+    // and fall through to Unknown.
+    assert_eq!(classify_status_str("ach_processing"), StatusCategory::Unknown);
+    assert_eq!(classify_status_str("kyc_required"), StatusCategory::Unknown);
+}
+
+#[test]
+fn classify_status_str_handles_case_and_whitespace() {
+    assert_eq!(classify_status_str("  COMPLETED  "), StatusCategory::Completed);
+    assert_eq!(classify_status_str("PENDING_EXTERNAL"), StatusCategory::Active);
+    assert_eq!(classify_status_str("  expired  "), StatusCategory::Expired);
+}
+
+// ── Integration: VendorStatusMap applied in deposit normalization ──────────────
+
+fn make_raw_deposit(status: &str) -> RawDepositResponse {
+    RawDepositResponse {
+        transaction_id: "txn-001".into(),
+        how: "Send to bank".into(),
+        extra_info: None,
+        min_amount: None,
+        max_amount: None,
+        fee_fixed: None,
+        status: Some(status.into()),
+        clawback_enabled: None,
+        stellar_memo: None,
+        stellar_memo_type: None,
+        asset_code: None,
+    }
+}
+
+#[test]
+fn vendor_map_resolve_then_deposit_normalization_consistent() {
+    let mut map = VendorStatusMap::new();
+    map.register("ach_processing", TransactionStatus::PendingExternal);
+
+    // Resolve via map to get the canonical status
+    let entry = map.resolve("ach_processing");
+    assert_eq!(entry.canonical, TransactionStatus::PendingExternal);
+
+    // Simulate what normalization does: use the canonical as the deposit status
+    let raw = make_raw_deposit("pending_external"); // already canonical
+    let deposit = initiate_deposit(raw).unwrap();
+    assert_eq!(deposit.status, TransactionStatus::PendingExternal);
+}
+
+#[test]
+fn vendor_status_raw_preserved_after_resolution() {
+    let mut map = VendorStatusMap::new();
+    map.register("Ach_Processing", TransactionStatus::PendingExternal);
+
+    let entry = map.resolve("ACH_PROCESSING");
+    // Canonical is correctly mapped
+    assert_eq!(entry.canonical, TransactionStatus::PendingExternal);
+    // Raw is trimmed but otherwise the caller's spelling is preserved
+    assert_eq!(entry.vendor_status, "ACH_PROCESSING");
+}
+
+// ── Tie-breaker: vendor map registered canonical is used in fetch_transaction_status ──
+
+#[test]
+fn fetch_transaction_status_with_resolved_vendor_canonical() {
+    // Scenario: anchor returns "ach_processing"; after map resolution we feed
+    // the canonical string into fetch_transaction_status.
+    let mut map = VendorStatusMap::new();
+    map.register("ach_processing", TransactionStatus::PendingExternal);
+
+    let resolved = map.resolve("ach_processing");
+    // Use canonical string as the raw status for normalization
+    let raw = RawTransactionResponse {
+        transaction_id: "txn-002".into(),
+        kind: Some("deposit".into()),
+        status: resolved.canonical.as_str().into(),
+        amount_in: Some(500),
+        amount_out: None,
+        amount_fee: None,
+        message: None,
+    };
+    let resp = fetch_transaction_status(raw).unwrap();
+    assert_eq!(resp.status, TransactionStatus::PendingExternal);
+}
+
+// ── Edge cases: whitespace-only and punctuation vendor strings ────────────────
+
+#[test]
+fn whitespace_only_vendor_string_maps_to_error() {
+    let map = VendorStatusMap::new();
+    let entry = map.resolve("   ");
+    assert_eq!(entry.canonical, TransactionStatus::Error);
+}
+
+#[test]
+fn vendor_string_with_underscores_preserved() {
+    let mut map = VendorStatusMap::new();
+    map.register("on_hold_for_review", TransactionStatus::PendingUser);
+
+    let entry = map.resolve("on_hold_for_review");
+    assert_eq!(entry.canonical, TransactionStatus::PendingUser);
+    assert_eq!(entry.vendor_status, "on_hold_for_review");
+}
+
+// ── Ordering is stable: last write wins for duplicate registration ────────────
+
+#[test]
+fn last_register_wins_on_duplicate_key() {
+    let mut map = VendorStatusMap::new();
+    map.register("pending_review", TransactionStatus::PendingAnchor);
+    map.register("pending_review", TransactionStatus::PendingUser);
+    map.register("pending_review", TransactionStatus::PendingTrust);
+
+    assert_eq!(map.len(), 1);
+    assert_eq!(
+        map.resolve("pending_review").canonical,
+        TransactionStatus::PendingTrust
+    );
+}
+
+// ── VendorStatusEntry struct fields ──────────────────────────────────────────
+
+#[test]
+fn vendor_status_entry_fields_are_accessible() {
+    let entry = VendorStatusEntry {
+        vendor_status: "my_vendor_status".into(),
+        canonical: TransactionStatus::Completed,
+    };
+    assert_eq!(entry.vendor_status, "my_vendor_status");
+    assert_eq!(entry.canonical, TransactionStatus::Completed);
+}


### PR DESCRIPTION
## Summary

This PR implements four related normalization and data-quality improvements across the SEP-6, SEP-38, and health-monitoring layers.

Closes #660
Closes #662
Closes #663
Closes #664

---

## Changes by issue

### #660 — Vendor-specific status mappings

Added `VendorStatusMap` and `VendorStatusEntry` to `src/sep6.rs`.

- `VendorStatusMap::register(vendor_str, canonical)` stores a custom mapping from a proprietary anchor status string to a canonical `TransactionStatus`.
- `VendorStatusMap::resolve(raw)` looks up the trimmed, lowercased value in the map first, then falls back to `TransactionStatus::from_str` for standard SEP-6 values, then `TransactionStatus::Error` for truly unknown strings.
- The raw vendor string is always preserved in the returned `VendorStatusEntry` so callers never lose vendor detail.
- Helper methods: `contains`, `remove`, `len`, `is_empty`.
- `classify_status_str` extended to cover all active-state variants consistently.
- Both types are re-exported from `lib.rs`.

Tests: `tests/vendor_status_mapping_tests.rs`

### #662 — Partial quote responses

Added `RawPartialFirmQuote`, `PartialFirmQuote`, and `parse_partial_quote` to `src/sep38.rs`.

- `RawPartialFirmQuote` mirrors `RawFirmQuote` but every field is `Option\<String\>`.
- `parse_partial_quote` parses whatever fields are present, records absent or unparseable field names in `PartialFirmQuote::missing_fields`, and never returns an error for missing fields.
- `PartialFirmQuote::is_complete()` returns `true` when `missing_fields` is empty.
- `PartialFirmQuote::into_full()` promotes a complete partial quote to a `FirmQuote`, or returns `Err(Error::invalid_quote())` when fields are still missing.
- Asset codes are normalized to uppercase; stale `expires_at` values are accepted (caller decides on freshness).
- All three types are re-exported from `lib.rs`.

Tests: `tests/partial_quote_tests.rs`

### #663 — Deterministic ordering

Added `QuoteSortOrder` enum and `sort_quotes` function to `src/sep38.rs`, and `AttestationSortOrder` enum and `sort_attestations` function to `src/contract.rs`.

- `QuoteSortOrder` variants: `PriceAsc`, `PriceDesc`, `ExpiresAtAsc`, `ExpiresAtDesc`, `IdAsc`.
- `sort_quotes(&[FirmQuote], QuoteSortOrder) -> Vec<FirmQuote>` — stable sort with `id` as the final tiebreaker for all non-id orderings, ensuring fully deterministic output regardless of storage order.
- `AttestationSortOrder` variants: `IdAsc`, `IdDesc`, `TimestampAsc`, `TimestampDesc`.
- `sort_attestations(&[Attestation], AttestationSortOrder) -> Vec<Attestation>` — same tiebreaker guarantee for attestation records.
- Both functions are re-exported from `lib.rs` (host-only, excluded from WASM builds).

Tests: `tests/deterministic_ordering_tests.rs`

### #664 — Health report export

Added `HealthReportFormat`, `AnchorHealthReport`, `build_health_report`, and `export_health_report` to `src/anchor_health.rs`.

- `HealthReportFormat::Text` produces a multi-line `key: value` string — easy to grep and shell-parse.
- `HealthReportFormat::Json` produces a compact JSON object suitable for dashboard ingestion and incident tooling.
- `build_health_report(anchor_id, &[HealthWindow])` builds the report from raw observation windows using the existing composite scoring model.
- `export_health_report(&AnchorHealthReport, HealthReportFormat)` serializes to the requested format.
- Report fields: `anchor_id`, `window_count`, `composite_score`, sub-scores (`success_rate_score`, `latency_score`, `routing_score`, `recovery_score`), `label`, `trend`, `previous_composite`.
- All four symbols are re-exported from `lib.rs` (host-only).

Tests: `tests/health_report_export_tests.rs`

---

## Files changed

| File | Change |
|------|--------|
| `src/sep6.rs` | Added `VendorStatusMap`, `VendorStatusEntry`, `classify_status_str` improvements |
| `src/sep38.rs` | Added `RawPartialFirmQuote`, `PartialFirmQuote`, `parse_partial_quote`, `QuoteSortOrder`, `sort_quotes` |
| `src/contract.rs` | Added `AttestationSortOrder`, `sort_attestations` |
| `src/anchor_health.rs` | Added `HealthReportFormat`, `AnchorHealthReport`, `build_health_report`, `export_health_report` |
| `src/lib.rs` | Re-exported all new public types and functions |
| `tests/vendor_status_mapping_tests.rs` | New test file for #660 |
| `tests/partial_quote_tests.rs` | New test file for #662 |
| `tests/deterministic_ordering_tests.rs` | New test file for #663 |
| `tests/health_report_export_tests.rs` | New test file for #664 |