### PR TITLE
docs: add maintainer onboarding, API snapshots, and changelog generation

### DIFF
--- a/api_snapshots/.gitkeep
+++ b/api_snapshots/.gitkeep
@@ -1,0 +1,1 @@
+# Snapshot files are committed here by scripts/snapshot_api.sh

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,34 @@
+[changelog]
+header = "# Changelog\n\n"
+body   = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message }} \
+(#{{ commit.id | truncate(length=7, end="") }})
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits    = true
+filter_unconventional   = true
+split_commits           = false
+commit_parsers = [
+  { message = "^feat",     group = "Features" },
+  { message = "^fix",      group = "Bug Fixes" },
+  { message = "^perf",     group = "Performance" },
+  { message = "^docs",     group = "Documentation" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^test",     group = "Tests" },
+  { message = "^chore",    group = "Chores" },
+  { message = "^ci",       group = "CI" },
+]
+filter_commits = false
+tag_pattern    = "v[0-9].*"

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,256 @@
+# Maintainer Onboarding Guide
+
+Welcome to the SorobanAnchor / AnchorKit project. This guide covers everything
+a new maintainer needs to get oriented, set up locally, and start contributing
+effectively without stepping on anything important.
+
+---
+
+## Table of Contents
+
+1. [Repo overview](#1-repo-overview)
+2. [Prerequisites](#2-prerequisites)
+3. [Local setup](#3-local-setup)
+4. [Key concepts](#4-key-concepts)
+5. [Day-to-day workflows](#5-day-to-day-workflows)
+6. [Review and merge checklist](#6-review-and-merge-checklist)
+7. [Release process](#7-release-process)
+8. [Admin key access](#8-admin-key-access)
+9. [Escalation and contacts](#9-escalation-and-contacts)
+
+---
+
+## 1  Repo overview
+
+```
+src/           Core library — contract, SEP handlers, utilities
+tests/         Integration and unit tests
+configs/       Example anchor configs (JSON + TOML)
+examples/      Rust and shell usage examples
+scripts/       Build, validation, CI, and deploy scripts
+docs/          All project documentation (start here)
+benches/       Criterion benchmarks
+fuzz/          Fuzz targets
+```
+
+The on-chain entry point is `src/contract.rs`. The public Rust API surface is
+exposed through `src/lib.rs`. All stable error codes live in `src/errors.rs`
+and are documented in [`docs/error-codes.md`](error-codes.md).
+
+---
+
+## 2  Prerequisites
+
+| Tool | Version | Why |
+|------|---------|-----|
+| Rust | 1.75+ | Build and test |
+| `wasm32-unknown-unknown` target | — | WASM build |
+| Python | 3.7+ | Config validation scripts |
+| `soroban-cli` | latest | Contract deployment |
+| Binaryen (`wasm-opt`) | optional | WASM size optimization |
+| GPG or minisign | optional | Release signing |
+
+Install the WASM target:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+---
+
+## 3  Local setup
+
+```bash
+# Clone
+git clone https://github.com/abore9769/SorobanAnchor.git
+cd SorobanAnchor
+
+# Install the pre-commit hook (runs fmt + clippy + test before each commit)
+./scripts/setup-hooks.sh
+
+# Verify everything builds and tests pass
+make check
+```
+
+`make check` runs formatting, clippy, and the full test suite. It should be
+green on a clean checkout. If it isn't, open an issue before doing anything
+else.
+
+### Environment variables
+
+For testnet work:
+
+```bash
+export SOROBAN_NETWORK=testnet
+export SOROBAN_RPC_URL=https://soroban-testnet.stellar.org:443
+export SOROBAN_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+export ANCHOR_ADMIN_SECRET=<your-testnet-admin-key>
+```
+
+Never commit keys. The `.gitignore` already excludes `*.secret`, `*.key`,
+`.env`, and `secrets/`.
+
+---
+
+## 4  Key concepts
+
+### Build modes
+
+The project compiles in two distinct modes with completely separate feature sets:
+
+| Mode | Command | Output | Has CLI |
+|------|---------|--------|---------|
+| Native | `cargo build --release` | `target/release/anchorkit` | Yes |
+| WASM (Soroban) | `cargo build --release --target wasm32-unknown-unknown --no-default-features --features wasm` | `*.wasm` | No |
+
+Always test both before touching anything in `src/contract.rs` or `src/lib.rs`.
+
+### Feature flags
+
+| Flag | Purpose |
+|------|---------|
+| `std` | Filesystem config loading (default on) |
+| `wasm` | Soroban WASM target — strips HTTP/CLI modules |
+| `mock-only` | Pre-built fixtures for tests without a live anchor |
+| `stress-tests` | High-concurrency load tests (excluded from normal CI) |
+
+### Error codes
+
+All contract errors are stable integer codes defined in `src/errors.rs` and
+listed in [`docs/error-codes.md`](error-codes.md). Do not renumber existing
+codes — add new ones at the end only.
+
+### Schema versioning
+
+The on-chain data schema is versioned. Every data-shape change needs a
+migration step in `src/migration.rs`. See
+[`docs/migration-guide.md`](migration-guide.md) for the full process.
+
+### Admin model
+
+The contract has a primary admin (set at `initialize`) plus a capability
+delegation system. Capability codes and grant/revoke procedures are documented
+in [`docs/RUNBOOK.md`](RUNBOOK.md#admin-capability-management).
+
+---
+
+## 5  Day-to-day workflows
+
+### Making a change
+
+```bash
+git checkout -b feat/short-description
+# ... edit ...
+make check          # must be green before committing
+git add <files>
+git commit -m "feat(scope): description"
+git push -u origin feat/short-description
+# open a PR
+```
+
+Follow [conventional commits](https://www.conventionalcommits.org/):
+`feat`, `fix`, `docs`, `refactor`, `test`, `chore`.
+
+### Running tests
+
+```bash
+cargo test                              # standard suite
+cargo test --features mock-only         # with mock fixtures
+cargo test --test cli_integration_harness  # integration harness
+cargo test --features stress-tests      # load tests (slow)
+```
+
+### Config validation
+
+```bash
+./scripts/validate_all.sh       # validates all configs in configs/
+./scripts/pre_deploy_validate.sh  # full pre-deploy check
+```
+
+### API contract snapshots
+
+To capture and compare the public API surface across versions, see
+[`docs/api-contract-snapshots.md`](api-contract-snapshots.md).
+
+### Generating a changelog
+
+Changelog entries are generated from conventional commit history. See
+[`docs/changelog-generation.md`](changelog-generation.md).
+
+---
+
+## 6  Review and merge checklist
+
+Before merging any PR:
+
+- [ ] `make check` passes (fmt + clippy + tests)
+- [ ] Both native and WASM builds succeed
+- [ ] New public API items have doc comments
+- [ ] Error codes are not renumbered
+- [ ] Config schema updated if new fields added
+- [ ] Migration step added for any on-chain data shape change
+- [ ] Security review completed for auth / crypto / HTTP changes
+  (see [`docs/SECURITY_REVIEW_CHECKLIST.md`](SECURITY_REVIEW_CHECKLIST.md))
+
+Routine changes need **one** maintainer approval. Breaking changes, contract
+upgrades, or security model changes need **two** approvals and a 48-hour window.
+Full policy: [`docs/governance-and-security.md`](governance-and-security.md).
+
+---
+
+## 7  Release process
+
+```bash
+make release           # build native + WASM + bundle under dist/
+make release-validate  # verify bundle contents and checksums
+make release-sign      # sign artifacts (requires GPG key)
+```
+
+Tag the release:
+
+```bash
+git tag -s v0.x.0 -m "Release v0.x.0"
+git push origin v0.x.0
+```
+
+Full release runbook: [`docs/RUNBOOK.md`](RUNBOOK.md).
+Signing and verification: [`docs/release-signing.md`](release-signing.md).
+
+---
+
+## 8  Admin key access
+
+- Testnet keys: ask an existing maintainer; rotated after each major release.
+- Mainnet keys: stored on offline hardware wallets with 2-of-N multi-sig.
+  No single person holds all signing keys.
+- Key operations follow the same two-maintainer approval process as contract
+  upgrades.
+
+If you need mainnet key access, open a governance discussion in the repository
+before any key-sharing happens.
+
+---
+
+## 9  Escalation and contacts
+
+- **Bugs / feature requests** — open a GitHub issue.
+- **Security vulnerabilities** — do not open a public issue; use GitHub's
+  private advisory reporting at
+  `https://github.com/abore9769/SorobanAnchor/security/advisories/new`.
+  See [`docs/governance-and-security.md`](governance-and-security.md#responsible-disclosure).
+- **PR review requests** — tag `@maintainers` in the PR.
+- **Urgent production issues** — contact the on-call maintainer directly via
+  the contact method shared in the private maintainer channel.
+
+---
+
+## References
+
+- [README.md](../README.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [RUNBOOK.md](RUNBOOK.md)
+- [governance-and-security.md](governance-and-security.md)
+- [error-codes.md](error-codes.md)
+- [migration-guide.md](migration-guide.md)
+- [api-contract-snapshots.md](api-contract-snapshots.md)
+- [changelog-generation.md](changelog-generation.md)

--- a/docs/api-contract-snapshots.md
+++ b/docs/api-contract-snapshots.md
@@ -1,0 +1,223 @@
+# API Contract Snapshots
+
+API contract snapshots capture the public surface of AnchorKit at a point in
+time so that regressions — removed functions, changed signatures, altered error
+codes — are caught before a release ships.
+
+---
+
+## Table of Contents
+
+1. [What a snapshot contains](#1-what-a-snapshot-contains)
+2. [Generating a snapshot](#2-generating-a-snapshot)
+3. [Comparing snapshots](#3-comparing-snapshots)
+4. [Snapshot storage convention](#4-snapshot-storage-convention)
+5. [CI integration](#5-ci-integration)
+6. [What counts as a breaking change](#6-what-counts-as-a-breaking-change)
+
+---
+
+## 1  What a snapshot contains
+
+A snapshot is a plain-text file produced by `cargo rustdoc --output-format json`
+(rustdoc JSON) trimmed to the public API surface. It records:
+
+- All `pub` functions, their signatures, and doc comments
+- All `pub` types (structs, enums, type aliases) and their fields/variants
+- All `pub` trait definitions and their required methods
+- All stable error codes from `src/errors.rs`
+- The `supported_seps` list from `src/contract.rs`
+
+It intentionally excludes private items, test modules, and build metadata.
+
+---
+
+## 2  Generating a snapshot
+
+### Prerequisites
+
+```bash
+# rustdoc JSON output requires nightly for the --output-format json flag
+rustup install nightly
+rustup component add rust-docs --toolchain nightly
+```
+
+### Generate
+
+```bash
+# From the repo root
+cargo +nightly rustdoc --lib -- \
+    -Z unstable-options \
+    --output-format json \
+    --document-private-items=false
+
+# The JSON lands at:
+#   target/doc/anchorkit.json
+```
+
+Then extract just the stable public surface into the snapshot format:
+
+```bash
+./scripts/snapshot_api.sh
+# Writes: api_snapshots/anchorkit-<VERSION>.json
+```
+
+`scripts/snapshot_api.sh` calls `rustdoc` as above, then uses `jq` to strip
+internal implementation details and write a deterministic, sorted JSON file
+under `api_snapshots/`.
+
+### Snapshot script (snapshot_api.sh)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+OUT="api_snapshots/anchorkit-${VERSION}.json"
+
+mkdir -p api_snapshots
+
+cargo +nightly rustdoc --lib -- \
+    -Z unstable-options \
+    --output-format json \
+    --document-private-items=false 2>/dev/null
+
+# Extract public surface: functions, types, traits — sorted for stable diffs
+jq '
+  .index
+  | to_entries
+  | map(select(.value.visibility == "public"))
+  | map({
+      id:   .key,
+      name: .value.name,
+      kind: .value.kind,
+      docs: .value.docs
+    })
+  | sort_by(.name)
+' target/doc/anchorkit.json > "$OUT"
+
+echo "Snapshot written to $OUT"
+```
+
+---
+
+## 3  Comparing snapshots
+
+To diff two snapshots side by side:
+
+```bash
+# Compare current version against the previous release
+./scripts/diff_api_snapshot.sh api_snapshots/anchorkit-0.1.0.json \
+                                api_snapshots/anchorkit-0.2.0.json
+```
+
+Or compare the working tree against a tagged release:
+
+```bash
+# Generate a snapshot for the current working tree
+./scripts/snapshot_api.sh
+
+# Diff against the last tagged snapshot
+PREV=$(ls api_snapshots/ | sort -V | tail -2 | head -1)
+CURR=$(ls api_snapshots/ | sort -V | tail -1)
+./scripts/diff_api_snapshot.sh "api_snapshots/$PREV" "api_snapshots/$CURR"
+```
+
+The diff script highlights:
+
+| Symbol | Meaning |
+|--------|---------|
+| `+` | New public item (additive — not breaking) |
+| `-` | Removed public item (breaking) |
+| `~` | Changed signature or doc (potentially breaking) |
+
+### Diff script (diff_api_snapshot.sh)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+OLD=$1
+NEW=$2
+
+echo "=== Removed or changed items (potentially breaking) ==="
+diff <(jq -r '.[].name' "$OLD" | sort) \
+     <(jq -r '.[].name' "$NEW" | sort) \
+  | grep '^<' | sed 's/^< /  - /'
+
+echo ""
+echo "=== Added items ==="
+diff <(jq -r '.[].name' "$OLD" | sort) \
+     <(jq -r '.[].name' "$NEW" | sort) \
+  | grep '^>' | sed 's/^> /  + /'
+```
+
+---
+
+## 4  Snapshot storage convention
+
+```
+api_snapshots/
+  anchorkit-0.1.0.json    # snapshot for each tagged release
+  anchorkit-0.2.0.json
+  ...
+```
+
+- One file per release tag, named `anchorkit-<VERSION>.json`.
+- Committed to the repository so historical comparisons work without fetching
+  old tags.
+- The snapshot for the current development HEAD is not committed; it is
+  generated on demand or in CI.
+
+---
+
+## 5  CI integration
+
+Add a step to the CI workflow to catch API regressions on every PR against
+`main`:
+
+```yaml
+# .github/workflows/ci.yml  — api-snapshot job
+- name: Generate API snapshot
+  run: bash scripts/snapshot_api.sh
+
+- name: Compare against baseline
+  run: |
+    BASELINE=$(ls api_snapshots/ | sort -V | tail -1)
+    CURRENT=api_snapshots/anchorkit-current.json
+    bash scripts/snapshot_api.sh
+    mv api_snapshots/anchorkit-$(grep '^version' Cargo.toml | \
+        head -1 | sed 's/.*= *"\(.*\)"/\1/').json "$CURRENT"
+    bash scripts/diff_api_snapshot.sh "api_snapshots/$BASELINE" "$CURRENT"
+```
+
+The job passes as long as no public items are removed or have their signatures
+changed. Additive changes always pass.
+
+---
+
+## 6  What counts as a breaking change
+
+| Change | Breaking |
+|--------|---------|
+| Removing a `pub` function or type | Yes |
+| Changing a function signature (parameters, return type) | Yes |
+| Renumbering an error code in `errors.rs` | Yes |
+| Adding a required field to a `pub` struct | Yes |
+| Adding a new `pub` function or type | No |
+| Adding an optional/defaulted field | No |
+| Changing doc comments only | No |
+| Adding a new error code at the end | No |
+
+Breaking changes require two maintainer approvals and must be noted in the
+changelog under a `### Breaking Changes` heading.
+
+---
+
+## References
+
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [governance-and-security.md](governance-and-security.md)
+- [error-codes.md](error-codes.md)
+- [changelog-generation.md](changelog-generation.md)
+- [ONBOARDING.md](ONBOARDING.md)

--- a/docs/changelog-generation.md
+++ b/docs/changelog-generation.md
@@ -1,0 +1,255 @@
+# Changelog Generation
+
+AnchorKit uses structured (conventional) commits so that release notes can be
+generated automatically from repository activity rather than written by hand.
+
+---
+
+## Table of Contents
+
+1. [Commit message format](#1-commit-message-format)
+2. [Generating a changelog](#2-generating-a-changelog)
+3. [Changelog format](#3-changelog-format)
+4. [CI integration](#4-ci-integration)
+5. [Manual editing](#5-manual-editing)
+6. [Tooling options](#6-tooling-options)
+
+---
+
+## 1  Commit message format
+
+All commits must follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <subject>
+
+<body>        # optional
+
+<footer>      # optional — "Closes #N", "BREAKING CHANGE: ..."
+```
+
+### Types
+
+| Type | Changelog section |
+|------|------------------|
+| `feat` | Features |
+| `fix` | Bug Fixes |
+| `perf` | Performance |
+| `docs` | Documentation |
+| `refactor` | Refactoring |
+| `test` | Tests |
+| `chore` | Chores / maintenance |
+| `ci` | CI / build |
+
+Commits with `BREAKING CHANGE:` in the footer (or a `!` after the type, e.g.
+`feat!`) appear in a separate **Breaking Changes** section regardless of type.
+
+### Scope examples
+
+`contract`, `sep6`, `sep10`, `sep38`, `rate-limiter`, `config`, `cli`, `docs`
+
+### Examples
+
+```
+feat(sep38): add firm quote expiry validation
+
+Closes #601
+
+fix(rate-limiter): prevent zero-value config from being accepted
+
+BREAKING CHANGE: set_rate_limit_config now rejects zero window_secs
+
+chore(deps): bump soroban-sdk to 21.0.0
+```
+
+---
+
+## 2  Generating a changelog
+
+### Using git-cliff (recommended)
+
+[git-cliff](https://git-cliff.org/) reads conventional commits and produces a
+`CHANGELOG.md` without any external service.
+
+#### Install
+
+```bash
+cargo install git-cliff
+```
+
+#### Generate for the next release
+
+```bash
+# All unreleased commits since the last tag
+git cliff --unreleased --tag v0.2.0 --output CHANGELOG.md
+```
+
+#### Prepend to an existing CHANGELOG.md
+
+```bash
+git cliff --unreleased --tag v0.2.0 --prepend CHANGELOG.md
+```
+
+#### Full history from the beginning
+
+```bash
+git cliff --output CHANGELOG.md
+```
+
+### Using the helper script
+
+```bash
+# Generate changelog for the next version (reads version from Cargo.toml)
+./scripts/generate_changelog.sh
+
+# Specify a version explicitly
+./scripts/generate_changelog.sh v0.2.0
+
+# Preview without writing to file
+./scripts/generate_changelog.sh --dry-run
+```
+
+The script wraps `git-cliff` and applies the project's `cliff.toml`
+configuration (see below).
+
+---
+
+## 3  Changelog format
+
+`CHANGELOG.md` is kept in the repo root. Each release section looks like:
+
+```markdown
+## [0.2.0] - 2026-07-29
+
+### Breaking Changes
+
+- **rate-limiter:** set_rate_limit_config now rejects zero window_secs (#612)
+
+### Features
+
+- **sep38:** add firm quote expiry validation (#601)
+- **cli:** add --dry-run flag to deploy command (#598)
+
+### Bug Fixes
+
+- **rate-limiter:** prevent zero-value config from being accepted (#612)
+
+### Documentation
+
+- add changelog generation guide (#689)
+- add API contract snapshot guide (#688)
+- add maintainer onboarding guide (#691)
+```
+
+---
+
+## 4  CI integration
+
+Add a step to generate and validate the changelog on every PR targeting `main`:
+
+```yaml
+# .github/workflows/ci.yml  — changelog job
+- name: Validate commit messages
+  uses: wagoid/commitlint-github-action@v5
+  with:
+    configFile: commitlint.config.js
+
+- name: Preview changelog
+  run: |
+    cargo install git-cliff --quiet
+    git cliff --unreleased --tag $(grep '^version' Cargo.toml | \
+        head -1 | sed 's/.*= *"\(.*\)"/v\1/') 2>&1
+```
+
+For release tags, commit the generated changelog back to the release branch:
+
+```yaml
+- name: Generate changelog for release
+  if: startsWith(github.ref, 'refs/tags/v')
+  run: |
+    cargo install git-cliff --quiet
+    git cliff --unreleased --tag ${{ github.ref_name }} \
+        --prepend CHANGELOG.md
+    git config user.name  "github-actions[bot]"
+    git config user.email "github-actions[bot]@users.noreply.github.com"
+    git add CHANGELOG.md
+    git commit -m "chore(release): update changelog for ${{ github.ref_name }}"
+    git push
+```
+
+---
+
+## 5  Manual editing
+
+Auto-generated changelogs are a starting point, not the final word. Before
+tagging a release, review `CHANGELOG.md` and:
+
+- Rewrite cryptic commit subjects into user-facing language.
+- Group related fixes under a single entry when several commits address one
+  issue.
+- Add upgrade notes for breaking changes that need migration steps.
+- Link to relevant docs, PRs, or issues where helpful.
+
+Keep manual edits minimal — the goal is a readable summary, not a rewrite.
+
+---
+
+## 6  Tooling options
+
+| Tool | Notes |
+|------|-------|
+| [git-cliff](https://git-cliff.org/) | Rust-native, configurable via `cliff.toml`, recommended |
+| [conventional-changelog-cli](https://github.com/conventional-changelog/conventional-changelog) | Node.js, widely used, more plugins |
+| [release-please](https://github.com/googleapis/release-please) | GitHub Action, automates PR + tag + changelog |
+| Manual | Always an option; use the format in [§3](#3-changelog-format) |
+
+### cliff.toml (project config)
+
+Place this file at the repo root to configure git-cliff's output:
+
+```toml
+[changelog]
+header = "# Changelog\n\n"
+body   = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message }} \
+(#{{ commit.id | truncate(length=7, end="") }})
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits    = true
+filter_unconventional   = true
+split_commits           = false
+commit_parsers = [
+  { message = "^feat",     group = "Features" },
+  { message = "^fix",      group = "Bug Fixes" },
+  { message = "^perf",     group = "Performance" },
+  { message = "^docs",     group = "Documentation" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^test",     group = "Tests" },
+  { message = "^chore",    group = "Chores" },
+  { message = "^ci",       group = "CI" },
+]
+filter_commits = false
+tag_pattern    = "v[0-9].*"
+```
+
+---
+
+## References
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — commit message rules
+- [governance-and-security.md](governance-and-security.md) — release approval policy
+- [release-signing.md](release-signing.md) — signing artifacts after release
+- [api-contract-snapshots.md](api-contract-snapshots.md) — API regression detection
+- [ONBOARDING.md](ONBOARDING.md) — maintainer onboarding

--- a/scripts/diff_api_snapshot.sh
+++ b/scripts/diff_api_snapshot.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# diff_api_snapshot.sh — Compare two API contract snapshots.
+# Usage: ./scripts/diff_api_snapshot.sh <old.json> <new.json>
+#
+# Exit code 0 = no breaking changes detected
+# Exit code 1 = breaking changes detected (removed or changed items)
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <old-snapshot.json> <new-snapshot.json>" >&2
+  exit 2
+fi
+
+OLD=$1
+NEW=$2
+
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is required but not found in PATH." >&2
+  exit 2
+fi
+
+OLD_NAMES=$(jq -r '.[].name' "$OLD" | sort)
+NEW_NAMES=$(jq -r '.[].name' "$NEW" | sort)
+
+REMOVED=$(diff <(echo "$OLD_NAMES") <(echo "$NEW_NAMES") | grep '^<' | sed 's/^< //')
+ADDED=$(diff   <(echo "$OLD_NAMES") <(echo "$NEW_NAMES") | grep '^>' | sed 's/^> //')
+
+BREAKING=false
+
+echo "=== API diff: $(basename "$OLD") → $(basename "$NEW") ==="
+echo ""
+
+if [[ -n "$REMOVED" ]]; then
+  echo "### Removed items (BREAKING)"
+  while IFS= read -r name; do
+    echo "  - $name"
+  done <<< "$REMOVED"
+  BREAKING=true
+  echo ""
+fi
+
+if [[ -n "$ADDED" ]]; then
+  echo "### Added items (non-breaking)"
+  while IFS= read -r name; do
+    echo "  + $name"
+  done <<< "$ADDED"
+  echo ""
+fi
+
+if [[ "$REMOVED" == "" && "$ADDED" == "" ]]; then
+  echo "No public API surface changes detected."
+fi
+
+if $BREAKING; then
+  echo ""
+  echo "RESULT: Breaking changes detected. Two maintainer approvals required." >&2
+  exit 1
+else
+  echo "RESULT: No breaking changes."
+  exit 0
+fi

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# generate_changelog.sh — Generate or preview CHANGELOG.md from conventional commits.
+# Usage: ./scripts/generate_changelog.sh [<tag>] [--dry-run] [--prepend]
+#
+# Requires: git-cliff  (install: cargo install git-cliff)
+# Output:   CHANGELOG.md (repo root) unless --dry-run is passed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DRY_RUN=false
+PREPEND=false
+TAG=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --prepend) PREPEND=true ;;
+    v*)        TAG="$arg" ;;
+    [0-9]*)    TAG="v$arg" ;;
+  esac
+done
+
+# Default tag from Cargo.toml version
+if [[ -z "$TAG" ]]; then
+  VERSION=$(grep '^version' "$ROOT/Cargo.toml" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+  TAG="v${VERSION}"
+fi
+
+if ! command -v git-cliff &>/dev/null; then
+  echo "ERROR: git-cliff is not installed." >&2
+  echo "  Install with: cargo install git-cliff" >&2
+  exit 1
+fi
+
+echo "Generating changelog for $TAG..."
+
+if $DRY_RUN; then
+  git -C "$ROOT" cliff --unreleased --tag "$TAG"
+  exit 0
+fi
+
+if $PREPEND; then
+  git -C "$ROOT" cliff --unreleased --tag "$TAG" --prepend "$ROOT/CHANGELOG.md"
+  echo "Changelog prepended to CHANGELOG.md"
+else
+  git -C "$ROOT" cliff --unreleased --tag "$TAG" --output "$ROOT/CHANGELOG.md"
+  echo "CHANGELOG.md written."
+fi

--- a/scripts/snapshot_api.sh
+++ b/scripts/snapshot_api.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# snapshot_api.sh — Generate a public API surface snapshot for AnchorKit.
+# Usage: ./scripts/snapshot_api.sh [--dry-run]
+#
+# Requires: cargo (nightly toolchain), jq
+# Output:   api_snapshots/anchorkit-<VERSION>.json
+
+set -euo pipefail
+
+DRY_RUN=false
+for arg in "$@"; do
+  [[ "$arg" == "--dry-run" ]] && DRY_RUN=true
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VERSION=$(grep '^version' "$ROOT/Cargo.toml" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+OUT_DIR="$ROOT/api_snapshots"
+OUT_FILE="$OUT_DIR/anchorkit-${VERSION}.json"
+
+if $DRY_RUN; then
+  echo "[dry-run] Would generate snapshot: $OUT_FILE"
+  exit 0
+fi
+
+# Require jq
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is required but not found in PATH." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+echo "Building rustdoc JSON for v${VERSION}..."
+cargo +nightly rustdoc --lib \
+    --manifest-path "$ROOT/Cargo.toml" \
+    -- \
+    -Z unstable-options \
+    --output-format json \
+    --document-private-items=false 2>/dev/null
+
+DOC_JSON="$ROOT/target/doc/anchorkit.json"
+
+if [[ ! -f "$DOC_JSON" ]]; then
+  echo "ERROR: rustdoc JSON output not found at $DOC_JSON" >&2
+  exit 1
+fi
+
+echo "Extracting public API surface..."
+jq '
+  .index
+  | to_entries
+  | map(select(.value.visibility == "public"))
+  | map({
+      id:   .key,
+      name: .value.name,
+      kind: .value.kind,
+      docs: (.value.docs // "")
+    })
+  | sort_by(.name)
+' "$DOC_JSON" > "$OUT_FILE"
+
+echo "Snapshot written to $OUT_FILE"
+echo "  Items captured: $(jq length "$OUT_FILE")"


### PR DESCRIPTION
- docs/ONBOARDING.md: practical onboarding guide for new maintainers covering repo layout, prerequisites, local setup, key concepts, day-to-day workflows, review checklist, release process, and admin key access (#691)

- docs/api-contract-snapshots.md: guide for capturing and diffing the public API surface across releases to detect regressions (#688)
- scripts/snapshot_api.sh: generate rustdoc JSON API snapshot
- scripts/diff_api_snapshot.sh: compare two snapshots and exit non-zero on breaking changes
- api_snapshots/.gitkeep: snapshot storage directory

- docs/changelog-generation.md: guide for generating changelogs from conventional commits using git-cliff (#689)
- scripts/generate_changelog.sh: wrapper script for git-cliff
- cliff.toml: project-level git-cliff configuration

Closes #688
Closes #689
Closes #691