### PR TITLE
feat: add tx archive, compaction, artifact provenance, and deployment…

### DIFF
--- a/src/artifact_provenance.rs
+++ b/src/artifact_provenance.rs
@@ -1,0 +1,496 @@
+//! Artifact provenance tracking for release artifacts (issue #674).
+//!
+//! Release artifacts should be traceable to their build inputs and environment
+//! for trust and compliance. This module records and verifies the origin,
+//! build command, source revision, and environment for each artifact so the
+//! full provenance chain is available for audit.
+//!
+//! ## Design
+//!
+//! - [`ArtifactProvenance`] is the canonical provenance record for a single
+//!   release artifact.
+//! - [`ProvenanceStore`] manages an in-memory collection of provenance records
+//!   and supports lookup by artifact name or content hash.
+//! - [`ProvenanceVerifier`] checks a given record against expected values and
+//!   returns a detailed [`VerificationReport`].
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
+
+use crate::errors::{AnchorKitError, ErrorCode};
+
+// ---------------------------------------------------------------------------
+// Core provenance record
+// ---------------------------------------------------------------------------
+
+/// Provenance record for a single release artifact.
+///
+/// Every field that could be unknown at record time is `Option<String>` so
+/// callers can attach partial provenance and fill in remaining fields later
+/// via [`ProvenanceStore::update`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct ArtifactProvenance {
+    /// Unique identifier for this provenance record (monotonically increasing).
+    pub provenance_id: u64,
+    /// Name of the artifact (e.g. `"anchorkit-0.1.0-wasm32.wasm"`).
+    pub artifact_name: String,
+    /// Hex-encoded SHA-256 content hash of the artifact file.
+    pub content_hash: String,
+    /// Source control revision (e.g. a Git commit SHA).
+    pub source_revision: Option<String>,
+    /// Source repository URI.
+    pub source_repository: Option<String>,
+    /// Exact build command used to produce the artifact
+    /// (e.g. `"cargo build --release --target wasm32-unknown-unknown"`).
+    pub build_command: Option<String>,
+    /// Key/value pairs describing the build environment
+    /// (e.g. `rustc` version, OS, CI job ID).
+    pub build_env: Vec<(String, String)>,
+    /// Unix timestamp when this record was created.
+    pub recorded_at: u64,
+    /// Optional signature over the content hash for non-repudiation.
+    pub signature: Option<String>,
+}
+
+impl ArtifactProvenance {
+    /// Returns `true` when all required audit fields are populated.
+    ///
+    /// Required for a provenance record to be considered "complete" for
+    /// compliance purposes: `source_revision`, `source_repository`, and
+    /// `build_command` must all be `Some`.
+    pub fn is_complete(&self) -> bool {
+        self.source_revision.is_some()
+            && self.source_repository.is_some()
+            && self.build_command.is_some()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Verification
+// ---------------------------------------------------------------------------
+
+/// Result of a single field comparison in a provenance verification.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FieldVerdict {
+    /// Field matched the expected value.
+    Match,
+    /// Field did not match: `(expected, actual)`.
+    Mismatch(String, String),
+    /// Expected value was provided but the field is absent in the record.
+    Missing,
+    /// Field was not checked (no expected value was supplied).
+    NotChecked,
+}
+
+/// Detailed report produced by [`ProvenanceVerifier::verify`].
+#[derive(Clone, Debug)]
+pub struct VerificationReport {
+    /// Provenance record ID that was verified.
+    pub provenance_id: u64,
+    /// Artifact name from the record.
+    pub artifact_name: String,
+    /// Verdict for the content hash field.
+    pub content_hash: FieldVerdict,
+    /// Verdict for the source revision field.
+    pub source_revision: FieldVerdict,
+    /// Verdict for the build command field.
+    pub build_command: FieldVerdict,
+    /// `true` when all checked fields passed.
+    pub passed: bool,
+}
+
+/// Builder-style verifier for a [`ArtifactProvenance`] record.
+///
+/// Supply expected values for whichever fields you care about; unset fields
+/// are reported as [`FieldVerdict::NotChecked`].
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::artifact_provenance::{ArtifactProvenance, ProvenanceVerifier};
+///
+/// let record = ArtifactProvenance {
+///     provenance_id: 0,
+///     artifact_name: "anchorkit.wasm".into(),
+///     content_hash: "abc123".into(),
+///     source_revision: Some("deadbeef".into()),
+///     source_repository: Some("https://github.com/org/repo".into()),
+///     build_command: Some("cargo build --release".into()),
+///     build_env: vec![],
+///     recorded_at: 1000,
+///     signature: None,
+/// };
+///
+/// let report = ProvenanceVerifier::new(&record)
+///     .expect_content_hash("abc123")
+///     .expect_source_revision("deadbeef")
+///     .verify();
+///
+/// assert!(report.passed);
+/// ```
+pub struct ProvenanceVerifier<'a> {
+    record: &'a ArtifactProvenance,
+    expected_hash: Option<&'a str>,
+    expected_revision: Option<&'a str>,
+    expected_build_command: Option<&'a str>,
+}
+
+impl<'a> ProvenanceVerifier<'a> {
+    /// Create a new verifier for `record`.
+    pub fn new(record: &'a ArtifactProvenance) -> Self {
+        Self {
+            record,
+            expected_hash: None,
+            expected_revision: None,
+            expected_build_command: None,
+        }
+    }
+
+    /// Set the expected content hash.
+    pub fn expect_content_hash(mut self, hash: &'a str) -> Self {
+        self.expected_hash = Some(hash);
+        self
+    }
+
+    /// Set the expected source revision.
+    pub fn expect_source_revision(mut self, rev: &'a str) -> Self {
+        self.expected_revision = Some(rev);
+        self
+    }
+
+    /// Set the expected build command.
+    pub fn expect_build_command(mut self, cmd: &'a str) -> Self {
+        self.expected_build_command = Some(cmd);
+        self
+    }
+
+    /// Run the verification and return a [`VerificationReport`].
+    pub fn verify(self) -> VerificationReport {
+        let hash_verdict = check_field(
+            self.expected_hash,
+            Some(self.record.content_hash.as_str()),
+        );
+        let rev_verdict = check_field(
+            self.expected_revision,
+            self.record.source_revision.as_deref(),
+        );
+        let cmd_verdict = check_field(
+            self.expected_build_command,
+            self.record.build_command.as_deref(),
+        );
+
+        let passed = is_passing(&hash_verdict)
+            && is_passing(&rev_verdict)
+            && is_passing(&cmd_verdict);
+
+        VerificationReport {
+            provenance_id: self.record.provenance_id,
+            artifact_name: self.record.artifact_name.clone(),
+            content_hash: hash_verdict,
+            source_revision: rev_verdict,
+            build_command: cmd_verdict,
+            passed,
+        }
+    }
+}
+
+fn check_field(expected: Option<&str>, actual: Option<&str>) -> FieldVerdict {
+    match (expected, actual) {
+        (None, _) => FieldVerdict::NotChecked,
+        (Some(exp), None) => FieldVerdict::Missing,
+        (Some(exp), Some(act)) => {
+            if exp == act {
+                FieldVerdict::Match
+            } else {
+                FieldVerdict::Mismatch(exp.into(), act.into())
+            }
+        }
+    }
+}
+
+fn is_passing(v: &FieldVerdict) -> bool {
+    matches!(v, FieldVerdict::Match | FieldVerdict::NotChecked)
+}
+
+// ---------------------------------------------------------------------------
+// Provenance store
+// ---------------------------------------------------------------------------
+
+/// Manages a collection of [`ArtifactProvenance`] records.
+pub struct ProvenanceStore {
+    records: Vec<ArtifactProvenance>,
+    next_id: u64,
+}
+
+impl ProvenanceStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self {
+            records: Vec::new(),
+            next_id: 0,
+        }
+    }
+
+    /// Record provenance for a new artifact.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnchorKitError`] with [`ErrorCode::ValidationError`] when
+    /// `artifact_name` or `content_hash` is empty.
+    pub fn record(
+        &mut self,
+        artifact_name: String,
+        content_hash: String,
+        recorded_at: u64,
+    ) -> Result<&ArtifactProvenance, AnchorKitError> {
+        if artifact_name.is_empty() {
+            return Err(AnchorKitError::validation_error("artifact_name must not be empty"));
+        }
+        if content_hash.is_empty() {
+            return Err(AnchorKitError::validation_error("content_hash must not be empty"));
+        }
+
+        let provenance = ArtifactProvenance {
+            provenance_id: self.next_id,
+            artifact_name,
+            content_hash,
+            source_revision: None,
+            source_repository: None,
+            build_command: None,
+            build_env: Vec::new(),
+            recorded_at,
+            signature: None,
+        };
+
+        self.next_id += 1;
+        self.records.push(provenance);
+        Ok(self.records.last().unwrap())
+    }
+
+    /// Update fields on an existing provenance record.
+    ///
+    /// Only `Some` fields in the update closure are applied; `None` leaves
+    /// the current value unchanged.
+    pub fn update(
+        &mut self,
+        provenance_id: u64,
+        source_revision: Option<String>,
+        source_repository: Option<String>,
+        build_command: Option<String>,
+        build_env: Option<Vec<(String, String)>>,
+        signature: Option<String>,
+    ) -> Result<(), AnchorKitError> {
+        let record = self
+            .records
+            .iter_mut()
+            .find(|r| r.provenance_id == provenance_id)
+            .ok_or_else(|| AnchorKitError::new(ErrorCode::TransactionNotFound, "provenance record not found"))?;
+
+        if let Some(v) = source_revision { record.source_revision = Some(v); }
+        if let Some(v) = source_repository { record.source_repository = Some(v); }
+        if let Some(v) = build_command { record.build_command = Some(v); }
+        if let Some(v) = build_env { record.build_env = v; }
+        if let Some(v) = signature { record.signature = Some(v); }
+
+        Ok(())
+    }
+
+    /// Look up a provenance record by its ID.
+    pub fn get_by_id(&self, provenance_id: u64) -> Option<&ArtifactProvenance> {
+        self.records.iter().find(|r| r.provenance_id == provenance_id)
+    }
+
+    /// Look up all provenance records for an artifact name.
+    pub fn get_by_name(&self, artifact_name: &str) -> Vec<&ArtifactProvenance> {
+        self.records
+            .iter()
+            .filter(|r| r.artifact_name == artifact_name)
+            .collect()
+    }
+
+    /// Look up a provenance record by its content hash.
+    pub fn get_by_hash(&self, content_hash: &str) -> Option<&ArtifactProvenance> {
+        self.records.iter().find(|r| r.content_hash == content_hash)
+    }
+
+    /// Total number of recorded provenance entries.
+    pub fn count(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Return all records, oldest first.
+    pub fn list(&self) -> &[ArtifactProvenance] {
+        &self.records
+    }
+}
+
+impl Default for ProvenanceStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_empty_name_rejected() {
+        let mut store = ProvenanceStore::new();
+        let err = store.record("".into(), "abc".into(), 0).unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValidationError);
+    }
+
+    #[test]
+    fn record_empty_hash_rejected() {
+        let mut store = ProvenanceStore::new();
+        let err = store.record("artifact.wasm".into(), "".into(), 0).unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValidationError);
+    }
+
+    #[test]
+    fn record_creates_entry_with_correct_fields() {
+        let mut store = ProvenanceStore::new();
+        let p = store.record("a.wasm".into(), "hash1".into(), 1000).unwrap();
+        assert_eq!(p.provenance_id, 0);
+        assert_eq!(p.artifact_name, "a.wasm");
+        assert_eq!(p.content_hash, "hash1");
+        assert_eq!(p.recorded_at, 1000);
+        assert!(!p.is_complete());
+    }
+
+    #[test]
+    fn update_populates_optional_fields() {
+        let mut store = ProvenanceStore::new();
+        store.record("a.wasm".into(), "h1".into(), 0).unwrap();
+        store
+            .update(
+                0,
+                Some("abc123".into()),
+                Some("https://github.com/org/repo".into()),
+                Some("cargo build --release".into()),
+                Some(vec![("rustc".into(), "1.80.0".into())]),
+                None,
+            )
+            .unwrap();
+        let p = store.get_by_id(0).unwrap();
+        assert!(p.is_complete());
+        assert_eq!(p.source_revision.as_deref(), Some("abc123"));
+        assert_eq!(p.build_env[0].0, "rustc");
+    }
+
+    #[test]
+    fn update_unknown_id_returns_error() {
+        let mut store = ProvenanceStore::new();
+        let err = store.update(99, None, None, None, None, None).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TransactionNotFound);
+    }
+
+    #[test]
+    fn get_by_hash_finds_correct_record() {
+        let mut store = ProvenanceStore::new();
+        store.record("a.wasm".into(), "h1".into(), 0).unwrap();
+        store.record("b.wasm".into(), "h2".into(), 1).unwrap();
+        let p = store.get_by_hash("h2").unwrap();
+        assert_eq!(p.artifact_name, "b.wasm");
+    }
+
+    #[test]
+    fn get_by_name_returns_all_versions() {
+        let mut store = ProvenanceStore::new();
+        store.record("a.wasm".into(), "h1".into(), 0).unwrap();
+        store.record("a.wasm".into(), "h2".into(), 1).unwrap();
+        store.record("b.wasm".into(), "h3".into(), 2).unwrap();
+        let results = store.get_by_name("a.wasm");
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn verifier_all_match_passes() {
+        let record = ArtifactProvenance {
+            provenance_id: 0,
+            artifact_name: "a.wasm".into(),
+            content_hash: "deadbeef".into(),
+            source_revision: Some("abc123".into()),
+            source_repository: Some("https://github.com/org/repo".into()),
+            build_command: Some("cargo build".into()),
+            build_env: vec![],
+            recorded_at: 0,
+            signature: None,
+        };
+        let report = ProvenanceVerifier::new(&record)
+            .expect_content_hash("deadbeef")
+            .expect_source_revision("abc123")
+            .expect_build_command("cargo build")
+            .verify();
+        assert!(report.passed);
+        assert_eq!(report.content_hash, FieldVerdict::Match);
+    }
+
+    #[test]
+    fn verifier_hash_mismatch_fails() {
+        let record = ArtifactProvenance {
+            provenance_id: 1,
+            artifact_name: "b.wasm".into(),
+            content_hash: "real_hash".into(),
+            source_revision: None,
+            source_repository: None,
+            build_command: None,
+            build_env: vec![],
+            recorded_at: 0,
+            signature: None,
+        };
+        let report = ProvenanceVerifier::new(&record)
+            .expect_content_hash("wrong_hash")
+            .verify();
+        assert!(!report.passed);
+        assert!(matches!(report.content_hash, FieldVerdict::Mismatch(_, _)));
+    }
+
+    #[test]
+    fn verifier_missing_field_fails() {
+        let record = ArtifactProvenance {
+            provenance_id: 2,
+            artifact_name: "c.wasm".into(),
+            content_hash: "h".into(),
+            source_revision: None, // absent
+            source_repository: None,
+            build_command: None,
+            build_env: vec![],
+            recorded_at: 0,
+            signature: None,
+        };
+        let report = ProvenanceVerifier::new(&record)
+            .expect_source_revision("abc")
+            .verify();
+        assert!(!report.passed);
+        assert_eq!(report.source_revision, FieldVerdict::Missing);
+    }
+
+    #[test]
+    fn is_complete_requires_all_three_fields() {
+        let mut p = ArtifactProvenance {
+            provenance_id: 0,
+            artifact_name: "a".into(),
+            content_hash: "h".into(),
+            source_revision: None,
+            source_repository: None,
+            build_command: None,
+            build_env: vec![],
+            recorded_at: 0,
+            signature: None,
+        };
+        assert!(!p.is_complete());
+        p.source_revision = Some("rev".into());
+        assert!(!p.is_complete());
+        p.source_repository = Some("repo".into());
+        assert!(!p.is_complete());
+        p.build_command = Some("cargo build".into());
+        assert!(p.is_complete());
+    }
+}

--- a/src/deployment_drift.rs
+++ b/src/deployment_drift.rs
@@ -1,0 +1,490 @@
+//! Deployment drift detection (issue #673).
+//!
+//! Environments drift over time. This module helps operators catch unexpected
+//! differences between intended and actual deployment state by comparing a
+//! [`DeploymentSpec`] (what you expect) against a [`DeploymentSnapshot`]
+//! (what is actually running) and producing a detailed [`DriftReport`].
+//!
+//! ## Design
+//!
+//! - [`DeploymentSpec`] describes the intended state: contract version,
+//!   network, admin address, and a set of expected config entries.
+//! - [`DeploymentSnapshot`] captures the observed state at a point in time.
+//! - [`detect_drift`] compares the two and returns a [`DriftReport`] listing
+//!   every [`DriftItem`] — fields that are missing, changed, or unexpected.
+//! - [`DriftSeverity`] classifies each drift item so operators can triage
+//!   critical divergences from cosmetic ones.
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
+
+// ---------------------------------------------------------------------------
+// Spec and snapshot types
+// ---------------------------------------------------------------------------
+
+/// A key/value configuration entry in a deployment spec or snapshot.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConfigEntry {
+    pub key: String,
+    pub value: String,
+}
+
+impl ConfigEntry {
+    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { key: key.into(), value: value.into() }
+    }
+}
+
+/// The intended (expected) deployment state for a single environment.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeploymentSpec {
+    /// Human-readable environment name (e.g. `"mainnet"`, `"testnet"`).
+    pub environment: String,
+    /// Expected deployed contract/binary version string.
+    pub expected_version: String,
+    /// Expected Stellar network passphrase or short name.
+    pub expected_network: String,
+    /// Expected admin address.
+    pub expected_admin: Option<String>,
+    /// Expected configuration key/value pairs.
+    pub expected_config: Vec<ConfigEntry>,
+}
+
+/// The observed deployment state captured at a point in time.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeploymentSnapshot {
+    /// Environment this snapshot was taken from.
+    pub environment: String,
+    /// Unix timestamp when the snapshot was captured.
+    pub captured_at: u64,
+    /// Observed deployed version string.
+    pub observed_version: String,
+    /// Observed Stellar network passphrase or short name.
+    pub observed_network: String,
+    /// Observed admin address.
+    pub observed_admin: Option<String>,
+    /// Observed configuration key/value pairs.
+    pub observed_config: Vec<ConfigEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Drift classification
+// ---------------------------------------------------------------------------
+
+/// How severe a detected drift item is.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DriftSeverity {
+    /// The difference is cosmetic or informational (e.g. an extra config key
+    /// not listed in the spec but not dangerous).
+    Low,
+    /// The difference is notable and should be investigated (e.g. a config
+    /// value mismatch that could affect behaviour).
+    Medium,
+    /// The difference is critical and requires immediate action (e.g. wrong
+    /// network, wrong version, wrong admin address).
+    Critical,
+}
+
+impl DriftSeverity {
+    pub fn label(&self) -> &'static str {
+        match self {
+            DriftSeverity::Low => "low",
+            DriftSeverity::Medium => "medium",
+            DriftSeverity::Critical => "critical",
+        }
+    }
+}
+
+/// A single detected difference between spec and snapshot.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DriftItem {
+    /// Short identifier for the field or config key that drifted.
+    pub field: String,
+    /// Severity of this drift item.
+    pub severity: DriftSeverity,
+    /// The expected value (from the spec). `None` means "not expected at all".
+    pub expected: Option<String>,
+    /// The observed value (from the snapshot). `None` means "not present".
+    pub observed: Option<String>,
+    /// Human-readable description of the drift.
+    pub description: String,
+}
+
+// ---------------------------------------------------------------------------
+// Drift report
+// ---------------------------------------------------------------------------
+
+/// The full result of comparing a [`DeploymentSpec`] against a
+/// [`DeploymentSnapshot`].
+#[derive(Clone, Debug)]
+pub struct DriftReport {
+    /// Environment name from the spec.
+    pub environment: String,
+    /// Unix timestamp of the snapshot.
+    pub snapshot_captured_at: u64,
+    /// All detected drift items, ordered by severity descending.
+    pub items: Vec<DriftItem>,
+    /// `true` when no drift items were found.
+    pub is_clean: bool,
+    /// Number of critical drift items.
+    pub critical_count: usize,
+    /// Number of medium drift items.
+    pub medium_count: usize,
+    /// Number of low drift items.
+    pub low_count: usize,
+}
+
+impl DriftReport {
+    /// Returns `true` when any item has [`DriftSeverity::Critical`] severity.
+    pub fn has_critical(&self) -> bool {
+        self.critical_count > 0
+    }
+
+    /// Returns only the items at or above `min_severity`.
+    pub fn items_at_or_above(&self, min_severity: DriftSeverity) -> Vec<&DriftItem> {
+        self.items
+            .iter()
+            .filter(|i| i.severity >= min_severity)
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core detection function
+// ---------------------------------------------------------------------------
+
+/// Compare a [`DeploymentSpec`] against a [`DeploymentSnapshot`] and return
+/// a [`DriftReport`] listing all detected differences.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::deployment_drift::{
+///     ConfigEntry, DeploymentSpec, DeploymentSnapshot, detect_drift, DriftSeverity,
+/// };
+///
+/// let spec = DeploymentSpec {
+///     environment: "testnet".into(),
+///     expected_version: "0.1.0".into(),
+///     expected_network: "Test SDF Network ; September 2015".into(),
+///     expected_admin: Some("GABC123".into()),
+///     expected_config: vec![ConfigEntry::new("rate_limit", "100")],
+/// };
+///
+/// let snapshot = DeploymentSnapshot {
+///     environment: "testnet".into(),
+///     captured_at: 9999,
+///     observed_version: "0.2.0".into(), // drifted
+///     observed_network: "Test SDF Network ; September 2015".into(),
+///     observed_admin: Some("GABC123".into()),
+///     observed_config: vec![ConfigEntry::new("rate_limit", "100")],
+/// };
+///
+/// let report = detect_drift(&spec, &snapshot);
+/// assert!(!report.is_clean);
+/// assert!(report.has_critical());
+/// ```
+pub fn detect_drift(spec: &DeploymentSpec, snapshot: &DeploymentSnapshot) -> DriftReport {
+    let mut items: Vec<DriftItem> = Vec::new();
+
+    // ── Version ─────────────────────────────────────────────────────────────
+    if spec.expected_version != snapshot.observed_version {
+        items.push(DriftItem {
+            field: "version".into(),
+            severity: DriftSeverity::Critical,
+            expected: Some(spec.expected_version.clone()),
+            observed: Some(snapshot.observed_version.clone()),
+            description: alloc::format!(
+                "deployed version '{}' differs from expected '{}'",
+                snapshot.observed_version, spec.expected_version
+            ),
+        });
+    }
+
+    // ── Network ─────────────────────────────────────────────────────────────
+    if spec.expected_network != snapshot.observed_network {
+        items.push(DriftItem {
+            field: "network".into(),
+            severity: DriftSeverity::Critical,
+            expected: Some(spec.expected_network.clone()),
+            observed: Some(snapshot.observed_network.clone()),
+            description: alloc::format!(
+                "network '{}' differs from expected '{}'",
+                snapshot.observed_network, spec.expected_network
+            ),
+        });
+    }
+
+    // ── Admin address ────────────────────────────────────────────────────────
+    match (&spec.expected_admin, &snapshot.observed_admin) {
+        (Some(exp), Some(obs)) if exp != obs => {
+            items.push(DriftItem {
+                field: "admin".into(),
+                severity: DriftSeverity::Critical,
+                expected: Some(exp.clone()),
+                observed: Some(obs.clone()),
+                description: alloc::format!(
+                    "admin address '{}' differs from expected '{}'",
+                    obs, exp
+                ),
+            });
+        }
+        (Some(exp), None) => {
+            items.push(DriftItem {
+                field: "admin".into(),
+                severity: DriftSeverity::Critical,
+                expected: Some(exp.clone()),
+                observed: None,
+                description: "expected admin address is absent in snapshot".into(),
+            });
+        }
+        (None, Some(obs)) => {
+            items.push(DriftItem {
+                field: "admin".into(),
+                severity: DriftSeverity::Medium,
+                expected: None,
+                observed: Some(obs.clone()),
+                description: alloc::format!(
+                    "unexpected admin address '{}' found in snapshot",
+                    obs
+                ),
+            });
+        }
+        _ => {}
+    }
+
+    // ── Config entries ───────────────────────────────────────────────────────
+
+    // Check that every expected config key is present and matches.
+    for expected_entry in &spec.expected_config {
+        match snapshot
+            .observed_config
+            .iter()
+            .find(|e| e.key == expected_entry.key)
+        {
+            None => {
+                items.push(DriftItem {
+                    field: alloc::format!("config.{}", expected_entry.key),
+                    severity: DriftSeverity::Medium,
+                    expected: Some(expected_entry.value.clone()),
+                    observed: None,
+                    description: alloc::format!(
+                        "expected config key '{}' is absent in snapshot",
+                        expected_entry.key
+                    ),
+                });
+            }
+            Some(obs_entry) if obs_entry.value != expected_entry.value => {
+                items.push(DriftItem {
+                    field: alloc::format!("config.{}", expected_entry.key),
+                    severity: DriftSeverity::Medium,
+                    expected: Some(expected_entry.value.clone()),
+                    observed: Some(obs_entry.value.clone()),
+                    description: alloc::format!(
+                        "config key '{}': observed '{}', expected '{}'",
+                        expected_entry.key, obs_entry.value, expected_entry.value
+                    ),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    // Flag extra config keys in the snapshot that the spec doesn't mention.
+    for obs_entry in &snapshot.observed_config {
+        if !spec
+            .expected_config
+            .iter()
+            .any(|e| e.key == obs_entry.key)
+        {
+            items.push(DriftItem {
+                field: alloc::format!("config.{}", obs_entry.key),
+                severity: DriftSeverity::Low,
+                expected: None,
+                observed: Some(obs_entry.value.clone()),
+                description: alloc::format!(
+                    "config key '{}' is present in snapshot but not in spec",
+                    obs_entry.key
+                ),
+            });
+        }
+    }
+
+    // Sort: Critical first, then Medium, then Low.
+    items.sort_by(|a, b| b.severity.cmp(&a.severity));
+
+    let critical_count = items.iter().filter(|i| i.severity == DriftSeverity::Critical).count();
+    let medium_count   = items.iter().filter(|i| i.severity == DriftSeverity::Medium).count();
+    let low_count      = items.iter().filter(|i| i.severity == DriftSeverity::Low).count();
+    let is_clean       = items.is_empty();
+
+    DriftReport {
+        environment: spec.environment.clone(),
+        snapshot_captured_at: snapshot.captured_at,
+        items,
+        is_clean,
+        critical_count,
+        medium_count,
+        low_count,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_spec() -> DeploymentSpec {
+        DeploymentSpec {
+            environment: "testnet".into(),
+            expected_version: "0.1.0".into(),
+            expected_network: "Test SDF Network ; September 2015".into(),
+            expected_admin: Some("GABC123".into()),
+            expected_config: vec![
+                ConfigEntry::new("rate_limit", "100"),
+                ConfigEntry::new("max_sessions", "50"),
+            ],
+        }
+    }
+
+    fn base_snapshot() -> DeploymentSnapshot {
+        DeploymentSnapshot {
+            environment: "testnet".into(),
+            captured_at: 9999,
+            observed_version: "0.1.0".into(),
+            observed_network: "Test SDF Network ; September 2015".into(),
+            observed_admin: Some("GABC123".into()),
+            observed_config: vec![
+                ConfigEntry::new("rate_limit", "100"),
+                ConfigEntry::new("max_sessions", "50"),
+            ],
+        }
+    }
+
+    #[test]
+    fn no_drift_when_spec_and_snapshot_match() {
+        let report = detect_drift(&base_spec(), &base_snapshot());
+        assert!(report.is_clean);
+        assert_eq!(report.critical_count, 0);
+        assert_eq!(report.medium_count, 0);
+        assert_eq!(report.low_count, 0);
+    }
+
+    #[test]
+    fn version_mismatch_is_critical() {
+        let mut snap = base_snapshot();
+        snap.observed_version = "0.2.0".into();
+        let report = detect_drift(&base_spec(), &snap);
+        assert!(!report.is_clean);
+        assert!(report.has_critical());
+        let item = report.items.iter().find(|i| i.field == "version").unwrap();
+        assert_eq!(item.severity, DriftSeverity::Critical);
+        assert_eq!(item.expected.as_deref(), Some("0.1.0"));
+        assert_eq!(item.observed.as_deref(), Some("0.2.0"));
+    }
+
+    #[test]
+    fn network_mismatch_is_critical() {
+        let mut snap = base_snapshot();
+        snap.observed_network = "Public Global Stellar Network ; September 2015".into();
+        let report = detect_drift(&base_spec(), &snap);
+        assert!(report.has_critical());
+        assert!(report.items.iter().any(|i| i.field == "network"));
+    }
+
+    #[test]
+    fn admin_mismatch_is_critical() {
+        let mut snap = base_snapshot();
+        snap.observed_admin = Some("GDIFFERENT".into());
+        let report = detect_drift(&base_spec(), &snap);
+        assert!(report.has_critical());
+        assert!(report.items.iter().any(|i| i.field == "admin"));
+    }
+
+    #[test]
+    fn missing_expected_admin_is_critical() {
+        let mut snap = base_snapshot();
+        snap.observed_admin = None;
+        let report = detect_drift(&base_spec(), &snap);
+        assert!(report.has_critical());
+    }
+
+    #[test]
+    fn unexpected_admin_in_snapshot_is_medium() {
+        let mut spec = base_spec();
+        spec.expected_admin = None;
+        let report = detect_drift(&spec, &base_snapshot());
+        let item = report.items.iter().find(|i| i.field == "admin").unwrap();
+        assert_eq!(item.severity, DriftSeverity::Medium);
+    }
+
+    #[test]
+    fn config_value_mismatch_is_medium() {
+        let mut snap = base_snapshot();
+        snap.observed_config[0].value = "200".into(); // rate_limit changed
+        let report = detect_drift(&base_spec(), &snap);
+        assert_eq!(report.medium_count, 1);
+        let item = report.items.iter().find(|i| i.field == "config.rate_limit").unwrap();
+        assert_eq!(item.severity, DriftSeverity::Medium);
+    }
+
+    #[test]
+    fn missing_config_key_is_medium() {
+        let mut snap = base_snapshot();
+        snap.observed_config.retain(|e| e.key != "max_sessions");
+        let report = detect_drift(&base_spec(), &snap);
+        assert!(report.items.iter().any(|i| i.field == "config.max_sessions"));
+        assert_eq!(
+            report.items.iter().find(|i| i.field == "config.max_sessions").unwrap().severity,
+            DriftSeverity::Medium
+        );
+    }
+
+    #[test]
+    fn extra_config_key_in_snapshot_is_low() {
+        let mut snap = base_snapshot();
+        snap.observed_config.push(ConfigEntry::new("extra_key", "val"));
+        let report = detect_drift(&base_spec(), &snap);
+        let item = report.items.iter().find(|i| i.field == "config.extra_key").unwrap();
+        assert_eq!(item.severity, DriftSeverity::Low);
+    }
+
+    #[test]
+    fn items_sorted_critical_first() {
+        let mut snap = base_snapshot();
+        snap.observed_version = "0.2.0".into();        // critical
+        snap.observed_config[0].value = "999".into();  // medium
+        snap.observed_config.push(ConfigEntry::new("extra", "x")); // low
+        let report = detect_drift(&base_spec(), &snap);
+        let severities: Vec<&DriftSeverity> =
+            report.items.iter().map(|i| &i.severity).collect();
+        // Verify descending order (Critical >= Medium >= Low).
+        for window in severities.windows(2) {
+            assert!(window[0] >= window[1]);
+        }
+    }
+
+    #[test]
+    fn items_at_or_above_filters_correctly() {
+        let mut snap = base_snapshot();
+        snap.observed_version = "0.2.0".into();
+        snap.observed_config[0].value = "999".into();
+        snap.observed_config.push(ConfigEntry::new("extra", "x"));
+        let report = detect_drift(&base_spec(), &snap);
+        let critical_only = report.items_at_or_above(DriftSeverity::Critical);
+        assert!(critical_only.iter().all(|i| i.severity == DriftSeverity::Critical));
+        let med_and_above = report.items_at_or_above(DriftSeverity::Medium);
+        assert!(med_and_above.iter().all(|i| i.severity >= DriftSeverity::Medium));
+    }
+
+    #[test]
+    fn report_environment_matches_spec() {
+        let report = detect_drift(&base_spec(), &base_snapshot());
+        assert_eq!(report.environment, "testnet");
+        assert_eq!(report.snapshot_captured_at, 9999);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,20 @@ pub mod streaming_monitor;
 #[cfg(not(feature = "wasm"))]
 pub mod structured_log;
 
+// ── Transaction archive (#675), compaction (#676) ────────────────────────────
+#[cfg(not(feature = "wasm"))]
+pub mod transaction_archive;
+#[cfg(not(feature = "wasm"))]
+pub mod transaction_compaction;
+
+// ── Artifact provenance tracking (#674) ──────────────────────────────────────
+#[cfg(not(feature = "wasm"))]
+pub mod artifact_provenance;
+
+// ── Deployment drift detection (#673) ────────────────────────────────────────
+#[cfg(not(feature = "wasm"))]
+pub mod deployment_drift;
+
 // ── Multi-asset quote routing (#656) ─────────────────────────────────────────
 // Available in host (non-WASM) builds. Provides asset-pair routing across
 // multiple corridors in a single pass.
@@ -303,6 +317,34 @@ pub use multi_asset_routing::{
 };
 #[cfg(not(feature = "wasm"))]
 pub use structured_log::{StructuredLogger, LogLevel, LogRecord, FieldValue, log_attestor_registration};
+
+// ── Issue #675: archived transaction histories ────────────────────────────────
+#[cfg(not(feature = "wasm"))]
+pub use transaction_archive::{
+    TransactionArchive, TransactionArchiveManager, ArchiveRetrievalStatus,
+    compute_archive_commitment, verify_archive_commitment,
+};
+
+// ── Issue #676: transaction history compaction ────────────────────────────────
+#[cfg(not(feature = "wasm"))]
+pub use transaction_compaction::{
+    compact_history, CompactionConfig, RawTransactionRecord,
+    TransactionSummaryRecord, CompactionResult, CompactionAggregate,
+};
+
+// ── Issue #674: artifact provenance tracking ──────────────────────────────────
+#[cfg(not(feature = "wasm"))]
+pub use artifact_provenance::{
+    ArtifactProvenance, ProvenanceStore, ProvenanceVerifier,
+    VerificationReport, FieldVerdict,
+};
+
+// ── Issue #673: deployment drift detection ────────────────────────────────────
+#[cfg(not(feature = "wasm"))]
+pub use deployment_drift::{
+    detect_drift, ConfigEntry, DeploymentSpec, DeploymentSnapshot,
+    DriftReport, DriftItem, DriftSeverity,
+};
 
 #[cfg(all(test, not(feature = "wasm")))]
 mod stellar_toml_tests;

--- a/src/transaction_archive.rs
+++ b/src/transaction_archive.rs
@@ -1,0 +1,327 @@
+//! Archived transaction history support (issue #675).
+//!
+//! Long-lived transaction histories can become expensive to keep in active
+//! on-chain storage. This module provides a clearly-defined archive path so
+//! operators can move old records out of hot storage while retaining a
+//! verifiable retrieval path.
+//!
+//! ## Design
+//!
+//! - [`TransactionArchive`] is the on-chain envelope written when records are
+//!   archived.  It stores the archive timestamp, the record count, and a
+//!   SHA-256 commitment over all archived transaction IDs so the archive can
+//!   be verified without re-fetching every record.
+//! - [`ArchiveIndex`] is a lightweight persistent index mapping an archive ID
+//!   to its [`TransactionArchive`] envelope.
+//! - [`TransactionArchiveManager`] exposes the archive/retrieval operations.
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
+
+use crate::errors::{AnchorKitError, ErrorCode};
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+/// Metadata envelope stored for a single archived batch of transactions.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransactionArchive {
+    /// Unique, monotonically-increasing identifier for this archive batch.
+    pub archive_id: u64,
+    /// Ledger timestamp when the archive was created.
+    pub archived_at: u64,
+    /// Number of transaction records included in this archive batch.
+    pub record_count: u32,
+    /// SHA-256 commitment over the concatenated archived transaction IDs.
+    /// Allows integrity verification without re-reading every record.
+    pub commitment: [u8; 32],
+    /// Human-readable label supplied by the operator (e.g. `"2025-Q1"`).
+    pub label: String,
+    /// Optional URI where the full archive payload can be retrieved
+    /// (e.g. an IPFS CID or an S3 object key).
+    pub retrieval_uri: Option<String>,
+}
+
+/// Status of an archived record retrieval attempt.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ArchiveRetrievalStatus {
+    /// Archive envelope found; retrieval URI is available.
+    Found(TransactionArchive),
+    /// Archive ID exists but no retrieval URI has been set.
+    PendingUri(TransactionArchive),
+    /// No archive with the given ID exists.
+    NotFound,
+}
+
+// ---------------------------------------------------------------------------
+// Archive commitment helpers
+// ---------------------------------------------------------------------------
+
+/// Compute the SHA-256 commitment for an ordered slice of transaction IDs.
+///
+/// The commitment is `SHA-256(id_0 || "\n" || id_1 || "\n" || … || id_n || "\n")`.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::transaction_archive::compute_archive_commitment;
+///
+/// let ids = vec!["txn-001".to_string(), "txn-002".to_string()];
+/// let c1 = compute_archive_commitment(&ids);
+/// let c2 = compute_archive_commitment(&ids);
+/// assert_eq!(c1, c2); // deterministic
+///
+/// let other = compute_archive_commitment(&["txn-003".to_string()]);
+/// assert_ne!(c1, other);
+/// ```
+pub fn compute_archive_commitment(transaction_ids: &[String]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    for id in transaction_ids {
+        hasher.update(id.as_bytes());
+        hasher.update(b"\n");
+    }
+    hasher.finalize().into()
+}
+
+/// Verify that a stored commitment matches the recomputed one for `transaction_ids`.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::transaction_archive::{compute_archive_commitment, verify_archive_commitment};
+///
+/// let ids = vec!["txn-a".to_string()];
+/// let commitment = compute_archive_commitment(&ids);
+/// assert!(verify_archive_commitment(&commitment, &ids));
+/// assert!(!verify_archive_commitment(&commitment, &["txn-b".to_string()]));
+/// ```
+pub fn verify_archive_commitment(stored: &[u8; 32], transaction_ids: &[String]) -> bool {
+    let expected = compute_archive_commitment(transaction_ids);
+    // Constant-time comparison.
+    let mut diff = 0u8;
+    for (a, b) in stored.iter().zip(expected.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+// ---------------------------------------------------------------------------
+// In-memory archive manager
+// ---------------------------------------------------------------------------
+
+/// Manages a collection of [`TransactionArchive`] envelopes in memory.
+///
+/// In production the archive index would be backed by persistent storage
+/// (e.g. Soroban contract storage or an off-chain database). This struct
+/// provides the core logic that can be wrapped by any storage backend.
+pub struct TransactionArchiveManager {
+    archives: Vec<TransactionArchive>,
+    next_id: u64,
+}
+
+impl TransactionArchiveManager {
+    /// Create an empty archive manager.
+    pub fn new() -> Self {
+        Self {
+            archives: Vec::new(),
+            next_id: 0,
+        }
+    }
+
+    /// Archive a batch of transaction IDs, returning the new [`TransactionArchive`].
+    ///
+    /// # Arguments
+    ///
+    /// * `transaction_ids` – ordered slice of IDs being archived (must be non-empty).
+    /// * `archived_at` – Unix timestamp for the archive event.
+    /// * `label` – operator-supplied label (e.g. `"2025-Q1"`).
+    /// * `retrieval_uri` – optional URI for the full payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnchorKitError`] with [`ErrorCode::ValidationError`] when
+    /// `transaction_ids` is empty.
+    pub fn archive(
+        &mut self,
+        transaction_ids: &[String],
+        archived_at: u64,
+        label: String,
+        retrieval_uri: Option<String>,
+    ) -> Result<TransactionArchive, AnchorKitError> {
+        if transaction_ids.is_empty() {
+            return Err(AnchorKitError::validation_error(
+                "transaction_ids must not be empty",
+            ));
+        }
+
+        let commitment = compute_archive_commitment(transaction_ids);
+        let archive = TransactionArchive {
+            archive_id: self.next_id,
+            archived_at,
+            record_count: transaction_ids.len() as u32,
+            commitment,
+            label,
+            retrieval_uri,
+        };
+
+        self.next_id += 1;
+        self.archives.push(archive.clone());
+        Ok(archive)
+    }
+
+    /// Retrieve an archive by ID.
+    pub fn get(&self, archive_id: u64) -> ArchiveRetrievalStatus {
+        match self.archives.iter().find(|a| a.archive_id == archive_id) {
+            None => ArchiveRetrievalStatus::NotFound,
+            Some(a) if a.retrieval_uri.is_some() => {
+                ArchiveRetrievalStatus::Found(a.clone())
+            }
+            Some(a) => ArchiveRetrievalStatus::PendingUri(a.clone()),
+        }
+    }
+
+    /// Update the retrieval URI for an existing archive.
+    ///
+    /// Returns `true` when the archive was found and updated.
+    pub fn set_retrieval_uri(&mut self, archive_id: u64, uri: String) -> bool {
+        match self.archives.iter_mut().find(|a| a.archive_id == archive_id) {
+            Some(a) => {
+                a.retrieval_uri = Some(uri);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Total number of archived batches.
+    pub fn archive_count(&self) -> usize {
+        self.archives.len()
+    }
+
+    /// Return all archive envelopes, oldest first.
+    pub fn list(&self) -> &[TransactionArchive] {
+        &self.archives
+    }
+}
+
+impl Default for TransactionArchiveManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn compute_commitment_is_deterministic() {
+        let a = compute_archive_commitment(&ids(&["t1", "t2"]));
+        let b = compute_archive_commitment(&ids(&["t1", "t2"]));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn compute_commitment_differs_on_different_input() {
+        let a = compute_archive_commitment(&ids(&["t1"]));
+        let b = compute_archive_commitment(&ids(&["t2"]));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn verify_commitment_round_trip() {
+        let list = ids(&["txn-001", "txn-002", "txn-003"]);
+        let c = compute_archive_commitment(&list);
+        assert!(verify_archive_commitment(&c, &list));
+        assert!(!verify_archive_commitment(&c, &ids(&["txn-001", "txn-999"])));
+    }
+
+    #[test]
+    fn archive_manager_empty_ids_rejected() {
+        let mut mgr = TransactionArchiveManager::new();
+        let err = mgr.archive(&[], 1000, "batch-1".into(), None).unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValidationError);
+    }
+
+    #[test]
+    fn archive_manager_creates_archive_with_correct_fields() {
+        let mut mgr = TransactionArchiveManager::new();
+        let list = ids(&["t1", "t2", "t3"]);
+        let archive = mgr.archive(&list, 9999, "q1".into(), None).unwrap();
+        assert_eq!(archive.archive_id, 0);
+        assert_eq!(archive.record_count, 3);
+        assert_eq!(archive.archived_at, 9999);
+        assert_eq!(archive.label, "q1");
+        assert!(archive.retrieval_uri.is_none());
+        assert!(verify_archive_commitment(&archive.commitment, &list));
+    }
+
+    #[test]
+    fn archive_manager_ids_are_monotonic() {
+        let mut mgr = TransactionArchiveManager::new();
+        let a1 = mgr.archive(&ids(&["t1"]), 1, "a".into(), None).unwrap();
+        let a2 = mgr.archive(&ids(&["t2"]), 2, "b".into(), None).unwrap();
+        assert_eq!(a1.archive_id, 0);
+        assert_eq!(a2.archive_id, 1);
+        assert_eq!(mgr.archive_count(), 2);
+    }
+
+    #[test]
+    fn get_returns_pending_uri_when_uri_absent() {
+        let mut mgr = TransactionArchiveManager::new();
+        mgr.archive(&ids(&["t1"]), 1, "lbl".into(), None).unwrap();
+        assert!(matches!(mgr.get(0), ArchiveRetrievalStatus::PendingUri(_)));
+    }
+
+    #[test]
+    fn get_returns_found_when_uri_present() {
+        let mut mgr = TransactionArchiveManager::new();
+        mgr.archive(&ids(&["t1"]), 1, "lbl".into(), Some("ipfs://cid".into())).unwrap();
+        assert!(matches!(mgr.get(0), ArchiveRetrievalStatus::Found(_)));
+    }
+
+    #[test]
+    fn get_returns_not_found_for_unknown_id() {
+        let mgr = TransactionArchiveManager::new();
+        assert_eq!(mgr.get(99), ArchiveRetrievalStatus::NotFound);
+    }
+
+    #[test]
+    fn set_retrieval_uri_updates_existing_archive() {
+        let mut mgr = TransactionArchiveManager::new();
+        mgr.archive(&ids(&["t1"]), 1, "lbl".into(), None).unwrap();
+        assert!(mgr.set_retrieval_uri(0, "ipfs://abc".into()));
+        if let ArchiveRetrievalStatus::Found(a) = mgr.get(0) {
+            assert_eq!(a.retrieval_uri.as_deref(), Some("ipfs://abc"));
+        } else {
+            panic!("expected Found after setting URI");
+        }
+    }
+
+    #[test]
+    fn set_retrieval_uri_returns_false_for_unknown_id() {
+        let mut mgr = TransactionArchiveManager::new();
+        assert!(!mgr.set_retrieval_uri(42, "uri".into()));
+    }
+
+    #[test]
+    fn list_returns_archives_oldest_first() {
+        let mut mgr = TransactionArchiveManager::new();
+        mgr.archive(&ids(&["t1"]), 1, "first".into(), None).unwrap();
+        mgr.archive(&ids(&["t2"]), 2, "second".into(), None).unwrap();
+        let list = mgr.list();
+        assert_eq!(list[0].label, "first");
+        assert_eq!(list[1].label, "second");
+    }
+}

--- a/src/transaction_compaction.rs
+++ b/src/transaction_compaction.rs
@@ -1,0 +1,490 @@
+//! Transaction history compaction and summary generation (issue #676).
+//!
+//! Large transaction histories are difficult to work with directly. This module
+//! reduces a raw history into a compact, useful form so operators can inspect
+//! high-level trends without reading every record.
+//!
+//! ## Design
+//!
+//! - [`TransactionSummaryRecord`] is the compacted representation of a single
+//!   time window (e.g. one day or one hour).
+//! - [`compact_history`] reduces an ordered slice of raw transaction records
+//!   into a [`CompactionResult`] containing per-window summaries and overall
+//!   aggregate statistics.
+//! - [`CompactionConfig`] controls the window size and which status categories
+//!   are counted separately.
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
+
+use crate::errors::{AnchorKitError, ErrorCode};
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Controls how transaction history is compacted.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CompactionConfig {
+    /// Width of each summary window in seconds (e.g. 3 600 for hourly).
+    /// Must be > 0.
+    pub window_seconds: u64,
+    /// When `true`, the compaction retains the first and last transaction ID
+    /// within each window for audit trail purposes.
+    pub retain_boundary_ids: bool,
+}
+
+impl Default for CompactionConfig {
+    fn default() -> Self {
+        Self {
+            window_seconds: 3_600, // hourly windows
+            retain_boundary_ids: true,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Input record
+// ---------------------------------------------------------------------------
+
+/// A minimal representation of a single transaction record fed into the
+/// compaction pipeline.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RawTransactionRecord {
+    /// Unique transaction identifier.
+    pub id: String,
+    /// Unix timestamp of the transaction.
+    pub timestamp: u64,
+    /// Status string (e.g. `"completed"`, `"pending_external"`, `"error"`).
+    pub status: String,
+    /// Transaction amount as an integer in the asset's minor unit.
+    pub amount: u64,
+    /// Asset code (e.g. `"USDC"`).
+    pub asset_code: String,
+}
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+/// Compacted summary for a single time window.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransactionSummaryRecord {
+    /// Unix timestamp marking the start of this window.
+    pub window_start: u64,
+    /// Unix timestamp marking the end of this window (exclusive).
+    pub window_end: u64,
+    /// Total number of transactions in this window.
+    pub total_count: u32,
+    /// Number of transactions with a `"completed"` status.
+    pub completed_count: u32,
+    /// Number of transactions with a status containing `"pending"`.
+    pub pending_count: u32,
+    /// Number of transactions with a status containing `"error"` or `"failed"`.
+    pub error_count: u32,
+    /// Sum of all transaction amounts in this window.
+    pub total_volume: u64,
+    /// Largest single transaction amount in this window.
+    pub max_amount: u64,
+    /// Smallest single transaction amount in this window (0 if no transactions).
+    pub min_amount: u64,
+    /// Average amount (integer division). 0 when `total_count == 0`.
+    pub avg_amount: u64,
+    /// ID of the first transaction in this window (when `retain_boundary_ids`).
+    pub first_id: Option<String>,
+    /// ID of the last transaction in this window (when `retain_boundary_ids`).
+    pub last_id: Option<String>,
+}
+
+/// Overall aggregate statistics across all windows.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CompactionAggregate {
+    /// Total transactions across all windows.
+    pub total_count: u64,
+    /// Total volume across all windows.
+    pub total_volume: u64,
+    /// Overall completion rate in [0.0, 1.0].
+    pub completion_rate: f64,
+    /// Overall error rate in [0.0, 1.0].
+    pub error_rate: f64,
+    /// Timestamp of the earliest transaction seen.
+    pub earliest_timestamp: u64,
+    /// Timestamp of the latest transaction seen.
+    pub latest_timestamp: u64,
+    /// Number of summary windows produced.
+    pub window_count: usize,
+}
+
+/// The output of a compaction run.
+#[derive(Clone, Debug)]
+pub struct CompactionResult {
+    /// Per-window summaries, ordered by `window_start` ascending.
+    pub windows: Vec<TransactionSummaryRecord>,
+    /// Aggregate statistics across all windows.
+    pub aggregate: CompactionAggregate,
+}
+
+// ---------------------------------------------------------------------------
+// Status classification helpers
+// ---------------------------------------------------------------------------
+
+fn classify_status(status: &str) -> (bool, bool, bool) {
+    let s = status.to_ascii_lowercase();
+    let completed = s == "completed" || s == "complete";
+    let pending = s.contains("pending");
+    let error = s.contains("error") || s.contains("failed") || s.contains("failure");
+    (completed, pending, error)
+}
+
+// ---------------------------------------------------------------------------
+// Core compaction function
+// ---------------------------------------------------------------------------
+
+/// Compact an ordered slice of raw transaction records into per-window summaries.
+///
+/// Records **must** be provided in ascending `timestamp` order. If the slice is
+/// empty, a [`CompactionResult`] with no windows and zeroed aggregate is returned.
+///
+/// # Errors
+///
+/// Returns [`AnchorKitError`] with [`ErrorCode::ValidationError`] when
+/// `config.window_seconds` is zero.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::transaction_compaction::{
+///     compact_history, CompactionConfig, RawTransactionRecord,
+/// };
+///
+/// let records = vec![
+///     RawTransactionRecord {
+///         id: "t1".into(), timestamp: 100, status: "completed".into(),
+///         amount: 500, asset_code: "USDC".into(),
+///     },
+///     RawTransactionRecord {
+///         id: "t2".into(), timestamp: 200, status: "pending_external".into(),
+///         amount: 300, asset_code: "USDC".into(),
+///     },
+/// ];
+/// let config = CompactionConfig { window_seconds: 3600, retain_boundary_ids: true };
+/// let result = compact_history(&records, &config).unwrap();
+/// assert_eq!(result.windows.len(), 1);
+/// assert_eq!(result.aggregate.total_count, 2);
+/// ```
+pub fn compact_history(
+    records: &[RawTransactionRecord],
+    config: &CompactionConfig,
+) -> Result<CompactionResult, AnchorKitError> {
+    if config.window_seconds == 0 {
+        return Err(AnchorKitError::validation_error(
+            "window_seconds must be greater than zero",
+        ));
+    }
+
+    if records.is_empty() {
+        return Ok(CompactionResult {
+            windows: Vec::new(),
+            aggregate: CompactionAggregate {
+                total_count: 0,
+                total_volume: 0,
+                completion_rate: 0.0,
+                error_rate: 0.0,
+                earliest_timestamp: 0,
+                latest_timestamp: 0,
+                window_count: 0,
+            },
+        });
+    }
+
+    let ws = config.window_seconds;
+    let mut windows: Vec<TransactionSummaryRecord> = Vec::new();
+
+    // Determine the first window start by aligning to the window boundary.
+    let first_ts = records[0].timestamp;
+    let mut current_window_start = (first_ts / ws) * ws;
+    let mut current_window_end = current_window_start + ws;
+
+    // Scratch state for the window being built.
+    let mut total_count: u32 = 0;
+    let mut completed_count: u32 = 0;
+    let mut pending_count: u32 = 0;
+    let mut error_count: u32 = 0;
+    let mut total_volume: u64 = 0;
+    let mut max_amount: u64 = 0;
+    let mut min_amount: u64 = u64::MAX;
+    let mut first_id: Option<String> = None;
+    let mut last_id: Option<String> = None;
+
+    let flush = |wstart: u64,
+                  wend: u64,
+                  tc: u32,
+                  cc: u32,
+                  pc: u32,
+                  ec: u32,
+                  vol: u64,
+                  mx: u64,
+                  mn: u64,
+                  fid: Option<String>,
+                  lid: Option<String>,
+                  retain: bool|
+     -> TransactionSummaryRecord {
+        let avg = if tc > 0 { vol / tc as u64 } else { 0 };
+        let min_out = if tc > 0 { mn } else { 0 };
+        TransactionSummaryRecord {
+            window_start: wstart,
+            window_end: wend,
+            total_count: tc,
+            completed_count: cc,
+            pending_count: pc,
+            error_count: ec,
+            total_volume: vol,
+            max_amount: mx,
+            min_amount: min_out,
+            avg_amount: avg,
+            first_id: if retain { fid } else { None },
+            last_id: if retain { lid } else { None },
+        }
+    };
+
+    for rec in records {
+        // Advance window if this record falls outside the current one.
+        while rec.timestamp >= current_window_end {
+            if total_count > 0 || !windows.is_empty() {
+                // Only emit non-empty windows, but always emit the current one
+                // if it has data.
+                if total_count > 0 {
+                    windows.push(flush(
+                        current_window_start,
+                        current_window_end,
+                        total_count,
+                        completed_count,
+                        pending_count,
+                        error_count,
+                        total_volume,
+                        max_amount,
+                        min_amount,
+                        first_id.take(),
+                        last_id.take(),
+                        config.retain_boundary_ids,
+                    ));
+                }
+            }
+            current_window_start = current_window_end;
+            current_window_end = current_window_start + ws;
+            total_count = 0;
+            completed_count = 0;
+            pending_count = 0;
+            error_count = 0;
+            total_volume = 0;
+            max_amount = 0;
+            min_amount = u64::MAX;
+            first_id = None;
+            last_id = None;
+        }
+
+        let (completed, pending, error) = classify_status(&rec.status);
+        if completed { completed_count += 1; }
+        if pending { pending_count += 1; }
+        if error { error_count += 1; }
+
+        total_count += 1;
+        total_volume = total_volume.saturating_add(rec.amount);
+        if rec.amount > max_amount { max_amount = rec.amount; }
+        if rec.amount < min_amount { min_amount = rec.amount; }
+
+        if config.retain_boundary_ids {
+            if first_id.is_none() { first_id = Some(rec.id.clone()); }
+            last_id = Some(rec.id.clone());
+        }
+    }
+
+    // Flush the final window.
+    if total_count > 0 {
+        windows.push(flush(
+            current_window_start,
+            current_window_end,
+            total_count,
+            completed_count,
+            pending_count,
+            error_count,
+            total_volume,
+            max_amount,
+            min_amount,
+            first_id,
+            last_id,
+            config.retain_boundary_ids,
+        ));
+    }
+
+    // Compute aggregate.
+    let agg_total: u64 = windows.iter().map(|w| w.total_count as u64).sum();
+    let agg_completed: u64 = windows.iter().map(|w| w.completed_count as u64).sum();
+    let agg_errors: u64 = windows.iter().map(|w| w.error_count as u64).sum();
+    let agg_volume: u64 = windows.iter().map(|w| w.total_volume).sum();
+
+    let completion_rate = if agg_total > 0 {
+        agg_completed as f64 / agg_total as f64
+    } else {
+        0.0
+    };
+    let error_rate = if agg_total > 0 {
+        agg_errors as f64 / agg_total as f64
+    } else {
+        0.0
+    };
+
+    let aggregate = CompactionAggregate {
+        total_count: agg_total,
+        total_volume: agg_volume,
+        completion_rate,
+        error_rate,
+        earliest_timestamp: records.first().map(|r| r.timestamp).unwrap_or(0),
+        latest_timestamp: records.last().map(|r| r.timestamp).unwrap_or(0),
+        window_count: windows.len(),
+    };
+
+    Ok(CompactionResult { windows, aggregate })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(id: &str, ts: u64, status: &str, amount: u64) -> RawTransactionRecord {
+        RawTransactionRecord {
+            id: id.into(),
+            timestamp: ts,
+            status: status.into(),
+            amount,
+            asset_code: "USDC".into(),
+        }
+    }
+
+    #[test]
+    fn empty_input_returns_zeroed_aggregate() {
+        let result = compact_history(&[], &CompactionConfig::default()).unwrap();
+        assert!(result.windows.is_empty());
+        assert_eq!(result.aggregate.total_count, 0);
+        assert_eq!(result.aggregate.window_count, 0);
+    }
+
+    #[test]
+    fn zero_window_seconds_rejected() {
+        let cfg = CompactionConfig { window_seconds: 0, retain_boundary_ids: false };
+        assert_eq!(
+            compact_history(&[rec("t1", 100, "completed", 50)], &cfg)
+                .unwrap_err()
+                .code,
+            ErrorCode::ValidationError
+        );
+    }
+
+    #[test]
+    fn single_record_produces_one_window() {
+        let records = vec![rec("t1", 500, "completed", 100)];
+        let cfg = CompactionConfig { window_seconds: 3600, retain_boundary_ids: true };
+        let result = compact_history(&records, &cfg).unwrap();
+        assert_eq!(result.windows.len(), 1);
+        let w = &result.windows[0];
+        assert_eq!(w.total_count, 1);
+        assert_eq!(w.completed_count, 1);
+        assert_eq!(w.total_volume, 100);
+        assert_eq!(w.max_amount, 100);
+        assert_eq!(w.min_amount, 100);
+        assert_eq!(w.avg_amount, 100);
+        assert_eq!(w.first_id.as_deref(), Some("t1"));
+        assert_eq!(w.last_id.as_deref(), Some("t1"));
+    }
+
+    #[test]
+    fn multiple_records_same_window() {
+        let records = vec![
+            rec("t1", 100, "completed", 200),
+            rec("t2", 200, "pending_external", 100),
+            rec("t3", 300, "error", 50),
+        ];
+        let cfg = CompactionConfig { window_seconds: 3600, retain_boundary_ids: true };
+        let result = compact_history(&records, &cfg).unwrap();
+        assert_eq!(result.windows.len(), 1);
+        let w = &result.windows[0];
+        assert_eq!(w.total_count, 3);
+        assert_eq!(w.completed_count, 1);
+        assert_eq!(w.pending_count, 1);
+        assert_eq!(w.error_count, 1);
+        assert_eq!(w.total_volume, 350);
+        assert_eq!(w.max_amount, 200);
+        assert_eq!(w.min_amount, 50);
+        assert_eq!(w.first_id.as_deref(), Some("t1"));
+        assert_eq!(w.last_id.as_deref(), Some("t3"));
+    }
+
+    #[test]
+    fn records_spanning_two_windows() {
+        let cfg = CompactionConfig { window_seconds: 100, retain_boundary_ids: false };
+        let records = vec![
+            rec("t1", 0,   "completed", 10),
+            rec("t2", 50,  "completed", 20),
+            rec("t3", 100, "completed", 30), // starts new window at t=100
+            rec("t4", 150, "completed", 40),
+        ];
+        let result = compact_history(&records, &cfg).unwrap();
+        assert_eq!(result.windows.len(), 2);
+        assert_eq!(result.windows[0].total_count, 2);
+        assert_eq!(result.windows[1].total_count, 2);
+        assert_eq!(result.aggregate.total_count, 4);
+    }
+
+    #[test]
+    fn boundary_ids_not_retained_when_disabled() {
+        let records = vec![rec("t1", 10, "completed", 5)];
+        let cfg = CompactionConfig { window_seconds: 3600, retain_boundary_ids: false };
+        let result = compact_history(&records, &cfg).unwrap();
+        assert!(result.windows[0].first_id.is_none());
+        assert!(result.windows[0].last_id.is_none());
+    }
+
+    #[test]
+    fn aggregate_completion_and_error_rates() {
+        let records = vec![
+            rec("t1", 10, "completed", 1),
+            rec("t2", 20, "completed", 1),
+            rec("t3", 30, "error", 1),
+            rec("t4", 40, "failed", 1),
+        ];
+        let cfg = CompactionConfig { window_seconds: 3600, retain_boundary_ids: false };
+        let result = compact_history(&records, &cfg).unwrap();
+        let agg = &result.aggregate;
+        assert_eq!(agg.total_count, 4);
+        assert!((agg.completion_rate - 0.5).abs() < 1e-9);
+        assert!((agg.error_rate - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_timestamps_span_full_range() {
+        let records = vec![
+            rec("t1", 1000, "completed", 1),
+            rec("t2", 2000, "completed", 1),
+            rec("t3", 5000, "completed", 1),
+        ];
+        let cfg = CompactionConfig::default();
+        let result = compact_history(&records, &cfg).unwrap();
+        assert_eq!(result.aggregate.earliest_timestamp, 1000);
+        assert_eq!(result.aggregate.latest_timestamp, 5000);
+    }
+
+    #[test]
+    fn classify_status_variants() {
+        assert_eq!(classify_status("completed"), (true, false, false));
+        assert_eq!(classify_status("COMPLETED"), (true, false, false));
+        assert_eq!(classify_status("pending_external"), (false, true, false));
+        assert_eq!(classify_status("error"), (false, false, true));
+        assert_eq!(classify_status("failed"), (false, false, true));
+        assert_eq!(classify_status("unknown"), (false, false, false));
+    }
+}


### PR DESCRIPTION
This PR implements four related features that improve operational visibility, storage management, audit readiness, and deployment safety for AnchorKit anchors.

---

### Issue #675 — Archived transaction histories

Introduces `transaction_archive` module with:
- `TransactionArchive` envelope storing a SHA-256 commitment over archived transaction IDs, record count, timestamp, and optional retrieval URI
- `TransactionArchiveManager` for creating archive batches, looking them up by ID, and updating retrieval URIs after off-chain storage
- `compute_archive_commitment` / `verify_archive_commitment` helpers for integrity verification without re-fetching every record

Closes #675

---

### Issue #676 — Transaction history compaction and summary generation

Introduces `transaction_compaction` module with:
- `CompactionConfig` controlling time-window width and boundary ID retention
- `compact_history` reducing an ordered slice of raw transaction records into per-window `TransactionSummaryRecord` entries (count, volume, min/max/avg amounts, status category breakdowns)
- `CompactionAggregate` for overall completion rate, error rate, and full time-range statistics

Closes #676

---

### Issue #674 — Artifact provenance tracking

Introduces `artifact_provenance` module with:
- `ArtifactProvenance` record capturing artifact name, SHA-256 content hash, source revision, source repository, build command, build environment key/value pairs, timestamp, and optional signature
- `ProvenanceStore` for recording, updating, and looking up provenance by ID, name, or content hash
- `ProvenanceVerifier` / `VerificationReport` for field-level comparison against expected values, producing `Match`, `Mismatch`, `Missing`, or `NotChecked` verdicts per field

Closes #674

---

### Issue #673 — Deployment drift detection

Introduces `deployment_drift` module with:
- `DeploymentSpec` describing intended state (version, network, admin, config entries)
- `DeploymentSnapshot` capturing observed state at a point in time
- `detect_drift` comparing spec vs snapshot across all fields and returning a `DriftReport` with `DriftItem` entries classified as `Critical` (version, network, admin), `Medium` (config mismatches, missing keys), or `Low` (unexpected extra config keys)
- Items sorted by severity descending; `DriftReport::items_at_or_above` for targeted filtering

Closes #673

---

## Changes

- `src/transaction_archive.rs` — new (issue #675)
- `src/transaction_compaction.rs` — new (issue #676)
- `src/artifact_provenance.rs` — new (issue #674)
- `src/deployment_drift.rs` — new (issue #673)
- `src/lib.rs` — module declarations and public re-exports for all four modules, gated behind `cfg(not(feature = \"wasm\"))`









