### PR TITLE
feat: partial recovery, host replay prevention, retention policies, and export/archival

### DIFF
--- a/src/host_replay_prevention.rs
+++ b/src/host_replay_prevention.rs
@@ -1,0 +1,342 @@
+//! Host-boundary replay prevention (#678).
+//!
+//! The on-chain [`replay_detection`](crate::replay_detection) module catches
+//! duplicate request IDs inside Soroban contract execution.  This module
+//! provides a complementary **host-side** guard that rejects duplicate
+//! transaction submissions *before* any business logic runs, at the boundary
+//! where the host application receives a request.
+//!
+//! ## Design
+//!
+//! [`HostReplayGuard`] maintains a set of recently-seen request IDs.  Each ID
+//! is stored alongside the Unix timestamp at which it was first seen.  Before
+//! processing a new request, callers call [`HostReplayGuard::check`]:
+//!
+//! - **First time**: the ID is recorded and [`CheckResult::Accepted`] is returned.
+//! - **Duplicate**: [`CheckResult::Replay`] is returned with the original
+//!   timestamp, and the request should be rejected before any further processing.
+//!
+//! Expired entries (older than the configured `window_secs`) are pruned lazily
+//! on every [`check`](HostReplayGuard::check) call so memory stays bounded even
+//! under high traffic.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use anchorkit::host_replay_prevention::{HostReplayGuard, CheckResult};
+//!
+//! let mut guard = HostReplayGuard::new(300); // 5-minute dedup window
+//!
+//! match guard.check("req-001", "GXXX", 1_000_000) {
+//!     CheckResult::Accepted => { /* proceed with processing */ }
+//!     CheckResult::Replay { first_seen_at } => {
+//!         eprintln!("duplicate submission detected (first seen at {})", first_seen_at);
+//!     }
+//! }
+//! ```
+
+extern crate alloc;
+use alloc::{string::String, vec::Vec};
+
+// ---------------------------------------------------------------------------
+// CheckResult
+// ---------------------------------------------------------------------------
+
+/// Outcome of a [`HostReplayGuard::check`] call.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CheckResult {
+    /// The request ID has not been seen before within the dedup window; safe to proceed.
+    Accepted,
+    /// The request ID was already seen within the window — this is a duplicate.
+    Replay {
+        /// Unix timestamp (seconds) when the request ID was first received.
+        first_seen_at: u64,
+    },
+}
+
+impl CheckResult {
+    /// Return `true` if the result is [`Accepted`](CheckResult::Accepted).
+    pub fn is_accepted(&self) -> bool {
+        matches!(self, CheckResult::Accepted)
+    }
+
+    /// Return `true` if the result is a replay.
+    pub fn is_replay(&self) -> bool {
+        matches!(self, CheckResult::Replay { .. })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal entry
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct SeenEntry {
+    request_id: String,
+    actor: String,
+    first_seen_at: u64,
+}
+
+// ---------------------------------------------------------------------------
+// HostReplayGuard (#678)
+// ---------------------------------------------------------------------------
+
+/// Host-boundary deduplication guard for transaction request IDs.
+///
+/// Maintains a sliding window of recently-seen request IDs.  Any submission
+/// whose ID was already recorded within `window_secs` is flagged as a replay
+/// and should be rejected before business logic runs.
+///
+/// # Thread safety
+///
+/// [`HostReplayGuard`] is not `Sync`; for multi-threaded use wrap it in a
+/// `Mutex`.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::host_replay_prevention::{HostReplayGuard, CheckResult};
+///
+/// let mut guard = HostReplayGuard::new(60); // 60-second window
+///
+/// // First submission accepted.
+/// assert!(guard.check("req-abc", "GXXX", 1_000).is_accepted());
+///
+/// // Same ID within the window is a replay.
+/// assert!(guard.check("req-abc", "GXXX", 1_030).is_replay());
+///
+/// // A different ID is accepted.
+/// assert!(guard.check("req-xyz", "GXXX", 1_030).is_accepted());
+/// ```
+#[derive(Debug)]
+pub struct HostReplayGuard {
+    /// Deduplication window in seconds.
+    pub window_secs: u64,
+    /// Seen entries, ordered by `first_seen_at` ascending.
+    entries: Vec<SeenEntry>,
+    /// Total number of replay detections since creation.
+    pub replay_count: u64,
+    /// Total number of accepted (non-replay) requests since creation.
+    pub accepted_count: u64,
+}
+
+impl HostReplayGuard {
+    /// Create a new guard with the given deduplication window.
+    ///
+    /// # Arguments
+    ///
+    /// * `window_secs` – How long (in seconds) a request ID is remembered.
+    ///   Pass `0` to remember IDs indefinitely (no expiry).
+    pub fn new(window_secs: u64) -> Self {
+        Self {
+            window_secs,
+            entries: Vec::new(),
+            replay_count: 0,
+            accepted_count: 0,
+        }
+    }
+
+    /// Check whether `request_id` from `actor` at `now_secs` is a replay.
+    ///
+    /// Expired entries are pruned before the lookup.
+    ///
+    /// # Arguments
+    ///
+    /// * `request_id` – Unique identifier for the request (e.g. a nonce or
+    ///   transaction hash).
+    /// * `actor`      – The submitting party's identifier (used for metrics;
+    ///   the dedup key is `request_id` alone).
+    /// * `now_secs`   – Current Unix timestamp in seconds.
+    ///
+    /// # Returns
+    ///
+    /// [`CheckResult::Accepted`] if the ID is new; [`CheckResult::Replay`] if
+    /// it was already seen within the window.
+    pub fn check(&mut self, request_id: &str, actor: &str, now_secs: u64) -> CheckResult {
+        // Prune expired entries first.
+        self.prune_expired(now_secs);
+
+        // Look for an existing entry with the same request_id.
+        if let Some(entry) = self.entries.iter().find(|e| e.request_id == request_id) {
+            self.replay_count += 1;
+            return CheckResult::Replay { first_seen_at: entry.first_seen_at };
+        }
+
+        // New ID — record it.
+        self.entries.push(SeenEntry {
+            request_id: String::from(request_id),
+            actor: String::from(actor),
+            first_seen_at: now_secs,
+        });
+        self.accepted_count += 1;
+        CheckResult::Accepted
+    }
+
+    /// Manually prune all entries older than `now_secs - window_secs`.
+    ///
+    /// Called automatically by [`check`](Self::check), but exposed so callers
+    /// can trigger a cleanup sweep independently (e.g. on a background timer).
+    pub fn prune_expired(&mut self, now_secs: u64) {
+        if self.window_secs == 0 {
+            return; // Infinite window — nothing expires.
+        }
+        let cutoff = now_secs.saturating_sub(self.window_secs);
+        self.entries.retain(|e| e.first_seen_at >= cutoff);
+    }
+
+    /// Return the number of entries currently held in the window.
+    pub fn window_size(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Check whether `request_id` is currently in the window without recording it.
+    ///
+    /// Useful for pre-flight inspection without side effects.
+    pub fn is_known(&self, request_id: &str) -> bool {
+        self.entries.iter().any(|e| e.request_id == request_id)
+    }
+
+    /// Forcibly forget a request ID (e.g. after an admin-approved resubmission).
+    ///
+    /// Returns `true` if the entry was found and removed, `false` if it was not present.
+    pub fn forget(&mut self, request_id: &str) -> bool {
+        let before = self.entries.len();
+        self.entries.retain(|e| e.request_id != request_id);
+        self.entries.len() < before
+    }
+
+    /// Reset all state (entries and counters).
+    pub fn reset(&mut self) {
+        self.entries.clear();
+        self.replay_count = 0;
+        self.accepted_count = 0;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Basic accept / replay ───────────────────────────────────────────────
+
+    #[test]
+    fn test_new_id_is_accepted() {
+        let mut guard = HostReplayGuard::new(300);
+        assert!(guard.check("req-001", "GXXX", 1_000).is_accepted());
+        assert_eq!(guard.accepted_count, 1);
+        assert_eq!(guard.replay_count, 0);
+    }
+
+    #[test]
+    fn test_duplicate_id_is_replay() {
+        let mut guard = HostReplayGuard::new(300);
+        guard.check("req-001", "GXXX", 1_000);
+        let result = guard.check("req-001", "GXXX", 1_001);
+        assert!(result.is_replay());
+        assert_eq!(guard.replay_count, 1);
+        if let CheckResult::Replay { first_seen_at } = result {
+            assert_eq!(first_seen_at, 1_000);
+        }
+    }
+
+    #[test]
+    fn test_different_ids_both_accepted() {
+        let mut guard = HostReplayGuard::new(300);
+        assert!(guard.check("req-001", "GXXX", 1_000).is_accepted());
+        assert!(guard.check("req-002", "GXXX", 1_001).is_accepted());
+        assert_eq!(guard.window_size(), 2);
+    }
+
+    // ── Window expiry / pruning ──────────────────────────────────────────────
+
+    #[test]
+    fn test_expired_id_is_accepted_again() {
+        let mut guard = HostReplayGuard::new(60);
+        guard.check("req-001", "GXXX", 1_000);
+        // 70 seconds later — entry should have expired.
+        let result = guard.check("req-001", "GXXX", 1_070);
+        assert!(result.is_accepted(), "expired entry should be re-accepted");
+    }
+
+    #[test]
+    fn test_prune_expired_removes_old_entries() {
+        let mut guard = HostReplayGuard::new(60);
+        guard.check("req-old", "GXXX", 1_000);
+        guard.check("req-new", "GXXX", 1_090);
+
+        // Prune at t=1_090: req-old (age=90) is outside window.
+        guard.prune_expired(1_090);
+
+        assert_eq!(guard.window_size(), 1);
+        assert!(!guard.is_known("req-old"));
+        assert!(guard.is_known("req-new"));
+    }
+
+    #[test]
+    fn test_infinite_window_never_expires() {
+        let mut guard = HostReplayGuard::new(0); // window_secs = 0 → infinite
+        guard.check("req-001", "GXXX", 1_000);
+        // Very far in the future — should still be a replay.
+        assert!(guard.check("req-001", "GXXX", 9_999_999).is_replay());
+    }
+
+    // ── is_known / forget ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_known_after_accept() {
+        let mut guard = HostReplayGuard::new(300);
+        guard.check("req-001", "GXXX", 1_000);
+        assert!(guard.is_known("req-001"));
+        assert!(!guard.is_known("req-999"));
+    }
+
+    #[test]
+    fn test_forget_removes_entry() {
+        let mut guard = HostReplayGuard::new(300);
+        guard.check("req-001", "GXXX", 1_000);
+        assert!(guard.forget("req-001"));
+        assert!(!guard.is_known("req-001"));
+        // After forgetting, the same ID is accepted again.
+        assert!(guard.check("req-001", "GXXX", 1_001).is_accepted());
+    }
+
+    #[test]
+    fn test_forget_returns_false_for_unknown_id() {
+        let mut guard = HostReplayGuard::new(300);
+        assert!(!guard.forget("req-nope"));
+    }
+
+    // ── reset ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_reset_clears_all_state() {
+        let mut guard = HostReplayGuard::new(300);
+        guard.check("req-001", "GXXX", 1_000);
+        guard.check("req-001", "GXXX", 1_001); // replay
+
+        guard.reset();
+
+        assert_eq!(guard.window_size(), 0);
+        assert_eq!(guard.accepted_count, 0);
+        assert_eq!(guard.replay_count, 0);
+        assert!(guard.check("req-001", "GXXX", 1_002).is_accepted());
+    }
+
+    // ── window_size tracking ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_window_size_stays_bounded_after_expiry() {
+        let mut guard = HostReplayGuard::new(10);
+        for i in 0..20_u64 {
+            guard.check(&alloc::format!("req-{}", i), "GXXX", i);
+        }
+        // At t=20, all entries older than t=10 are pruned on next check.
+        guard.check("req-new", "GXXX", 20);
+        // Only entries from t=10..=20 remain (11 entries).
+        assert!(guard.window_size() <= 11);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,13 @@ pub mod session_state_machine;
 pub mod migration;
 #[cfg(not(feature = "wasm"))]
 pub mod url_normalizer;
+// Issue #679: configurable request record retention policies
+// Issue #680: request record export and archival support
+#[cfg(not(feature = "wasm"))]
+pub mod request_record;
+// Issue #678: host-boundary replay prevention
+#[cfg(not(feature = "wasm"))]
+pub mod host_replay_prevention;
 
 // ── std-only modules (filesystem, runtime config) ─────────────────────────────
 #[cfg(feature = "std")]
@@ -275,8 +282,7 @@ pub use admin_audit_log::{AdminAuditLog, AdminConfigChangeEvent, AdminAuditLogCo
 pub use contract::{HealthStatus, MetadataFreshnessReport, RateLimiterHealth};
 pub use contract::{AnchorHealthMetrics, AnchorProofRecord};
 pub use transaction_state_tracker::{BudgetStatus, BudgetAlert};
-// Issue #657: multi-anchor reputation weighting
-pub use contract::{AnchorReputationRecord, ReputationWeights};
+// Issue #657: multi-anchor reputation weightingpub use contract::{AnchorReputationRecord, ReputationWeights};
 // Issue #658: time-based routing policies
 pub use contract::{RoutingTimeWindow, TimedRoutingPolicy};
 // Issue #659: per-network routing profiles

--- a/src/request_record.rs
+++ b/src/request_record.rs
@@ -1,0 +1,622 @@
+//! Request record management: retention policies (#679) and export/archival (#680).
+//!
+//! This module provides:
+//! - [`RequestRetentionPolicy`]: configurable rules for how long request records
+//!   are kept and the maximum number to retain.
+//! - [`RequestRecord`]: a structured record of a request/transaction event
+//!   suitable for off-system archival.
+//! - [`RequestRecordStore`]: an in-memory store (host-side) that enforces the
+//!   retention policy and supports paginated batch export.
+//!
+//! ## Retention policy (#679)
+//!
+//! Operators configure a [`RequestRetentionPolicy`] with:
+//! - `max_records`: hard cap on the number of records retained (0 = unlimited).
+//! - `max_age_seconds`: maximum age in seconds; older records are pruned (0 = no age limit).
+//! - `prune_on_write`: when `true`, the policy is enforced on every [`RequestRecordStore::push`].
+//!
+//! ## Export and archival (#680)
+//!
+//! [`RequestRecordStore::export_batch`] returns a window of records by cursor
+//! position. Callers iterate through all records by advancing the cursor until
+//! `ExportBatch::has_more` is `false`, then write the batches to off-system
+//! storage (S3, a database, etc.).
+//!
+//! [`RequestRecordStore::archive_before`] moves records older than a given
+//! timestamp out of the active store into a separate archive `Vec` so they are
+//! no longer included in normal queries but remain available for inspection or
+//! final export before deletion.
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
+
+// ---------------------------------------------------------------------------
+// RequestRetentionPolicy (#679)
+// ---------------------------------------------------------------------------
+
+/// Configurable retention policy for request records.
+///
+/// # Fields
+///
+/// - `max_records`: maximum number of records to keep.  `0` means no limit.
+/// - `max_age_seconds`: discard records older than this many seconds.  `0` means no limit.
+/// - `prune_on_write`: when `true`, [`RequestRecordStore::push`] enforces the
+///   policy immediately after inserting the new record.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::request_record::RequestRetentionPolicy;
+///
+/// // Keep at most 1 000 records; no age-based pruning; enforce on every write.
+/// let policy = RequestRetentionPolicy::new(1_000, 0, true);
+/// assert_eq!(policy.max_records, 1_000);
+/// assert!(!policy.has_age_limit());
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct RequestRetentionPolicy {
+    /// Maximum number of records to keep (0 = unlimited).
+    pub max_records: usize,
+    /// Maximum age in seconds for a record (0 = no age limit).
+    pub max_age_seconds: u64,
+    /// Enforce policy automatically on each `push` call.
+    pub prune_on_write: bool,
+}
+
+impl RequestRetentionPolicy {
+    /// Create a new retention policy.
+    pub fn new(max_records: usize, max_age_seconds: u64, prune_on_write: bool) -> Self {
+        Self { max_records, max_age_seconds, prune_on_write }
+    }
+
+    /// Returns `true` when an age-based limit is configured.
+    pub fn has_age_limit(&self) -> bool {
+        self.max_age_seconds > 0
+    }
+
+    /// Returns `true` when a record-count limit is configured.
+    pub fn has_record_limit(&self) -> bool {
+        self.max_records > 0
+    }
+}
+
+impl Default for RequestRetentionPolicy {
+    fn default() -> Self {
+        // Sensible default: keep 10 000 records, no age pruning, enforce on write.
+        Self::new(10_000, 0, true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RequestRecord
+// ---------------------------------------------------------------------------
+
+/// A single request record eligible for retention management and archival.
+///
+/// Records are produced by higher-level callers (e.g. the host boundary replay
+/// prevention layer or the transaction state tracker) and pushed into a
+/// [`RequestRecordStore`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct RequestRecord {
+    /// Unique identifier for this record (e.g. the transaction ID).
+    pub id: u64,
+    /// Unix timestamp (seconds) when the request was received.
+    pub timestamp: u64,
+    /// Human-readable label for the operation (e.g. `"attest"`, `"quote"`).
+    pub operation: String,
+    /// The Stellar address that submitted the request.
+    pub actor: String,
+    /// Outcome tag: `"accepted"`, `"rejected"`, `"replayed"`, etc.
+    pub outcome: String,
+    /// Optional free-form detail (error message, routing reason, …).
+    pub detail: Option<String>,
+}
+
+impl RequestRecord {
+    /// Construct a new record.
+    pub fn new(
+        id: u64,
+        timestamp: u64,
+        operation: impl Into<String>,
+        actor: impl Into<String>,
+        outcome: impl Into<String>,
+        detail: Option<impl Into<String>>,
+    ) -> Self {
+        Self {
+            id,
+            timestamp,
+            operation: operation.into(),
+            actor: actor.into(),
+            outcome: outcome.into(),
+            detail: detail.map(Into::into),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExportBatch (#680)
+// ---------------------------------------------------------------------------
+
+/// A paginated batch of [`RequestRecord`]s returned by
+/// [`RequestRecordStore::export_batch`].
+#[derive(Clone, Debug)]
+pub struct ExportBatch {
+    /// The records in this batch.
+    pub records: Vec<RequestRecord>,
+    /// Cursor value to pass as `start_cursor` in the next call.
+    /// Meaningless when `has_more` is `false`.
+    pub next_cursor: usize,
+    /// `true` when there are more records beyond this batch.
+    pub has_more: bool,
+}
+
+// ---------------------------------------------------------------------------
+// RequestRecordStore
+// ---------------------------------------------------------------------------
+
+/// Host-side store for request records with retention and export support.
+///
+/// Combines:
+/// - An active record buffer (`records`) subject to the [`RequestRetentionPolicy`].
+/// - An archive buffer (`archive`) holding records moved out by
+///   [`archive_before`](Self::archive_before).
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::request_record::{RequestRecord, RequestRecordStore, RequestRetentionPolicy};
+///
+/// let policy = RequestRetentionPolicy::new(5, 0, true);
+/// let mut store = RequestRecordStore::new(policy);
+///
+/// for i in 0..10_u64 {
+///     store.push(RequestRecord::new(i, 1_000 + i, "attest", "GXXX", "accepted", None::<&str>));
+/// }
+/// // Only 5 most-recent records are kept.
+/// assert_eq!(store.len(), 5);
+/// ```
+#[derive(Debug, Default)]
+pub struct RequestRecordStore {
+    /// Active records, ordered by insertion (oldest first).
+    records: Vec<RequestRecord>,
+    /// Archived records (moved out by `archive_before`).
+    archive: Vec<RequestRecord>,
+    /// The active retention policy.
+    pub policy: RequestRetentionPolicy,
+}
+
+impl RequestRecordStore {
+    /// Create a new store with the given retention policy.
+    pub fn new(policy: RequestRetentionPolicy) -> Self {
+        Self { records: Vec::new(), archive: Vec::new(), policy }
+    }
+
+    /// Push a new record into the store.
+    ///
+    /// If `policy.prune_on_write` is `true`, the retention policy is enforced
+    /// immediately after insertion.
+    pub fn push(&mut self, record: RequestRecord) {
+        self.records.push(record);
+        if self.policy.prune_on_write {
+            self.enforce_policy(0);
+        }
+    }
+
+    /// Enforce the retention policy against the active record buffer.
+    ///
+    /// `now_secs` is the current Unix timestamp used for age-based pruning.
+    /// Pass `0` to skip age-based pruning regardless of the policy setting.
+    ///
+    /// Returns the number of records removed.
+    pub fn enforce_policy(&mut self, now_secs: u64) -> usize {
+        let before = self.records.len();
+
+        // Age-based pruning (oldest first).
+        if self.policy.has_age_limit() && now_secs > 0 {
+            let cutoff = now_secs.saturating_sub(self.policy.max_age_seconds);
+            self.records.retain(|r| r.timestamp >= cutoff);
+        }
+
+        // Record-count cap: drop oldest records when over limit.
+        if self.policy.has_record_limit() {
+            let limit = self.policy.max_records;
+            while self.records.len() > limit {
+                self.records.remove(0);
+            }
+        }
+
+        before.saturating_sub(self.records.len())
+    }
+
+    /// Update the retention policy and immediately apply it.
+    ///
+    /// `now_secs` is used for age-based pruning (pass `0` to skip).
+    pub fn set_policy(&mut self, policy: RequestRetentionPolicy, now_secs: u64) {
+        self.policy = policy;
+        self.enforce_policy(now_secs);
+    }
+
+    /// Return the number of active (non-archived) records.
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Return `true` when the active record buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Return the number of archived records.
+    pub fn archive_len(&self) -> usize {
+        self.archive.len()
+    }
+
+    // ── Export / archival (#680) ─────────────────────────────────────────────
+
+    /// Export a paginated batch of active records starting at `start_cursor`.
+    ///
+    /// `batch_size` is capped at 100 to prevent unbounded allocations.
+    ///
+    /// # Arguments
+    ///
+    /// * `start_cursor` – Zero-based index into the active record buffer.
+    /// * `batch_size`   – Maximum number of records per batch (capped at 100).
+    ///
+    /// # Returns
+    ///
+    /// An [`ExportBatch`] with the records and a cursor for the next call.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use anchorkit::request_record::{RequestRecord, RequestRecordStore, RequestRetentionPolicy};
+    ///
+    /// let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+    /// for i in 0..25_u64 {
+    ///     store.push(RequestRecord::new(i, 1_000 + i, "attest", "GXXX", "accepted", None::<&str>));
+    /// }
+    ///
+    /// let batch = store.export_batch(0, 10);
+    /// assert_eq!(batch.records.len(), 10);
+    /// assert!(batch.has_more);
+    ///
+    /// let last = store.export_batch(batch.next_cursor, 10);
+    /// assert_eq!(last.records.len(), 10);
+    /// assert!(last.has_more);
+    ///
+    /// let tail = store.export_batch(last.next_cursor, 10);
+    /// assert_eq!(tail.records.len(), 5);
+    /// assert!(!tail.has_more);
+    /// ```
+    pub fn export_batch(&self, start_cursor: usize, batch_size: usize) -> ExportBatch {
+        const MAX_BATCH: usize = 100;
+        let effective_size = batch_size.min(MAX_BATCH);
+
+        if start_cursor >= self.records.len() {
+            return ExportBatch {
+                records: Vec::new(),
+                next_cursor: start_cursor,
+                has_more: false,
+            };
+        }
+
+        let end = (start_cursor + effective_size).min(self.records.len());
+        let records = self.records[start_cursor..end].to_vec();
+        let next_cursor = end;
+        let has_more = next_cursor < self.records.len();
+
+        ExportBatch { records, next_cursor, has_more }
+    }
+
+    /// Export all active records in a single allocation (no pagination).
+    ///
+    /// Suitable for small stores where a single snapshot is acceptable.
+    pub fn export_all(&self) -> Vec<RequestRecord> {
+        self.records.clone()
+    }
+
+    /// Move all active records whose `timestamp < cutoff_secs` into the
+    /// archive buffer.
+    ///
+    /// Archived records are no longer included in [`len`](Self::len),
+    /// [`export_batch`](Self::export_batch), or [`export_all`](Self::export_all).
+    /// They remain accessible via [`archive_export`](Self::archive_export).
+    ///
+    /// Returns the number of records archived.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use anchorkit::request_record::{RequestRecord, RequestRecordStore, RequestRetentionPolicy};
+    ///
+    /// let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+    /// store.push(RequestRecord::new(1, 1_000, "attest", "GXXX", "accepted", None::<&str>));
+    /// store.push(RequestRecord::new(2, 2_000, "attest", "GXXX", "accepted", None::<&str>));
+    /// store.push(RequestRecord::new(3, 3_000, "attest", "GXXX", "accepted", None::<&str>));
+    ///
+    /// let archived = store.archive_before(2_500);
+    /// assert_eq!(archived, 2);
+    /// assert_eq!(store.len(), 1);
+    /// assert_eq!(store.archive_len(), 2);
+    /// ```
+    pub fn archive_before(&mut self, cutoff_secs: u64) -> usize {
+        let mut to_archive: Vec<RequestRecord> = Vec::new();
+        let mut remaining: Vec<RequestRecord> = Vec::new();
+
+        for record in self.records.drain(..) {
+            if record.timestamp < cutoff_secs {
+                to_archive.push(record);
+            } else {
+                remaining.push(record);
+            }
+        }
+
+        let count = to_archive.len();
+        self.archive.extend(to_archive);
+        self.records = remaining;
+        count
+    }
+
+    /// Export a paginated batch from the archive buffer.
+    ///
+    /// Same pagination contract as [`export_batch`](Self::export_batch).
+    pub fn archive_export(&self, start_cursor: usize, batch_size: usize) -> ExportBatch {
+        const MAX_BATCH: usize = 100;
+        let effective_size = batch_size.min(MAX_BATCH);
+
+        if start_cursor >= self.archive.len() {
+            return ExportBatch {
+                records: Vec::new(),
+                next_cursor: start_cursor,
+                has_more: false,
+            };
+        }
+
+        let end = (start_cursor + effective_size).min(self.archive.len());
+        let records = self.archive[start_cursor..end].to_vec();
+        let next_cursor = end;
+        let has_more = next_cursor < self.archive.len();
+
+        ExportBatch { records, next_cursor, has_more }
+    }
+
+    /// Drain and discard all archived records.
+    ///
+    /// Call this after a successful off-system write to reclaim memory.
+    /// Returns the number of records discarded.
+    pub fn clear_archive(&mut self) -> usize {
+        let count = self.archive.len();
+        self.archive.clear();
+        count
+    }
+
+    /// Look up a single active record by its `id` field.
+    pub fn get_by_id(&self, id: u64) -> Option<&RequestRecord> {
+        self.records.iter().find(|r| r.id == id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_record(id: u64, ts: u64) -> RequestRecord {
+        RequestRecord::new(id, ts, "attest", "GXXX", "accepted", None::<&str>)
+    }
+
+    // ── RetentionPolicy ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_policy_default_has_record_limit() {
+        let p = RequestRetentionPolicy::default();
+        assert!(p.has_record_limit());
+        assert!(!p.has_age_limit());
+        assert!(p.prune_on_write);
+    }
+
+    #[test]
+    fn test_policy_unlimited_no_limits() {
+        let p = RequestRetentionPolicy::new(0, 0, false);
+        assert!(!p.has_record_limit());
+        assert!(!p.has_age_limit());
+    }
+
+    // ── push + enforce_policy (record cap) ─────────────────────────────────
+
+    #[test]
+    fn test_push_enforces_record_cap() {
+        let policy = RequestRetentionPolicy::new(3, 0, true);
+        let mut store = RequestRecordStore::new(policy);
+        for i in 0..5_u64 {
+            store.push(make_record(i, 1_000 + i));
+        }
+        // Only the 3 most-recent records should remain.
+        assert_eq!(store.len(), 3);
+        assert_eq!(store.records[0].id, 2);
+        assert_eq!(store.records[2].id, 4);
+    }
+
+    #[test]
+    fn test_push_no_cap_unlimited() {
+        let policy = RequestRetentionPolicy::new(0, 0, true);
+        let mut store = RequestRecordStore::new(policy);
+        for i in 0..50_u64 {
+            store.push(make_record(i, i));
+        }
+        assert_eq!(store.len(), 50);
+    }
+
+    // ── enforce_policy (age-based) ───────────────────────────────────────────
+
+    #[test]
+    fn test_enforce_policy_age_prunes_old_records() {
+        let policy = RequestRetentionPolicy::new(0, 100, false);
+        let mut store = RequestRecordStore::new(policy);
+        store.records.push(make_record(1, 900));  // old
+        store.records.push(make_record(2, 950));  // old
+        store.records.push(make_record(3, 1_050)); // recent
+
+        let removed = store.enforce_policy(1_050);
+        assert_eq!(removed, 2);
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.records[0].id, 3);
+    }
+
+    #[test]
+    fn test_enforce_policy_age_zero_skips_pruning() {
+        let policy = RequestRetentionPolicy::new(0, 100, false);
+        let mut store = RequestRecordStore::new(policy);
+        store.records.push(make_record(1, 100));
+        // now_secs = 0 → skip age pruning
+        let removed = store.enforce_policy(0);
+        assert_eq!(removed, 0);
+        assert_eq!(store.len(), 1);
+    }
+
+    // ── set_policy ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_policy_applies_immediately() {
+        let policy = RequestRetentionPolicy::new(0, 0, false);
+        let mut store = RequestRecordStore::new(policy);
+        for i in 0..20_u64 {
+            store.records.push(make_record(i, i));
+        }
+        assert_eq!(store.len(), 20);
+
+        store.set_policy(RequestRetentionPolicy::new(5, 0, true), 0);
+        assert_eq!(store.len(), 5);
+    }
+
+    // ── export_batch ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_export_batch_first_page() {
+        let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        for i in 0..25_u64 {
+            store.records.push(make_record(i, i));
+        }
+
+        let batch = store.export_batch(0, 10);
+        assert_eq!(batch.records.len(), 10);
+        assert_eq!(batch.next_cursor, 10);
+        assert!(batch.has_more);
+    }
+
+    #[test]
+    fn test_export_batch_last_page() {
+        let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        for i in 0..25_u64 {
+            store.records.push(make_record(i, i));
+        }
+
+        let batch = store.export_batch(20, 10);
+        assert_eq!(batch.records.len(), 5);
+        assert!(!batch.has_more);
+    }
+
+    #[test]
+    fn test_export_batch_beyond_end_returns_empty() {
+        let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        store.records.push(make_record(1, 1));
+
+        let batch = store.export_batch(100, 10);
+        assert!(batch.records.is_empty());
+        assert!(!batch.has_more);
+    }
+
+    #[test]
+    fn test_export_batch_capped_at_100() {
+        let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        for i in 0..200_u64 {
+            store.records.push(make_record(i, i));
+        }
+
+        let batch = store.export_batch(0, 200);
+        assert_eq!(batch.records.len(), 100);
+    }
+
+    #[test]
+    fn test_export_all_returns_full_copy() {
+        let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        for i in 0..10_u64 {
+            store.records.push(make_record(i, i));
+        }
+        let all = store.export_all();
+        assert_eq!(all.len(), 10);
+    }
+
+    // ── archive_before ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_archive_before_moves_old_records() {
+        let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        store.records.push(make_record(1, 1_000));
+        store.records.push(make_record(2, 2_000));
+        store.records.push(make_record(3, 3_000));
+
+        let archived = store.archive_before(2_500);
+        assert_eq!(archived, 2);
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.archive_len(), 2);
+    }
+
+    #[test]
+    fn test_archive_before_nothing_to_archive() {
+        let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        store.records.push(make_record(1, 5_000));
+
+        let archived = store.archive_before(1_000);
+        assert_eq!(archived, 0);
+        assert_eq!(store.len(), 1);
+        assert_eq!(store.archive_len(), 0);
+    }
+
+    #[test]
+    fn test_archive_export_paginates() {
+        let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        for i in 0..15_u64 {
+            store.archive.push(make_record(i, i));
+        }
+
+        let batch = store.archive_export(0, 10);
+        assert_eq!(batch.records.len(), 10);
+        assert!(batch.has_more);
+
+        let tail = store.archive_export(batch.next_cursor, 10);
+        assert_eq!(tail.records.len(), 5);
+        assert!(!tail.has_more);
+    }
+
+    #[test]
+    fn test_clear_archive() {
+        let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        store.archive.push(make_record(1, 1));
+        store.archive.push(make_record(2, 2));
+
+        let cleared = store.clear_archive();
+        assert_eq!(cleared, 2);
+        assert_eq!(store.archive_len(), 0);
+    }
+
+    // ── get_by_id ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_by_id_found() {
+        let mut store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        store.records.push(make_record(42, 1_000));
+        let rec = store.get_by_id(42).unwrap();
+        assert_eq!(rec.id, 42);
+    }
+
+    #[test]
+    fn test_get_by_id_not_found() {
+        let store = RequestRecordStore::new(RequestRetentionPolicy::default());
+        assert!(store.get_by_id(99).is_none());
+    }
+}

--- a/src/transaction_state_tracker.rs
+++ b/src/transaction_state_tracker.rs
@@ -1807,6 +1807,217 @@ impl TransactionStateTracker {
         }
         removed
     }
+
+    // ── Partial recovery (#677) ───────────────────────────────────────────────
+
+    /// Resume a failed transaction from its last known intermediate state.
+    ///
+    /// "Partial recovery" allows a transaction that failed mid-flight to re-enter
+    /// processing from the state it had *before* it failed, rather than requiring
+    /// a full restart from [`Pending`](TransactionState::Pending).
+    ///
+    /// # Behaviour
+    ///
+    /// 1. Looks up the transaction; returns an error if not found or not `Failed`.
+    /// 2. Reads `recovery_metadata.failed_from_state` to determine the resume point.
+    /// 3. Resets the transaction state to `failed_from_state` and appends a
+    ///    `"partial_recovery"` note to the state history.
+    /// 4. Clears `error_message` so downstream callers see a clean slate.
+    /// 5. Increments `retry_count` on the existing [`RecoveryMetadata`].
+    ///
+    /// After calling this method the transaction is back in its intermediate state
+    /// and the normal transition path (e.g. `→ Completed` or `→ Failed` again) can
+    /// proceed.
+    ///
+    /// # Arguments
+    ///
+    /// * `transaction_id` – The ID of the failed transaction to resume.
+    /// * `env`            – The Soroban execution environment.
+    ///
+    /// # Returns
+    ///
+    /// The updated [`TransactionStateRecord`] with the resumed state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `String` error if:
+    /// - the transaction is not found,
+    /// - it is not in the [`Failed`](TransactionState::Failed) state,
+    /// - it has no [`RecoveryMetadata`] (legacy record), or
+    /// - `failed_from_state` is itself a terminal state (should never happen in
+    ///   practice but guarded defensively).
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use soroban_sdk::{Env, String};
+    /// # use soroban_sdk::testutils::Address as _;
+    /// # let env = Env::default();
+    /// # let initiator = soroban_sdk::Address::generate(&env);
+    /// use anchorkit::transaction_state_tracker::{TransactionStateTracker, TransactionState};
+    ///
+    /// let mut tracker = TransactionStateTracker::new(true);
+    /// tracker.create_transaction(1, initiator, &env).unwrap();
+    /// tracker.start_transaction(1, &env).unwrap();
+    /// tracker.fail_transaction(1, String::from_str(&env, "timeout"), &env).unwrap();
+    ///
+    /// // Resume from InProgress (the state before failure).
+    /// let record = tracker.resume_partial_recovery(1, &env).unwrap();
+    /// assert_eq!(record.state, TransactionState::InProgress);
+    /// ```
+    pub fn resume_partial_recovery(
+        &mut self,
+        transaction_id: u64,
+        env: &Env,
+    ) -> Result<TransactionStateRecord, String> {
+        let current_time = env.ledger().timestamp();
+        let current_ledger = env.ledger().sequence();
+
+        if self.is_dev_mode {
+            let pos = self
+                .cache
+                .iter()
+                .position(|r| r.transaction_id == transaction_id)
+                .ok_or_else(|| String::from_str(env, "Transaction not found in cache"))?;
+
+            let record = &self.cache[pos];
+
+            if record.state != TransactionState::Failed {
+                return Err(String::from_str(
+                    env,
+                    "resume_partial_recovery requires a Failed transaction",
+                ));
+            }
+
+            let (resume_state, new_retry_count) = match &record.recovery_metadata {
+                OptRecovery::None => {
+                    return Err(String::from_str(
+                        env,
+                        "Transaction has no recovery metadata; cannot resume",
+                    ));
+                }
+                OptRecovery::Some(meta) => {
+                    let rs = meta.failed_from_state;
+                    if rs.is_terminal() {
+                        return Err(String::from_str(
+                            env,
+                            "failed_from_state is terminal; cannot resume",
+                        ));
+                    }
+                    (rs, meta.retry_count + 1)
+                }
+            };
+
+            let record = &mut self.cache[pos];
+            record.state = resume_state;
+            record.last_updated = current_time;
+            record.last_updated_ledger = current_ledger;
+            record.error_message = None;
+            record.state_history.push_back((resume_state, current_time));
+
+            // Update retry count in recovery metadata.
+            if let OptRecovery::Some(ref mut meta) = record.recovery_metadata {
+                meta.retry_count = new_retry_count;
+            }
+
+            self.audit_log.push(TransitionAuditEntry {
+                transaction_id,
+                from_state: TransactionState::Failed,
+                to_state: resume_state,
+                timestamp: current_time,
+                success: true,
+            });
+
+            Ok(record.clone())
+        } else {
+            let key = (symbol_short!("TXSTATE"), transaction_id);
+            let mut record: TransactionStateRecord = env
+                .storage()
+                .persistent()
+                .get(&key)
+                .ok_or_else(|| String::from_str(env, "Transaction not found"))?;
+
+            if record.state != TransactionState::Failed {
+                return Err(String::from_str(
+                    env,
+                    "resume_partial_recovery requires a Failed transaction",
+                ));
+            }
+
+            let (resume_state, new_retry_count) = match &record.recovery_metadata {
+                OptRecovery::None => {
+                    return Err(String::from_str(
+                        env,
+                        "Transaction has no recovery metadata; cannot resume",
+                    ));
+                }
+                OptRecovery::Some(meta) => {
+                    let rs = meta.failed_from_state;
+                    if rs.is_terminal() {
+                        return Err(String::from_str(
+                            env,
+                            "failed_from_state is terminal; cannot resume",
+                        ));
+                    }
+                    (rs, meta.retry_count + 1)
+                }
+            };
+
+            record.state = resume_state;
+            record.last_updated = current_time;
+            record.last_updated_ledger = current_ledger;
+            record.error_message = None;
+            record.state_history.push_back((resume_state, current_time));
+
+            if let OptRecovery::Some(ref mut meta) = record.recovery_metadata {
+                meta.retry_count = new_retry_count;
+            }
+
+            env.storage().persistent().set(&key, &record);
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TXSTATE_TTL, TXSTATE_TTL);
+
+            Ok(record)
+        }
+    }
+
+    /// Return `true` when the transaction can be partially recovered.
+    ///
+    /// A transaction is partially recoverable when it:
+    /// 1. Exists and is in the [`Failed`](TransactionState::Failed) state.
+    /// 2. Has [`RecoveryMetadata`] with a non-terminal `failed_from_state`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use soroban_sdk::{Env, String};
+    /// # use soroban_sdk::testutils::Address as _;
+    /// # let env = Env::default();
+    /// # let initiator = soroban_sdk::Address::generate(&env);
+    /// use anchorkit::transaction_state_tracker::TransactionStateTracker;
+    ///
+    /// let mut tracker = TransactionStateTracker::new(true);
+    /// tracker.create_transaction(1, initiator, &env).unwrap();
+    /// tracker.start_transaction(1, &env).unwrap();
+    /// tracker.fail_transaction(1, String::from_str(&env, "err"), &env).unwrap();
+    ///
+    /// assert!(tracker.is_partially_recoverable(1, &env).unwrap());
+    /// ```
+    pub fn is_partially_recoverable(
+        &self,
+        transaction_id: u64,
+        env: &Env,
+    ) -> Result<bool, String> {
+        let record = self.get_transaction_state(transaction_id, env)?;
+        Ok(record.map(|r| {
+            r.state == TransactionState::Failed
+                && match &r.recovery_metadata {
+                    OptRecovery::Some(meta) => !meta.failed_from_state.is_terminal(),
+                    OptRecovery::None => false,
+                }
+        }).unwrap_or(false))
+    }
 }
 
 #[cfg(test)]
@@ -2555,5 +2766,153 @@ mod tests {
         assert_eq!(meta.failure_reason, soroban_sdk::String::from_str(&env, "round-trip error"));
         assert_eq!(meta.failed_from_state, TransactionState::InProgress);
         assert_eq!(meta.retry_count, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #677 — partial transaction recovery tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_resume_partial_recovery_from_in_progress() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        tracker.start_transaction(1, &env).unwrap(); // Pending → InProgress
+        tracker.fail_transaction(1, String::from_str(&env, "timeout"), &env).unwrap();
+
+        // Resume from InProgress (the state the transaction was in before failing).
+        let record = tracker.resume_partial_recovery(1, &env).unwrap();
+        assert_eq!(record.state, TransactionState::InProgress);
+        assert!(record.error_message.is_none(), "error_message must be cleared on resume");
+
+        // Retry count should be 1.
+        let meta = record.recovery_metadata.unwrap();
+        assert_eq!(meta.retry_count, 1);
+    }
+
+    #[test]
+    fn test_resume_partial_recovery_from_pending() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        // Fail immediately from Pending (pre-processing failure).
+        tracker.fail_transaction(1, String::from_str(&env, "pre-check failed"), &env).unwrap();
+
+        let record = tracker.resume_partial_recovery(1, &env).unwrap();
+        assert_eq!(record.state, TransactionState::Pending);
+    }
+
+    #[test]
+    fn test_resume_partial_recovery_then_complete() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        tracker.start_transaction(1, &env).unwrap();
+        tracker.fail_transaction(1, String::from_str(&env, "err"), &env).unwrap();
+        tracker.resume_partial_recovery(1, &env).unwrap();
+
+        // After resuming to InProgress, completing should succeed.
+        let record = tracker.complete_transaction(1, &env).unwrap();
+        assert_eq!(record.state, TransactionState::Completed);
+    }
+
+    #[test]
+    fn test_resume_partial_recovery_increments_retry_count_on_repeated_failures() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        tracker.start_transaction(1, &env).unwrap();
+
+        for expected_retry in 1..=3u32 {
+            tracker.fail_transaction(1, String::from_str(&env, "err"), &env).unwrap();
+            let record = tracker.resume_partial_recovery(1, &env).unwrap();
+            let meta = record.recovery_metadata.unwrap();
+            assert_eq!(meta.retry_count, expected_retry);
+        }
+    }
+
+    #[test]
+    fn test_resume_partial_recovery_requires_failed_state() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        tracker.start_transaction(1, &env).unwrap();
+        // Transaction is InProgress, not Failed.
+        let result = tracker.resume_partial_recovery(1, &env);
+        assert!(result.is_err(), "resume must fail for non-Failed transactions");
+    }
+
+    #[test]
+    fn test_resume_partial_recovery_missing_transaction_returns_error() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let result = tracker.resume_partial_recovery(99, &env);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_is_partially_recoverable_true_for_failed_with_metadata() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        tracker.start_transaction(1, &env).unwrap();
+        tracker.fail_transaction(1, String::from_str(&env, "err"), &env).unwrap();
+
+        assert!(tracker.is_partially_recoverable(1, &env).unwrap());
+    }
+
+    #[test]
+    fn test_is_partially_recoverable_false_for_pending() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        assert!(!tracker.is_partially_recoverable(1, &env).unwrap());
+    }
+
+    #[test]
+    fn test_is_partially_recoverable_false_for_completed() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        tracker.start_transaction(1, &env).unwrap();
+        tracker.complete_transaction(1, &env).unwrap();
+
+        assert!(!tracker.is_partially_recoverable(1, &env).unwrap());
+    }
+
+    #[test]
+    fn test_resume_partial_recovery_audit_log_entry() {
+        let env = Env::default();
+        let mut tracker = TransactionStateTracker::new(true);
+        let initiator = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+
+        tracker.create_transaction(1, initiator, &env).unwrap();
+        tracker.start_transaction(1, &env).unwrap();
+        tracker.fail_transaction(1, String::from_str(&env, "err"), &env).unwrap();
+
+        let audit_before = tracker.audit_log.len();
+        tracker.resume_partial_recovery(1, &env).unwrap();
+
+        assert_eq!(tracker.audit_log.len(), audit_before + 1);
+        let last = tracker.audit_log.last().unwrap();
+        assert_eq!(last.from_state, TransactionState::Failed);
+        assert_eq!(last.to_state, TransactionState::InProgress);
+        assert!(last.success);
     }
 }


### PR DESCRIPTION
## Summary

This PR resolves four related issues improving transaction lifecycle management, operational security, and record observability for SorobanAnchor.

---

### Closes #677 - Add support for partial transaction recovery

Extends `TransactionStateTracker` with:

- `resume_partial_recovery(transaction_id, env)` - resets a `Failed` transaction back to the state it occupied before failing (`Pending` or `InProgress`), clears the error message, and increments retry count. Processing resumes from a known checkpoint instead of restarting from scratch.
- `is_partially_recoverable(transaction_id, env)` - returns `true` when a transaction is `Failed` with valid recovery metadata pointing to a non-terminal prior state.

An audit log entry is recorded for every resume. Tests cover multi-retry cycles, post-resume completion, and error cases.

---

### Closes #678 - Add transaction replay prevention at the host boundary

New `host_replay_prevention` module with `HostReplayGuard`, a sliding-window dedup guard that runs **before** any business logic:

- Returns `CheckResult::Accepted` for new IDs and `CheckResult::Replay { first_seen_at }` for duplicates.
- Lazily prunes expired entries on every `check()` to keep memory bounded.
- Exposes `is_known()`, `forget()`, `reset()`, and accepted/replayed counters.
- Complements the existing on-chain `replay_detection` module.

---

### Closes #679 - Add data retention policies for request records

New `request_record` module with `RequestRetentionPolicy`:

- Configurable `max_records` and `max_age_seconds`, both independently optional.
- `prune_on_write` flag enforces policy on every insert.
- `set_policy()` applies changes immediately.
- `enforce_policy(now_secs)` for on-demand sweeps.

---

### Closes #680 - Add support for request record export and archival

Extends `RequestRecordStore` with:

- `export_batch(start_cursor, batch_size)` - paginated export, capped at 100 per batch.
- `export_all()` - full snapshot.
- `archive_before(cutoff_secs)` - moves old records into a separate archive buffer.
- `archive_export()` - paginated archive reads.
- `clear_archive()` - drains archive after confirmed off-system write.

---

## Files changed

- `src/transaction_state_tracker.rs` - partial recovery methods + tests (#677)
- `src/host_replay_prevention.rs` - new module, host-boundary replay guard (#678)
- `src/request_record.rs` - new module, retention policies + export/archival (#679 #680)
- `src/lib.rs` - module registration and feature-gated exports