### PR TITLE
feat: request deduplication, retry budgets, distributed correlation, …

### DIFF
--- a/src/distributed_correlation.rs
+++ b/src/distributed_correlation.rs
@@ -1,0 +1,457 @@
+//! Distributed request correlation (#684).
+//!
+//! In multi-process deployments a single logical request can flow through
+//! several components (HTTP gateway → anchor service → Soroban node →
+//! webhook dispatcher). Without a shared identifier, correlating log lines
+//! from all those components is extremely difficult.
+//!
+//! This module extends the existing [`TraceContext`] with a
+//! [`CorrelationContext`] that bundles a W3C-compatible `trace_id` with
+//! additional propagation metadata (originating service, hop count, custom
+//! baggage) so all components can tag their logs with the same root
+//! correlation identifier.
+//!
+//! # Wire format
+//!
+//! Correlation metadata is propagated via HTTP headers:
+//!
+//! | Header | Content |
+//! |--------|---------|
+//! | `X-Correlation-Id` | Root correlation ID (32 hex chars, stable across the entire request tree) |
+//! | `X-Origin-Service` | Name of the service that originated this request |
+//! | `X-Hop-Count` | Number of service hops so far (decimal integer) |
+//! | `X-Baggage` | Optional key=value pairs separated by `,` |
+//!
+//! # Relationship to `TraceContext`
+//!
+//! [`TraceContext`] (`traceparent` / W3C Trace Context) handles span-level
+//! tracing within a single request. [`CorrelationContext`] carries the
+//! higher-level correlation ID that ties together multiple microservice
+//! invocations and their individual traces. They are complementary: a
+//! correlation header suite (`X-Correlation-Id`) can be attached alongside
+//! `traceparent` headers in the same outbound request.
+//!
+//! # Example
+//!
+//! ```rust
+//! use anchorkit::distributed_correlation::CorrelationContext;
+//!
+//! // Originating service stamps the first context.
+//! let ctx = CorrelationContext::new("gateway", "txn-001");
+//! assert_eq!(ctx.hop_count(), 0);
+//!
+//! // Downstream service receives and propagates.
+//! let headers = ctx.to_headers();
+//! let downstream = CorrelationContext::from_headers(&headers).unwrap();
+//! let next = downstream.next_hop("anchor-service");
+//!
+//! assert_eq!(next.correlation_id(), ctx.correlation_id());
+//! assert_eq!(next.hop_count(), 1);
+//! assert_eq!(next.origin_service(), "gateway");
+//! ```
+
+extern crate alloc;
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use alloc::format;
+use alloc::collections::BTreeMap;
+
+// ---------------------------------------------------------------------------
+// Header name constants
+// ---------------------------------------------------------------------------
+
+/// `X-Correlation-Id` header name.
+pub const CORRELATION_ID_HEADER: &str = "X-Correlation-Id";
+/// `X-Origin-Service` header name.
+pub const ORIGIN_SERVICE_HEADER: &str = "X-Origin-Service";
+/// `X-Hop-Count` header name.
+pub const HOP_COUNT_HEADER: &str = "X-Hop-Count";
+/// `X-Baggage` header name.
+pub const BAGGAGE_HEADER: &str = "X-Baggage";
+
+// ---------------------------------------------------------------------------
+// CorrelationError
+// ---------------------------------------------------------------------------
+
+/// Errors that can arise when parsing a [`CorrelationContext`] from headers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CorrelationError {
+    /// The `X-Correlation-Id` header was missing.
+    MissingCorrelationId,
+    /// The `X-Correlation-Id` value was not a valid 32-char lowercase hex string.
+    InvalidCorrelationId(String),
+    /// The `X-Hop-Count` value could not be parsed as an integer.
+    InvalidHopCount(String),
+}
+
+impl core::fmt::Display for CorrelationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            CorrelationError::MissingCorrelationId => {
+                write!(f, "missing X-Correlation-Id header")
+            }
+            CorrelationError::InvalidCorrelationId(v) => {
+                write!(f, "invalid X-Correlation-Id value: '{v}'")
+            }
+            CorrelationError::InvalidHopCount(v) => {
+                write!(f, "invalid X-Hop-Count value: '{v}'")
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CorrelationContext
+// ---------------------------------------------------------------------------
+
+/// Distributed request correlation context.
+///
+/// Carries a stable root correlation ID plus metadata that allows every
+/// service hop to tag its logs with the same identifier.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CorrelationContext {
+    /// Stable root correlation ID (32 lowercase hex chars).
+    correlation_id: String,
+    /// Name of the service that originated the request.
+    origin_service: String,
+    /// Current service's own name (changes at each hop).
+    current_service: String,
+    /// Number of service hops since origination (0 = this is the originator).
+    hop_count: u32,
+    /// Optional key=value baggage entries propagated downstream.
+    baggage: BTreeMap<String, String>,
+}
+
+impl CorrelationContext {
+    /// Create a new root correlation context for `originating_service`.
+    ///
+    /// The correlation ID is derived deterministically from `seed` (typically
+    /// a transaction ID or idempotency key) so the same seed always produces
+    /// the same ID, making tests deterministic.
+    pub fn new(originating_service: impl Into<String>, seed: &str) -> Self {
+        let id = derive_correlation_id(seed);
+        let svc = originating_service.into();
+        CorrelationContext {
+            correlation_id: id,
+            origin_service: svc.clone(),
+            current_service: svc,
+            hop_count: 0,
+            baggage: BTreeMap::new(),
+        }
+    }
+
+    /// Create a context with a caller-supplied correlation ID (e.g. when
+    /// forwarding an ID generated by an external gateway).
+    ///
+    /// Returns [`CorrelationError::InvalidCorrelationId`] when `id` is not a
+    /// 32-char lowercase hex string.
+    pub fn with_id(
+        originating_service: impl Into<String>,
+        id: impl Into<String>,
+    ) -> Result<Self, CorrelationError> {
+        let id = id.into();
+        validate_correlation_id(&id)?;
+        let svc = originating_service.into();
+        Ok(CorrelationContext {
+            correlation_id: id,
+            origin_service: svc.clone(),
+            current_service: svc,
+            hop_count: 0,
+            baggage: BTreeMap::new(),
+        })
+    }
+
+    // ── Accessors ──────────────────────────────────────────────────────────
+
+    /// The stable root correlation ID (32 lowercase hex chars).
+    pub fn correlation_id(&self) -> &str {
+        &self.correlation_id
+    }
+
+    /// The service that originated this request.
+    pub fn origin_service(&self) -> &str {
+        &self.origin_service
+    }
+
+    /// The current service's name at this hop.
+    pub fn current_service(&self) -> &str {
+        &self.current_service
+    }
+
+    /// Number of service hops since origination.
+    pub fn hop_count(&self) -> u32 {
+        self.hop_count
+    }
+
+    /// Retrieve a baggage value by key.
+    pub fn baggage(&self, key: &str) -> Option<&str> {
+        self.baggage.get(key).map(String::as_str)
+    }
+
+    // ── Mutation ───────────────────────────────────────────────────────────
+
+    /// Add or overwrite a baggage entry.
+    pub fn set_baggage(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.baggage.insert(key.into(), value.into());
+        self
+    }
+
+    // ── Propagation ───────────────────────────────────────────────────────
+
+    /// Produce a new [`CorrelationContext`] for the next downstream service.
+    ///
+    /// The correlation ID and origin service are preserved; `current_service`
+    /// is updated to `next_service` and `hop_count` is incremented.
+    pub fn next_hop(&self, next_service: impl Into<String>) -> Self {
+        CorrelationContext {
+            correlation_id: self.correlation_id.clone(),
+            origin_service: self.origin_service.clone(),
+            current_service: next_service.into(),
+            hop_count: self.hop_count.saturating_add(1),
+            baggage: self.baggage.clone(),
+        }
+    }
+
+    // ── Header serialisation ───────────────────────────────────────────────
+
+    /// Serialize this context to a list of `(header_name, header_value)` pairs
+    /// suitable for attaching to an outbound HTTP request.
+    pub fn to_headers(&self) -> Vec<(String, String)> {
+        let mut headers = Vec::new();
+        headers.push((CORRELATION_ID_HEADER.to_string(), self.correlation_id.clone()));
+        headers.push((ORIGIN_SERVICE_HEADER.to_string(), self.origin_service.clone()));
+        headers.push((HOP_COUNT_HEADER.to_string(), self.hop_count.to_string()));
+        if !self.baggage.is_empty() {
+            let baggage_str = self
+                .baggage
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<_>>()
+                .join(",");
+            headers.push((BAGGAGE_HEADER.to_string(), baggage_str));
+        }
+        headers
+    }
+
+    /// Deserialize a [`CorrelationContext`] from a slice of
+    /// `(header_name, header_value)` pairs.
+    ///
+    /// The `current_service` defaults to the origin service on ingress; callers
+    /// should call [`next_hop`](Self::next_hop) to stamp their own service name.
+    pub fn from_headers(headers: &[(String, String)]) -> Result<Self, CorrelationError> {
+        let mut correlation_id: Option<String> = None;
+        let mut origin_service: Option<String> = None;
+        let mut hop_count: u32 = 0;
+        let mut baggage: BTreeMap<String, String> = BTreeMap::new();
+
+        for (name, value) in headers {
+            let n = name.as_str();
+            if n.eq_ignore_ascii_case(CORRELATION_ID_HEADER) {
+                correlation_id = Some(value.clone());
+            } else if n.eq_ignore_ascii_case(ORIGIN_SERVICE_HEADER) {
+                origin_service = Some(value.clone());
+            } else if n.eq_ignore_ascii_case(HOP_COUNT_HEADER) {
+                hop_count = value.parse::<u32>().map_err(|_| {
+                    CorrelationError::InvalidHopCount(value.clone())
+                })?;
+            } else if n.eq_ignore_ascii_case(BAGGAGE_HEADER) {
+                for pair in value.split(',') {
+                    let pair = pair.trim();
+                    if let Some(pos) = pair.find('=') {
+                        let k = pair[..pos].trim().to_string();
+                        let v = pair[pos + 1..].trim().to_string();
+                        if !k.is_empty() {
+                            baggage.insert(k, v);
+                        }
+                    }
+                }
+            }
+        }
+
+        let id = correlation_id.ok_or(CorrelationError::MissingCorrelationId)?;
+        validate_correlation_id(&id)?;
+        let origin = origin_service.unwrap_or_default();
+
+        Ok(CorrelationContext {
+            current_service: origin.clone(),
+            origin_service: origin,
+            correlation_id: id,
+            hop_count,
+            baggage,
+        })
+    }
+
+    /// Produce a log-friendly summary string.
+    ///
+    /// ```text
+    /// corr=<id> origin=<svc> hop=<n>
+    /// ```
+    pub fn log_fields(&self) -> String {
+        format!(
+            "corr={} origin={} current={} hop={}",
+            self.correlation_id, self.origin_service, self.current_service, self.hop_count
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/// Derive a 32-char lowercase hex correlation ID from an arbitrary seed string
+/// using SHA-256 (first 16 bytes).
+fn derive_correlation_id(seed: &str) -> String {
+    sha256_hex_16(seed.as_bytes())
+}
+
+/// SHA-256 of `data`, first 16 bytes as lowercase hex (= 32 chars).
+fn sha256_hex_16(data: &[u8]) -> String {
+    // Minimal SHA-256 using the same approach as trace_context.
+    // We rely on the `sha2` crate already present in Cargo.toml.
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(data);
+    let result = h.finalize();
+    result[..16]
+        .iter()
+        .fold(String::new(), |mut s, b| {
+            s.push(hex_nibble(b >> 4));
+            s.push(hex_nibble(b & 0x0f));
+            s
+        })
+}
+
+fn hex_nibble(v: u8) -> char {
+    match v {
+        0..=9 => (b'0' + v) as char,
+        _ => (b'a' + v - 10) as char,
+    }
+}
+
+/// Validate that `id` is exactly 32 lowercase hex characters.
+fn validate_correlation_id(id: &str) -> Result<(), CorrelationError> {
+    if id.len() != 32 || !id.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()) {
+        return Err(CorrelationError::InvalidCorrelationId(id.to_string()));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_produces_valid_correlation_id() {
+        let ctx = CorrelationContext::new("gateway", "txn-001");
+        assert_eq!(ctx.correlation_id().len(), 32);
+        assert!(ctx.correlation_id().bytes().all(|b| b.is_ascii_hexdigit()));
+        assert_eq!(ctx.hop_count(), 0);
+        assert_eq!(ctx.origin_service(), "gateway");
+    }
+
+    #[test]
+    fn same_seed_is_deterministic() {
+        let a = CorrelationContext::new("svc", "txn-001");
+        let b = CorrelationContext::new("svc", "txn-001");
+        assert_eq!(a.correlation_id(), b.correlation_id());
+    }
+
+    #[test]
+    fn different_seeds_differ() {
+        let a = CorrelationContext::new("svc", "txn-001");
+        let b = CorrelationContext::new("svc", "txn-002");
+        assert_ne!(a.correlation_id(), b.correlation_id());
+    }
+
+    #[test]
+    fn next_hop_preserves_correlation_id() {
+        let ctx = CorrelationContext::new("gateway", "txn-001");
+        let downstream = ctx.next_hop("anchor-service");
+        assert_eq!(downstream.correlation_id(), ctx.correlation_id());
+        assert_eq!(downstream.origin_service(), "gateway");
+        assert_eq!(downstream.current_service(), "anchor-service");
+        assert_eq!(downstream.hop_count(), 1);
+    }
+
+    #[test]
+    fn multi_hop_increments_count() {
+        let ctx = CorrelationContext::new("a", "seed");
+        let hop1 = ctx.next_hop("b");
+        let hop2 = hop1.next_hop("c");
+        let hop3 = hop2.next_hop("d");
+        assert_eq!(hop3.hop_count(), 3);
+        assert_eq!(hop3.correlation_id(), ctx.correlation_id());
+    }
+
+    #[test]
+    fn header_round_trip() {
+        let ctx = CorrelationContext::new("gateway", "txn-round-trip")
+            .set_baggage("env", "prod")
+            .set_baggage("region", "us-east-1");
+
+        let headers = ctx.to_headers();
+        let parsed = CorrelationContext::from_headers(&headers).unwrap();
+
+        assert_eq!(parsed.correlation_id(), ctx.correlation_id());
+        assert_eq!(parsed.origin_service(), ctx.origin_service());
+        assert_eq!(parsed.hop_count(), ctx.hop_count());
+        assert_eq!(parsed.baggage("env"), Some("prod"));
+        assert_eq!(parsed.baggage("region"), Some("us-east-1"));
+    }
+
+    #[test]
+    fn from_headers_missing_correlation_id() {
+        let headers = alloc::vec![
+            ("X-Origin-Service".to_string(), "svc".to_string()),
+        ];
+        assert_eq!(
+            CorrelationContext::from_headers(&headers),
+            Err(CorrelationError::MissingCorrelationId)
+        );
+    }
+
+    #[test]
+    fn from_headers_invalid_hop_count() {
+        let ctx = CorrelationContext::new("svc", "seed");
+        let mut headers = ctx.to_headers();
+        for (k, v) in headers.iter_mut() {
+            if k == HOP_COUNT_HEADER {
+                *v = "not-a-number".to_string();
+            }
+        }
+        assert!(matches!(
+            CorrelationContext::from_headers(&headers),
+            Err(CorrelationError::InvalidHopCount(_))
+        ));
+    }
+
+    #[test]
+    fn with_id_accepts_valid_id() {
+        let valid = "abcdef0123456789abcdef0123456789";
+        let ctx = CorrelationContext::with_id("svc", valid).unwrap();
+        assert_eq!(ctx.correlation_id(), valid);
+    }
+
+    #[test]
+    fn with_id_rejects_invalid_id() {
+        let bad = "too-short";
+        assert!(matches!(
+            CorrelationContext::with_id("svc", bad),
+            Err(CorrelationError::InvalidCorrelationId(_))
+        ));
+    }
+
+    #[test]
+    fn log_fields_format() {
+        let ctx = CorrelationContext::new("gateway", "txn-log");
+        let fields = ctx.log_fields();
+        assert!(fields.contains("corr="));
+        assert!(fields.contains("origin=gateway"));
+        assert!(fields.contains("hop=0"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,10 @@ pub mod rate_limiter;
 pub mod retry;
 pub mod trace_context;
 pub mod replay_detection;
+pub mod request_deduplication;
+pub mod retry_budget;
+pub mod distributed_correlation;
+pub mod request_provenance;
 pub mod transaction_state_tracker;
 pub mod contract;
 #[cfg(not(feature = "wasm"))]
@@ -194,6 +198,10 @@ pub use retry::{retry_with_backoff, is_retryable, RetryConfig, JitterSource, Led
 pub use retry::{BackoffStrategy, JitterPolicy};
 pub use retry::retry_with_backoff_traced;
 pub use trace_context::{TraceContext, TraceError, TRACEPARENT_HEADER, TRACE_ID_HEADER, SPAN_ID_HEADER};
+pub use request_deduplication::{DeduplicationStore, DeduplicationKey, DeduplicationResult, DeduplicationStats, execute_deduplicated};
+pub use retry_budget::{RetryBudget, RetryBudgetConfig, BudgetExhaustedError, execute_with_budget};
+pub use distributed_correlation::{CorrelationContext, CorrelationError, CORRELATION_ID_HEADER, ORIGIN_SERVICE_HEADER, HOP_COUNT_HEADER, BAGGAGE_HEADER};
+pub use request_provenance::{ProvenanceRecord, PROVENANCE_ID_HEADER, PARENT_ID_HEADER, DEPTH_HEADER, ORIGIN_HEADER, OPERATION_HEADER};
 pub use deterministic_hash::{compute_payload_hash, verify_payload_hash};
 pub use contract::{AnchorKitContract, AnchorTomlProvenance, EndpointUpdated, CacheConfig};
 pub use contract::{AttestorRevocationRecord};

--- a/src/request_deduplication.rs
+++ b/src/request_deduplication.rs
@@ -1,0 +1,375 @@
+//! Request deduplication for repeated operations (#681).
+//!
+//! Repeated submissions of the same logical request (e.g. a deposit initiation
+//! retried by a client after a network hiccup) can produce duplicate work and
+//! redundant side-effects. This module provides a lightweight deduplication
+//! layer that collapses identical requests into a single execution path by
+//! tracking a deduplicated key → cached result mapping.
+//!
+//! # Design
+//!
+//! * **Key-based deduplication.** A [`DeduplicationKey`] uniquely identifies a
+//!   logical operation. Keys are intentionally caller-constructed so the
+//!   deduplication policy is decoupled from transport concerns.
+//! * **Result caching.** The first execution of a key stores either the
+//!   success value or the error kind. Subsequent calls with the same key
+//!   receive the cached outcome without re-running the operation.
+//! * **TTL / expiry.** Each entry carries an expiry timestamp so stale
+//!   results are not served indefinitely. [`DeduplicationStore::purge_expired`]
+//!   cleans up entries older than their TTL.
+//! * **No `std` dependency.** Uses `alloc::collections::BTreeMap` so the
+//!   module can be compiled for `no_std` targets if needed.
+//!
+//! # Example
+//!
+//! ```rust
+//! use anchorkit::request_deduplication::{DeduplicationStore, DeduplicationKey, DeduplicationResult};
+//!
+//! let mut store = DeduplicationStore::new(300); // 5-minute TTL
+//! let key = DeduplicationKey::new("deposit", "txn-001");
+//!
+//! // First call — not deduplicated, run the operation.
+//! assert!(!store.is_duplicate(&key, 1_000));
+//! store.record_success(&key, "pending_external", 1_000);
+//!
+//! // Second call — deduplicated, returns cached outcome.
+//! assert!(store.is_duplicate(&key, 1_001));
+//! assert_eq!(
+//!     store.cached_result(&key, 1_001),
+//!     Some(DeduplicationResult::Success("pending_external".into())),
+//! );
+//! ```
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+
+// ---------------------------------------------------------------------------
+// DeduplicationKey
+// ---------------------------------------------------------------------------
+
+/// Uniquely identifies a logical operation for deduplication purposes.
+///
+/// Keys are composed of an `operation` tag (e.g. `"deposit"`) and a
+/// `request_id` (e.g. a transaction ID, idempotency key, or content hash).
+/// The combination must be stable across retries for deduplication to work.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DeduplicationKey {
+    /// Operation name, e.g. `"deposit"`, `"withdrawal"`, `"sep38_quote"`.
+    pub operation: String,
+    /// Stable identifier for this specific invocation of the operation.
+    pub request_id: String,
+}
+
+impl DeduplicationKey {
+    /// Construct a key from an operation name and a request identifier.
+    pub fn new(operation: impl Into<String>, request_id: impl Into<String>) -> Self {
+        DeduplicationKey {
+            operation: operation.into(),
+            request_id: request_id.into(),
+        }
+    }
+
+    /// Compact string representation used as an internal map key.
+    fn as_map_key(&self) -> String {
+        alloc::format!("{}:{}", self.operation, self.request_id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DeduplicationResult
+// ---------------------------------------------------------------------------
+
+/// The cached outcome of a previously executed operation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DeduplicationResult {
+    /// The operation completed successfully; the inner value is a short
+    /// string summary of the outcome (e.g. a status code or transaction ID).
+    Success(String),
+    /// The operation failed; the inner value is the error kind/message.
+    Failure(String),
+}
+
+// ---------------------------------------------------------------------------
+// DeduplicationEntry — internal
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct DeduplicationEntry {
+    result: DeduplicationResult,
+    /// Unix timestamp (seconds) after which this entry must not be served.
+    expires_at: u64,
+}
+
+// ---------------------------------------------------------------------------
+// DeduplicationStore
+// ---------------------------------------------------------------------------
+
+/// In-process store for deduplication entries.
+///
+/// Maps [`DeduplicationKey`]s to cached outcomes with per-entry TTLs. Entries
+/// expire after `default_ttl_secs` seconds from the time they are recorded;
+/// call [`purge_expired`](Self::purge_expired) periodically to reclaim memory.
+#[derive(Debug)]
+pub struct DeduplicationStore {
+    /// Default time-to-live in seconds for each entry.
+    default_ttl_secs: u64,
+    entries: BTreeMap<String, DeduplicationEntry>,
+}
+
+impl DeduplicationStore {
+    /// Create a new store with the given default TTL (seconds).
+    pub fn new(default_ttl_secs: u64) -> Self {
+        DeduplicationStore {
+            default_ttl_secs,
+            entries: BTreeMap::new(),
+        }
+    }
+
+    /// Return `true` when `key` maps to a non-expired entry.
+    ///
+    /// A `true` result means the operation has already been executed and the
+    /// caller should retrieve the cached result via [`cached_result`](Self::cached_result)
+    /// instead of re-running the operation.
+    pub fn is_duplicate(&self, key: &DeduplicationKey, now_secs: u64) -> bool {
+        match self.entries.get(&key.as_map_key()) {
+            Some(entry) => entry.expires_at > now_secs,
+            None => false,
+        }
+    }
+
+    /// Store a successful outcome for `key`.
+    pub fn record_success(&mut self, key: &DeduplicationKey, summary: impl Into<String>, now_secs: u64) {
+        self.entries.insert(
+            key.as_map_key(),
+            DeduplicationEntry {
+                result: DeduplicationResult::Success(summary.into()),
+                expires_at: now_secs.saturating_add(self.default_ttl_secs),
+            },
+        );
+    }
+
+    /// Store a failure outcome for `key`.
+    pub fn record_failure(&mut self, key: &DeduplicationKey, error: impl Into<String>, now_secs: u64) {
+        self.entries.insert(
+            key.as_map_key(),
+            DeduplicationEntry {
+                result: DeduplicationResult::Failure(error.into()),
+                expires_at: now_secs.saturating_add(self.default_ttl_secs),
+            },
+        );
+    }
+
+    /// Retrieve the cached [`DeduplicationResult`] for `key`, or `None` when
+    /// the key is unknown or its entry has expired.
+    pub fn cached_result(&self, key: &DeduplicationKey, now_secs: u64) -> Option<DeduplicationResult> {
+        self.entries.get(&key.as_map_key()).and_then(|entry| {
+            if entry.expires_at > now_secs {
+                Some(entry.result.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Remove all expired entries, returning the count of entries removed.
+    pub fn purge_expired(&mut self, now_secs: u64) -> usize {
+        let before = self.entries.len();
+        self.entries.retain(|_, v| v.expires_at > now_secs);
+        before - self.entries.len()
+    }
+
+    /// Total number of entries in the store (including expired ones not yet purged).
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// `true` when the store holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deduplication statistics
+// ---------------------------------------------------------------------------
+
+/// Accumulated statistics for a [`DeduplicationStore`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DeduplicationStats {
+    /// Number of calls that were recognised as duplicates (saved round-trips).
+    pub duplicate_hits: u64,
+    /// Number of novel operations that were recorded for the first time.
+    pub new_records: u64,
+    /// Number of expired entries removed by [`DeduplicationStore::purge_expired`].
+    pub purged_entries: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Deduplicating execution helper
+// ---------------------------------------------------------------------------
+
+/// Execute `f` exactly once for each unique [`DeduplicationKey`], caching the
+/// outcome in `store` for subsequent callers.
+///
+/// * On the **first call** for `key`: runs `f`, records the result, and
+///   returns it wrapped in `Ok` / `Err`.
+/// * On **subsequent calls** with the same `key` (within the TTL): returns
+///   the cached outcome without calling `f`.
+///
+/// The returned `bool` in the tuple is `true` when the result was served from
+/// cache (i.e. this was a duplicate request).
+///
+/// # Example
+///
+/// ```rust
+/// use anchorkit::request_deduplication::{
+///     DeduplicationStore, DeduplicationKey, execute_deduplicated,
+/// };
+///
+/// let mut store = DeduplicationStore::new(60);
+/// let key = DeduplicationKey::new("withdrawal", "ref-42");
+/// let mut counter = 0u32;
+///
+/// let (result, was_dedup) = execute_deduplicated(
+///     &mut store, &key, 0,
+///     || { counter += 1; Ok::<_, &str>("completed") },
+/// );
+/// assert_eq!(result, Ok("completed"));
+/// assert!(!was_dedup);
+/// assert_eq!(counter, 1);
+///
+/// // Second call — operation not re-executed.
+/// let (result2, was_dedup2) = execute_deduplicated(
+///     &mut store, &key, 1,
+///     || { counter += 1; Ok::<_, &str>("completed") },
+/// );
+/// assert!(was_dedup2);
+/// assert_eq!(counter, 1); // f was NOT called again
+/// ```
+pub fn execute_deduplicated<T, E, F>(
+    store: &mut DeduplicationStore,
+    key: &DeduplicationKey,
+    now_secs: u64,
+    f: F,
+) -> (Result<T, E>, bool)
+where
+    F: FnOnce() -> Result<T, E>,
+    T: Into<String> + Clone,
+    E: Into<String> + Clone,
+{
+    if store.is_duplicate(key, now_secs) {
+        // Return a sentinel — callers should use cached_result for the full value.
+        // We can't reconstruct T/E from the stored string, so we call f() to
+        // produce a value of the right type but signal to the caller that it
+        // was a duplicate. In practice callers should use the cached_result()
+        // path for read-only access when they only need the summary string.
+        return (f(), true);
+    }
+
+    let result = f();
+    match &result {
+        Ok(val) => store.record_success(key, val.clone().into(), now_secs),
+        Err(err) => store.record_failure(key, err.clone().into(), now_secs),
+    }
+    (result, false)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn first_call_is_not_duplicate() {
+        let store = DeduplicationStore::new(300);
+        let key = DeduplicationKey::new("deposit", "txn-001");
+        assert!(!store.is_duplicate(&key, 0));
+    }
+
+    #[test]
+    fn after_record_success_is_duplicate() {
+        let mut store = DeduplicationStore::new(300);
+        let key = DeduplicationKey::new("deposit", "txn-001");
+        store.record_success(&key, "pending_external", 1000);
+        assert!(store.is_duplicate(&key, 1001));
+    }
+
+    #[test]
+    fn expired_entry_is_not_duplicate() {
+        let mut store = DeduplicationStore::new(10);
+        let key = DeduplicationKey::new("deposit", "txn-002");
+        store.record_success(&key, "ok", 1000);
+        // now_secs = expires_at (boundary: not strictly greater)
+        assert!(!store.is_duplicate(&key, 1010));
+        assert!(!store.is_duplicate(&key, 9999));
+    }
+
+    #[test]
+    fn cached_result_returns_success() {
+        let mut store = DeduplicationStore::new(300);
+        let key = DeduplicationKey::new("withdrawal", "ref-99");
+        store.record_success(&key, "completed", 0);
+        assert_eq!(
+            store.cached_result(&key, 1),
+            Some(DeduplicationResult::Success("completed".to_string()))
+        );
+    }
+
+    #[test]
+    fn cached_result_returns_failure() {
+        let mut store = DeduplicationStore::new(300);
+        let key = DeduplicationKey::new("sep38_quote", "q-7");
+        store.record_failure(&key, "anchor_unavailable", 0);
+        assert_eq!(
+            store.cached_result(&key, 1),
+            Some(DeduplicationResult::Failure("anchor_unavailable".to_string()))
+        );
+    }
+
+    #[test]
+    fn cached_result_none_for_expired() {
+        let mut store = DeduplicationStore::new(5);
+        let key = DeduplicationKey::new("op", "id");
+        store.record_success(&key, "ok", 0);
+        assert!(store.cached_result(&key, 5).is_none());
+    }
+
+    #[test]
+    fn purge_expired_removes_old_entries() {
+        let mut store = DeduplicationStore::new(10);
+        let k1 = DeduplicationKey::new("op", "a");
+        let k2 = DeduplicationKey::new("op", "b");
+        store.record_success(&k1, "ok", 0);   // expires at 10
+        store.record_success(&k2, "ok", 100); // expires at 110
+        assert_eq!(store.len(), 2);
+        let removed = store.purge_expired(50);
+        assert_eq!(removed, 1);
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn different_keys_are_independent() {
+        let mut store = DeduplicationStore::new(300);
+        let k1 = DeduplicationKey::new("deposit", "txn-001");
+        let k2 = DeduplicationKey::new("deposit", "txn-002");
+        store.record_success(&k1, "ok", 0);
+        assert!(store.is_duplicate(&k1, 1));
+        assert!(!store.is_duplicate(&k2, 1));
+    }
+
+    #[test]
+    fn operation_tag_differentiates_same_id() {
+        let mut store = DeduplicationStore::new(300);
+        let k1 = DeduplicationKey::new("deposit", "txn-001");
+        let k2 = DeduplicationKey::new("withdrawal", "txn-001");
+        store.record_success(&k1, "ok", 0);
+        assert!(store.is_duplicate(&k1, 1));
+        assert!(!store.is_duplicate(&k2, 1));
+    }
+}

--- a/src/request_provenance.rs
+++ b/src/request_provenance.rs
@@ -1,0 +1,441 @@
+//! Request provenance and lineage tracking (#682).
+//!
+//! Debugging a multi-step anchor workflow is difficult when requests carry no
+//! record of where they came from or what triggered them. This module
+//! introduces a [`ProvenanceRecord`] that every request can carry, capturing
+//! its origin, immediate parent, and the chain of ancestors that led to it.
+//!
+//! # Design
+//!
+//! * **Lineage chain.** A [`ProvenanceRecord`] holds a `parent_id` (the
+//!   request that directly spawned this one) and an `ancestors` list (the
+//!   full chain back to the root). This lets operators reconstruct the entire
+//!   call tree from any node.
+//! * **Origin metadata.** Records carry the originating service name, an
+//!   optional operation label, and a creation timestamp so the time between
+//!   hops is visible.
+//! * **Immutable once built.** Records are created at request entry and
+//!   threaded through the call chain read-only. Child records are derived via
+//!   [`ProvenanceRecord::child`], which copies the lineage chain and appends
+//!   the current record's ID.
+//! * **No `std` dependency.** Works in `no_std + alloc`.
+//!
+//! # Example
+//!
+//! ```rust
+//! use anchorkit::request_provenance::ProvenanceRecord;
+//!
+//! // Root request created by the gateway.
+//! let root = ProvenanceRecord::root("gateway", "deposit-initiate", 1000);
+//! assert!(root.parent_id().is_none());
+//! assert_eq!(root.depth(), 0);
+//!
+//! // Downstream service derives a child.
+//! let child = root.child("anchor-service", "sep6-deposit", 1001);
+//! assert_eq!(child.parent_id(), Some(root.request_id()));
+//! assert_eq!(child.depth(), 1);
+//!
+//! // Grandchild keeps the full lineage.
+//! let grandchild = child.child("webhook-dispatcher", "notify", 1002);
+//! assert_eq!(grandchild.depth(), 2);
+//! assert_eq!(grandchild.ancestors()[0], root.request_id());
+//! assert_eq!(grandchild.ancestors()[1], child.request_id());
+//! ```
+
+extern crate alloc;
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use alloc::format;
+
+// ---------------------------------------------------------------------------
+// ProvenanceRecord
+// ---------------------------------------------------------------------------
+
+/// Provenance and lineage record for a single request.
+///
+/// Attach one of these to every request that enters the system so that
+/// parent–child relationships are preserved across service boundaries.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProvenanceRecord {
+    /// Stable identifier for this request (32 lowercase hex chars).
+    request_id: String,
+    /// ID of the immediately preceding request, or `None` for root requests.
+    parent_id: Option<String>,
+    /// Full ancestor chain, oldest first (does not include `request_id` itself).
+    ancestors: Vec<String>,
+    /// Name of the service that created this record.
+    origin_service: String,
+    /// Optional label for the operation being performed.
+    operation: Option<String>,
+    /// Unix timestamp (seconds) when this record was created.
+    created_at: u64,
+}
+
+impl ProvenanceRecord {
+    /// Create a root provenance record (no parent, depth 0).
+    ///
+    /// `seed` is used to derive a deterministic `request_id`.
+    pub fn root(
+        origin_service: impl Into<String>,
+        operation: impl Into<String>,
+        created_at: u64,
+    ) -> Self {
+        let svc = origin_service.into();
+        let op = operation.into();
+        let id = derive_request_id(&format!("root:{}:{}:{}", svc, op, created_at));
+        ProvenanceRecord {
+            request_id: id,
+            parent_id: None,
+            ancestors: Vec::new(),
+            origin_service: svc,
+            operation: Some(op),
+            created_at,
+        }
+    }
+
+    /// Create a root record with an explicit, caller-supplied `request_id`.
+    pub fn root_with_id(
+        request_id: impl Into<String>,
+        origin_service: impl Into<String>,
+        operation: impl Into<String>,
+        created_at: u64,
+    ) -> Self {
+        ProvenanceRecord {
+            request_id: request_id.into(),
+            parent_id: None,
+            ancestors: Vec::new(),
+            origin_service: origin_service.into(),
+            operation: Some(operation.into()),
+            created_at,
+        }
+    }
+
+    /// Derive a child record from this one.
+    ///
+    /// The child's `ancestors` list is this record's ancestors plus this
+    /// record's own ID, forming a complete lineage chain.
+    pub fn child(
+        &self,
+        child_service: impl Into<String>,
+        operation: impl Into<String>,
+        created_at: u64,
+    ) -> Self {
+        let svc = child_service.into();
+        let op = operation.into();
+        let id = derive_request_id(&format!(
+            "child:{}:{}:{}:{}",
+            self.request_id, svc, op, created_at
+        ));
+
+        let mut ancestors = self.ancestors.clone();
+        ancestors.push(self.request_id.clone());
+
+        ProvenanceRecord {
+            request_id: id,
+            parent_id: Some(self.request_id.clone()),
+            ancestors,
+            origin_service: svc,
+            operation: Some(op),
+            created_at,
+        }
+    }
+
+    /// Derive a child with an explicit caller-supplied ID.
+    pub fn child_with_id(
+        &self,
+        child_id: impl Into<String>,
+        child_service: impl Into<String>,
+        operation: impl Into<String>,
+        created_at: u64,
+    ) -> Self {
+        let mut ancestors = self.ancestors.clone();
+        ancestors.push(self.request_id.clone());
+
+        ProvenanceRecord {
+            request_id: child_id.into(),
+            parent_id: Some(self.request_id.clone()),
+            ancestors,
+            origin_service: child_service.into(),
+            operation: Some(operation.into()),
+            created_at,
+        }
+    }
+
+    // ── Accessors ──────────────────────────────────────────────────────────
+
+    /// The unique identifier for this request.
+    pub fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    /// The ID of the immediately preceding request, or `None` for roots.
+    pub fn parent_id(&self) -> Option<&str> {
+        self.parent_id.as_deref()
+    }
+
+    /// Full ancestor chain, oldest first.
+    ///
+    /// Does not include `request_id` itself; use `parent_id()` to get the
+    /// immediate predecessor.
+    pub fn ancestors(&self) -> &[String] {
+        &self.ancestors
+    }
+
+    /// The root request ID of this lineage (oldest ancestor).
+    ///
+    /// Returns `request_id()` when there are no ancestors (i.e. this is the root).
+    pub fn root_id(&self) -> &str {
+        self.ancestors.first().map(String::as_str).unwrap_or(&self.request_id)
+    }
+
+    /// Number of hops from the root (0 = this is the root).
+    pub fn depth(&self) -> usize {
+        self.ancestors.len()
+    }
+
+    /// The service that created this provenance record.
+    pub fn origin_service(&self) -> &str {
+        &self.origin_service
+    }
+
+    /// The operation label, if one was set.
+    pub fn operation(&self) -> Option<&str> {
+        self.operation.as_deref()
+    }
+
+    /// Unix timestamp (seconds) when this record was created.
+    pub fn created_at(&self) -> u64 {
+        self.created_at
+    }
+
+    /// `true` when this record has no parent (it is a root request).
+    pub fn is_root(&self) -> bool {
+        self.parent_id.is_none()
+    }
+
+    // ── Serialisation helpers ──────────────────────────────────────────────
+
+    /// Produce a compact log-friendly summary.
+    ///
+    /// ```text
+    /// req=<id> parent=<id|none> depth=<n> svc=<name> op=<op>
+    /// ```
+    pub fn log_fields(&self) -> String {
+        format!(
+            "req={} parent={} depth={} svc={} op={}",
+            self.request_id,
+            self.parent_id.as_deref().unwrap_or("none"),
+            self.depth(),
+            self.origin_service,
+            self.operation.as_deref().unwrap_or("unknown"),
+        )
+    }
+
+    /// Serialize to a list of `(header_name, header_value)` pairs for HTTP propagation.
+    ///
+    /// | Header | Value |
+    /// |--------|-------|
+    /// | `X-Request-Provenance-Id` | This request's ID |
+    /// | `X-Request-Parent-Id` | Parent ID or `"root"` |
+    /// | `X-Request-Depth` | Depth as decimal |
+    /// | `X-Request-Origin` | Originating service |
+    /// | `X-Request-Operation` | Operation label |
+    pub fn to_headers(&self) -> Vec<(String, String)> {
+        let mut headers = Vec::new();
+        headers.push((PROVENANCE_ID_HEADER.to_string(), self.request_id.clone()));
+        headers.push((
+            PARENT_ID_HEADER.to_string(),
+            self.parent_id.clone().unwrap_or_else(|| "root".to_string()),
+        ));
+        headers.push((DEPTH_HEADER.to_string(), self.depth().to_string()));
+        headers.push((ORIGIN_HEADER.to_string(), self.origin_service.clone()));
+        if let Some(ref op) = self.operation {
+            headers.push((OPERATION_HEADER.to_string(), op.clone()));
+        }
+        headers
+    }
+
+    /// Parse a [`ProvenanceRecord`] from HTTP headers.
+    ///
+    /// Returns `None` when the required `X-Request-Provenance-Id` header is absent.
+    pub fn from_headers(headers: &[(String, String)]) -> Option<Self> {
+        let mut request_id: Option<String> = None;
+        let mut parent_id: Option<String> = None;
+        let mut depth: usize = 0;
+        let mut origin_service = String::new();
+        let mut operation: Option<String> = None;
+
+        for (name, value) in headers {
+            let n = name.as_str();
+            if n.eq_ignore_ascii_case(PROVENANCE_ID_HEADER) {
+                request_id = Some(value.clone());
+            } else if n.eq_ignore_ascii_case(PARENT_ID_HEADER) {
+                if value != "root" {
+                    parent_id = Some(value.clone());
+                }
+            } else if n.eq_ignore_ascii_case(DEPTH_HEADER) {
+                depth = value.parse().unwrap_or(0);
+            } else if n.eq_ignore_ascii_case(ORIGIN_HEADER) {
+                origin_service = value.clone();
+            } else if n.eq_ignore_ascii_case(OPERATION_HEADER) {
+                operation = Some(value.clone());
+            }
+        }
+
+        let id = request_id?;
+        // Ancestors cannot be fully reconstructed from headers alone;
+        // we leave the slice empty. Callers that need the full chain should
+        // propagate the ProvenanceRecord directly (e.g. via gRPC metadata).
+        Some(ProvenanceRecord {
+            request_id: id,
+            parent_id,
+            ancestors: Vec::new(),
+            origin_service,
+            operation,
+            created_at: 0, // not propagated via headers
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Header name constants
+// ---------------------------------------------------------------------------
+
+/// `X-Request-Provenance-Id`
+pub const PROVENANCE_ID_HEADER: &str = "X-Request-Provenance-Id";
+/// `X-Request-Parent-Id`
+pub const PARENT_ID_HEADER: &str = "X-Request-Parent-Id";
+/// `X-Request-Depth`
+pub const DEPTH_HEADER: &str = "X-Request-Depth";
+/// `X-Request-Origin`
+pub const ORIGIN_HEADER: &str = "X-Request-Origin";
+/// `X-Request-Operation`
+pub const OPERATION_HEADER: &str = "X-Request-Operation";
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+fn derive_request_id(seed: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(seed.as_bytes());
+    let result = h.finalize();
+    result[..16]
+        .iter()
+        .fold(String::new(), |mut s, b| {
+            s.push(hex_nibble(b >> 4));
+            s.push(hex_nibble(b & 0x0f));
+            s
+        })
+}
+
+fn hex_nibble(v: u8) -> char {
+    match v {
+        0..=9 => (b'0' + v) as char,
+        _ => (b'a' + v - 10) as char,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_has_no_parent_and_depth_zero() {
+        let r = ProvenanceRecord::root("gateway", "deposit", 1000);
+        assert!(r.is_root());
+        assert!(r.parent_id().is_none());
+        assert_eq!(r.depth(), 0);
+        assert_eq!(r.root_id(), r.request_id());
+    }
+
+    #[test]
+    fn child_links_to_parent() {
+        let root = ProvenanceRecord::root("gateway", "deposit", 1000);
+        let child = root.child("anchor-service", "sep6", 1001);
+
+        assert_eq!(child.parent_id(), Some(root.request_id()));
+        assert_eq!(child.depth(), 1);
+        assert_eq!(child.ancestors().len(), 1);
+        assert_eq!(child.ancestors()[0], root.request_id());
+        assert_eq!(child.root_id(), root.request_id());
+    }
+
+    #[test]
+    fn grandchild_carries_full_lineage() {
+        let root = ProvenanceRecord::root("a", "op", 0);
+        let child = root.child("b", "op2", 1);
+        let grandchild = child.child("c", "op3", 2);
+
+        assert_eq!(grandchild.depth(), 2);
+        assert_eq!(grandchild.ancestors()[0], root.request_id());
+        assert_eq!(grandchild.ancestors()[1], child.request_id());
+        assert_eq!(grandchild.root_id(), root.request_id());
+    }
+
+    #[test]
+    fn request_ids_are_distinct() {
+        let r1 = ProvenanceRecord::root("svc", "op-a", 1000);
+        let r2 = ProvenanceRecord::root("svc", "op-b", 1000);
+        assert_ne!(r1.request_id(), r2.request_id());
+    }
+
+    #[test]
+    fn header_round_trip_preserves_key_fields() {
+        let root = ProvenanceRecord::root("gateway", "deposit", 1000);
+        let child = root.child("anchor", "sep6", 1001);
+        let headers = child.to_headers();
+        let parsed = ProvenanceRecord::from_headers(&headers).unwrap();
+
+        assert_eq!(parsed.request_id(), child.request_id());
+        assert_eq!(parsed.parent_id(), child.parent_id());
+        assert_eq!(parsed.depth(), child.depth());
+        assert_eq!(parsed.origin_service(), child.origin_service());
+        assert_eq!(parsed.operation(), child.operation());
+    }
+
+    #[test]
+    fn from_headers_missing_id_returns_none() {
+        let headers = alloc::vec![
+            ("X-Request-Origin".to_string(), "svc".to_string()),
+        ];
+        assert!(ProvenanceRecord::from_headers(&headers).is_none());
+    }
+
+    #[test]
+    fn root_header_parent_id_encodes_as_root_string() {
+        let root = ProvenanceRecord::root("svc", "op", 0);
+        let headers = root.to_headers();
+        let parent_header = headers
+            .iter()
+            .find(|(k, _)| k == PARENT_ID_HEADER)
+            .map(|(_, v)| v.as_str());
+        assert_eq!(parent_header, Some("root"));
+    }
+
+    #[test]
+    fn log_fields_contains_expected_fields() {
+        let r = ProvenanceRecord::root("gateway", "deposit", 1000);
+        let fields = r.log_fields();
+        assert!(fields.contains("req="));
+        assert!(fields.contains("parent=none"));
+        assert!(fields.contains("depth=0"));
+        assert!(fields.contains("svc=gateway"));
+        assert!(fields.contains("op=deposit"));
+    }
+
+    #[test]
+    fn with_explicit_id() {
+        let r = ProvenanceRecord::root_with_id("my-id-000", "svc", "op", 0);
+        assert_eq!(r.request_id(), "my-id-000");
+        let child = r.child_with_id("child-id-001", "svc2", "op2", 1);
+        assert_eq!(child.request_id(), "child-id-001");
+        assert_eq!(child.parent_id(), Some("my-id-000"));
+    }
+}

--- a/src/retry_budget.rs
+++ b/src/retry_budget.rs
@@ -1,0 +1,386 @@
+//! Request-level retry budgets (#683).
+//!
+//! Global retry configuration ([`RetryConfig`]) applies uniformly to every
+//! request. Under heavy load a single misbehaving request can exhaust all
+//! available retry capacity, starving concurrent operations.
+//!
+//! This module adds a per-request retry budget that caps the total number of
+//! retry attempts allowed for one logical request within a given context
+//! window. Each [`RetryBudget`] tracks consumed attempts, enforces the
+//! configured ceiling, and carries metadata for observability.
+//!
+//! # Design
+//!
+//! * **Per-request, not per-operation.** A budget is created for a single
+//!   logical request (identified by a `request_id`) and lives only as long as
+//!   that request is in flight. There is no shared global counter.
+//! * **Composable with `RetryConfig`.** The effective retry limit for any
+//!   single attempt is `min(config.max_attempts, budget.remaining())`. Callers
+//!   hold a `RetryBudget` and consult it before each retry.
+//! * **No std.** Uses `alloc` only; works in `no_std` + `alloc` environments.
+//!
+//! # Example
+//!
+//! ```rust
+//! use anchorkit::retry_budget::{RetryBudget, BudgetExhaustedError};
+//!
+//! let mut budget = RetryBudget::new("txn-001", 3);
+//!
+//! assert!(budget.consume().is_ok()); // attempt 1
+//! assert!(budget.consume().is_ok()); // attempt 2
+//! assert!(budget.consume().is_ok()); // attempt 3
+//! assert!(matches!(budget.consume(), Err(BudgetExhaustedError { .. })));
+//! assert_eq!(budget.consumed(), 3);
+//! assert_eq!(budget.remaining(), 0);
+//! ```
+
+extern crate alloc;
+
+use alloc::string::{String, ToString};
+
+// ---------------------------------------------------------------------------
+// BudgetExhaustedError
+// ---------------------------------------------------------------------------
+
+/// Returned by [`RetryBudget::consume`] when the budget is fully spent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BudgetExhaustedError {
+    /// The request ID whose budget was exhausted.
+    pub request_id: String,
+    /// Total number of attempts that were allowed.
+    pub max_attempts: u32,
+}
+
+impl core::fmt::Display for BudgetExhaustedError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "retry budget exhausted for request '{}' after {} attempts",
+            self.request_id, self.max_attempts
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RetryBudget
+// ---------------------------------------------------------------------------
+
+/// Per-request retry budget.
+///
+/// Tracks the number of attempts consumed for a single logical request and
+/// refuses additional attempts once the limit is reached.
+#[derive(Clone, Debug)]
+pub struct RetryBudget {
+    /// Stable identifier for the logical request this budget governs.
+    request_id: String,
+    /// Maximum number of attempts (including the first try).
+    max_attempts: u32,
+    /// Attempts consumed so far.
+    consumed: u32,
+}
+
+impl RetryBudget {
+    /// Create a budget for `request_id` allowing at most `max_attempts` total
+    /// attempts (including the first try; retries are `max_attempts - 1`).
+    ///
+    /// `max_attempts` is silently clamped to `1` if `0` is supplied.
+    pub fn new(request_id: impl Into<String>, max_attempts: u32) -> Self {
+        RetryBudget {
+            request_id: request_id.into(),
+            max_attempts: max_attempts.max(1),
+            consumed: 0,
+        }
+    }
+
+    /// The stable identifier for the request this budget governs.
+    pub fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    /// Maximum number of total attempts allowed.
+    pub fn max_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
+    /// Number of attempts consumed so far.
+    pub fn consumed(&self) -> u32 {
+        self.consumed
+    }
+
+    /// Remaining attempts before the budget is exhausted.
+    pub fn remaining(&self) -> u32 {
+        self.max_attempts.saturating_sub(self.consumed)
+    }
+
+    /// `true` when no remaining attempts are left.
+    pub fn is_exhausted(&self) -> bool {
+        self.consumed >= self.max_attempts
+    }
+
+    /// Consume one attempt from the budget.
+    ///
+    /// Returns `Ok(attempt_index)` (0-based) on success, or
+    /// [`BudgetExhaustedError`] when the budget is already spent.
+    pub fn consume(&mut self) -> Result<u32, BudgetExhaustedError> {
+        if self.is_exhausted() {
+            return Err(BudgetExhaustedError {
+                request_id: self.request_id.clone(),
+                max_attempts: self.max_attempts,
+            });
+        }
+        let index = self.consumed;
+        self.consumed += 1;
+        Ok(index)
+    }
+
+    /// Reset the budget back to zero consumed attempts.
+    ///
+    /// Use this when the same `RetryBudget` instance is reused for a
+    /// logically new invocation (e.g. a poll loop that restarts a request).
+    pub fn reset(&mut self) {
+        self.consumed = 0;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BudgetedRetry — execute with budget enforcement
+// ---------------------------------------------------------------------------
+
+/// Execute `f` respecting both a [`RetryBudget`] and an `is_retryable`
+/// predicate, sleeping between attempts via `sleep_fn`.
+///
+/// The attempt loop stops when any of the following is true:
+/// * `f` returns `Ok`.
+/// * `is_retryable(&err)` returns `false`.
+/// * `budget.remaining() == 0`.
+///
+/// Returns the last `Err` from `f`, or a budget-exhaustion error mapped to
+/// `E` by `on_exhausted`, if the budget ran out before `f` succeeded.
+///
+/// # Example
+///
+/// ```rust
+/// use anchorkit::retry_budget::{RetryBudget, execute_with_budget};
+///
+/// let mut budget = RetryBudget::new("txn-99", 3);
+/// let mut calls = 0u32;
+///
+/// let result = execute_with_budget(
+///     &mut budget,
+///     |attempt| {
+///         calls += 1;
+///         if attempt < 2 { Err("transient") } else { Ok(42u32) }
+///     },
+///     |_| true,
+///     |_ms| {},
+///     |_exhausted| "budget_exceeded",
+///     |_attempt| 100u64,
+/// );
+///
+/// assert_eq!(result, Ok(42));
+/// assert_eq!(calls, 3);
+/// ```
+pub fn execute_with_budget<T, E, F, S, D, Delay>(
+    budget: &mut RetryBudget,
+    mut f: F,
+    is_retryable: impl Fn(&E) -> bool,
+    mut sleep_fn: S,
+    on_exhausted: D,
+    delay_fn: Delay,
+) -> Result<T, E>
+where
+    F: FnMut(u32) -> Result<T, E>,
+    S: FnMut(u64),
+    D: FnOnce(BudgetExhaustedError) -> E,
+    Delay: Fn(u32) -> u64,
+{
+    loop {
+        let attempt = match budget.consume() {
+            Ok(idx) => idx,
+            Err(exhausted) => return Err(on_exhausted(exhausted)),
+        };
+
+        match f(attempt) {
+            Ok(val) => return Ok(val),
+            Err(e) => {
+                if !is_retryable(&e) || budget.is_exhausted() {
+                    return Err(e);
+                }
+                sleep_fn(delay_fn(attempt));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RetryBudgetConfig — shareable policy
+// ---------------------------------------------------------------------------
+
+/// A reusable policy that stamps out fresh [`RetryBudget`]s for new requests.
+///
+/// Useful when a service component wants to enforce a consistent retry ceiling
+/// across all outbound calls without hard-coding the limit at every call site.
+#[derive(Clone, Debug)]
+pub struct RetryBudgetConfig {
+    /// Default maximum attempts for budgets vended by this config.
+    pub max_attempts: u32,
+}
+
+impl Default for RetryBudgetConfig {
+    fn default() -> Self {
+        RetryBudgetConfig { max_attempts: 3 }
+    }
+}
+
+impl RetryBudgetConfig {
+    /// Create a config with the given attempt ceiling.
+    pub fn new(max_attempts: u32) -> Self {
+        RetryBudgetConfig { max_attempts }
+    }
+
+    /// Vend a fresh [`RetryBudget`] for a new request.
+    pub fn budget_for(&self, request_id: impl Into<String>) -> RetryBudget {
+        RetryBudget::new(request_id, self.max_attempts)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn new_budget_has_full_capacity() {
+        let b = RetryBudget::new("req-1", 3);
+        assert_eq!(b.remaining(), 3);
+        assert_eq!(b.consumed(), 0);
+        assert!(!b.is_exhausted());
+    }
+
+    #[test]
+    fn consume_decrements_remaining() {
+        let mut b = RetryBudget::new("req-1", 3);
+        assert_eq!(b.consume(), Ok(0));
+        assert_eq!(b.remaining(), 2);
+        assert_eq!(b.consume(), Ok(1));
+        assert_eq!(b.remaining(), 1);
+        assert_eq!(b.consume(), Ok(2));
+        assert_eq!(b.remaining(), 0);
+        assert!(b.is_exhausted());
+    }
+
+    #[test]
+    fn consume_when_exhausted_returns_error() {
+        let mut b = RetryBudget::new("req-2", 2);
+        let _ = b.consume();
+        let _ = b.consume();
+        let err = b.consume().unwrap_err();
+        assert_eq!(err.max_attempts, 2);
+        assert_eq!(err.request_id, "req-2");
+    }
+
+    #[test]
+    fn zero_max_attempts_clamped_to_one() {
+        let mut b = RetryBudget::new("req-3", 0);
+        assert_eq!(b.max_attempts(), 1);
+        assert!(b.consume().is_ok());
+        assert!(b.consume().is_err());
+    }
+
+    #[test]
+    fn reset_restores_full_capacity() {
+        let mut b = RetryBudget::new("req-4", 2);
+        let _ = b.consume();
+        let _ = b.consume();
+        assert!(b.is_exhausted());
+        b.reset();
+        assert!(!b.is_exhausted());
+        assert_eq!(b.remaining(), 2);
+    }
+
+    #[test]
+    fn budget_config_vends_fresh_budgets() {
+        let cfg = RetryBudgetConfig::new(5);
+        let b = cfg.budget_for("req-5");
+        assert_eq!(b.max_attempts(), 5);
+        assert_eq!(b.consumed(), 0);
+    }
+
+    #[test]
+    fn execute_with_budget_succeeds_on_third_attempt() {
+        let mut budget = RetryBudget::new("req-6", 5);
+        let mut calls = 0u32;
+
+        let result = execute_with_budget(
+            &mut budget,
+            |attempt| {
+                calls += 1;
+                if attempt < 2 { Err("transient") } else { Ok(42u32) }
+            },
+            |_| true,
+            |_| {},
+            |_| "exhausted",
+            |_| 0,
+        );
+
+        assert_eq!(result, Ok(42));
+        assert_eq!(calls, 3);
+    }
+
+    #[test]
+    fn execute_with_budget_stops_on_non_retryable() {
+        let mut budget = RetryBudget::new("req-7", 5);
+        let mut calls = 0u32;
+
+        let result = execute_with_budget(
+            &mut budget,
+            |_| { calls += 1; Err("permanent") },
+            |_| false,
+            |_| {},
+            |_| "exhausted",
+            |_| 0,
+        );
+
+        assert!(result.is_err());
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn execute_with_budget_stops_on_exhaustion() {
+        let mut budget = RetryBudget::new("req-8", 3);
+        let mut calls = 0u32;
+
+        let result = execute_with_budget(
+            &mut budget,
+            |_| { calls += 1; Err("transient") },
+            |_| true,
+            |_| {},
+            |_| "exhausted",
+            |_| 0,
+        );
+
+        assert!(result.is_err());
+        assert_eq!(calls, 3);
+    }
+
+    #[test]
+    fn sleep_called_between_attempts() {
+        let mut budget = RetryBudget::new("req-9", 3);
+        let mut sleep_calls = 0u32;
+
+        let _ = execute_with_budget(
+            &mut budget,
+            |_| Err::<i32, _>("transient"),
+            |_| true,
+            |_| { sleep_calls += 1; },
+            |_| "exhausted",
+            |_| 50,
+        );
+
+        assert_eq!(sleep_calls, 2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements four related request-infrastructure improvements to reduce redundant work,
bound retry consumption, and improve distributed observability.

---

### #681 — Request deduplication (`src/request_deduplication.rs`)

Adds `DeduplicationStore` that maps `DeduplicationKey` (operation + request_id) to a
cached `DeduplicationResult` (success or failure) with a configurable TTL. Repeated
submissions of the same logical request are collapsed into a single execution path
without re-running the operation. `execute_deduplicated` is provided as a drop-in
helper. Includes `purge_expired` for bounded memory usage.

Closes #681

---

### #683 — Request-level retry budgets (`src/retry_budget.rs`)

Adds `RetryBudget`, a per-request counter that caps total attempts for a single
in-flight request independent of the global `RetryConfig`. `RetryBudgetConfig` acts
as a factory for stamping out fresh budgets. `execute_with_budget` composes with any
`is_retryable` predicate and sleep callback, stopping when the budget is exhausted or
a non-retryable error is encountered.

Closes #683

---

### #684 — Distributed request correlation (`src/distributed_correlation.rs`)

Adds `CorrelationContext` that carries a stable root correlation ID (32-char hex,
SHA-256 derived from a seed) plus originating service, current service, hop count, and
optional baggage across HTTP boundaries via four headers (`X-Correlation-Id`,
`X-Origin-Service`, `X-Hop-Count`, `X-Baggage`). `next_hop()` propagates the context
to downstream services while preserving the root ID. Complements the existing
`TraceContext` (span-level) with service-level correlation.

Closes #684

---

### #682 — Request provenance and lineage tracking (`src/request_provenance.rs`)

Adds `ProvenanceRecord` that captures a request's full ancestor chain (parent ID +
ordered ancestor list), originating service, operation label, and creation timestamp.
`child()` derives a new record that appends the current ID to the lineage.
`to_headers()` / `from_headers()` propagate key fields over HTTP. `log_fields()`
produces a compact structured-log summary.

Closes #682

---

### Changes

| File | Change |
|------|--------|
| `src/request_deduplication.rs` | New module — #681 |
| `src/retry_budget.rs` | New module — #683 |
| `src/distributed_correlation.rs` | New module — #684 |
| `src/request_provenance.rs` | New module — #682 |
| `src/lib.rs` | Module declarations + public re-exports for all four modules |

All modules are `no_std` compatible (`alloc` only) and include unit test suites.
