### PR TITLE
feat: add architecture decision records

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -140,6 +140,16 @@ pub fn my_function(param1: Type1, param2: Type2) -> ReturnType {
 }
 ```
 
+## Architecture Decision Records
+
+Important architectural decisions are captured as Architecture Decision Records
+(ADRs) in [`docs/adr/`](adr/). Before making a significant design change, review
+the existing ADRs and consider whether a new ADR is needed.
+
+- [ADR-0001](adr/ADR-0001-record-architecture-decisions.md): Record Architecture Decisions
+- [ADR-0002](adr/ADR-0002-dual-build-strategy.md): Dual-Build Strategy
+- [ADR-0003](adr/ADR-0003-contract-lifecycle-and-schema-versioning.md): Contract Lifecycle and Schema Versioning
+
 ## Git Workflow
 
 1. **Create a feature branch:**

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -29,6 +29,7 @@ configs/       Example anchor configs (JSON + TOML)
 examples/      Rust and shell usage examples
 scripts/       Build, validation, CI, and deploy scripts
 docs/          All project documentation (start here)
+docs/adr/      Architecture Decision Records
 benches/       Criterion benchmarks
 fuzz/          Fuzz targets
 ```
@@ -249,6 +250,7 @@ before any key-sharing happens.
 - [README.md](../README.md)
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 - [RUNBOOK.md](RUNBOOK.md)
+- [Architecture Decision Records](adr/)
 - [governance-and-security.md](governance-and-security.md)
 - [error-codes.md](error-codes.md)
 - [migration-guide.md](migration-guide.md)

--- a/docs/adr/ADR-0001-record-architecture-decisions.md
+++ b/docs/adr/ADR-0001-record-architecture-decisions.md
@@ -1,0 +1,67 @@
+# ADR-0001: Record Architecture Decisions
+
+- **Status:** Accepted
+- **Date:** 2026-07-29
+- **Author:** Project Maintainers
+
+## Context
+
+As the AnchorKit project grows, contributors need to understand why the system
+is designed the way it is. Key architectural decisions were being lost or
+rediscovered through PR reviews. Without explicit records, new contributors
+cannot tell whether a design choice was deliberate or accidental.
+
+The project needed a lightweight process to capture design decisions so that:
+
+- Future contributors can understand the rationale behind past decisions.
+- Reviewers have a shared reference when evaluating new proposals.
+- Decisions are searchable and linked from the relevant code and docs.
+
+## Decision
+
+We adopt the Architecture Decision Record (ADR) format popularised by
+Michael Nygard. Each ADR is a one-page Markdown document stored in
+`docs/adr/`.
+
+### Format
+
+Each ADR contains:
+
+- **Title** — ADR number and short name
+- **Status** — Proposed, Accepted, Deprecated, or Superseded
+- **Date** — when the decision was made
+- **Context** — the problem or forces that motivated the decision
+- **Decision** — the chosen approach
+- **Consequences** — trade-offs, risks, and follow-up work
+
+### Process
+
+1. Anyone may propose an ADR by creating a PR that adds a new file to
+   `docs/adr/`.
+2. The PR follows the standard review process (one maintainer approval for
+   routine decisions, two for significant architectural changes).
+3. Once merged the ADR is considered Accepted.
+4. An ADR may be deprecated or superseded by a later ADR, which must
+   reference the superseded record.
+
+### Numbering
+
+ADRs are numbered sequentially (ADR-0001, ADR-0002, …). The leading zeros
+keep lexicographic sorting consistent.
+
+## Consequences
+
+**Positive:**
+- Design rationale is captured explicitly and survives staff changes.
+- New contributors can catch up on the project's architectural history.
+- PR discussions can reference ADRs as shared context.
+
+**Negative:**
+- Maintaining ADRs requires discipline; they can become stale if not kept in
+  sync with the code.
+- The process adds a small overhead to significant changes.
+
+**Mitigation:**
+- ADR reviews are lightweight and piggy-back on the existing PR process.
+- Code reviewers check whether a change that contradicts an ADR should update
+  or supersede it.

--- a/docs/adr/ADR-0002-dual-build-strategy.md
+++ b/docs/adr/ADR-0002-dual-build-strategy.md
@@ -1,0 +1,97 @@
+# ADR-0002: Dual-Build Strategy
+
+- **Status:** Accepted
+- **Date:** 2026-07-29
+- **Author:** Project Maintainers
+- **Supersedes:** None
+
+## Context
+
+AnchorKit operates in two distinct environments:
+
+1. **On-chain Soroban smart contract** — deployed as WASM on the Stellar
+   network. This environment has no standard library (`no_std`), no HTTP
+   client, no filesystem, and no CLI.
+2. **Off-chain CLI / service** — a native binary that loads configuration,
+   manages keys, talks to anchor APIs over HTTPS, and orchestrates attestation
+   workflows.
+
+Both environments share a large body of business logic: SEP protocol handling,
+response validation, deterministic hashing, domain validation, and error types.
+Duplicating this logic would be a maintenance burden.
+
+However, the WASM contract must be minimal (``opt-level = "z"``, `panic =
+"abort"`, no standard library) while the native binary needs blocking HTTP,
+filesystem access, and interactive password prompts.
+
+## Decision
+
+We use a single Cargo crate with two mutually exclusive compile modes driven
+by Cargo feature flags:
+
+| Mode | Command | Target | Features |
+|------|---------|--------|----------|
+| Native | `cargo build --release` | host triple | `std` (default) |
+| WASM | `cargo build --release --target wasm32-unknown-unknown --no-default-features --features wasm` | `wasm32-unknown-unknown` | `wasm` |
+
+### Feature isolation
+
+- **`std`** — enabled by default. Pulls in `clap`, `reqwest`, `aes-gcm`,
+  `argon2`, `rpassword`. Gates the binary entry point (`main.rs`) and all
+  HTTP/filesystem modules.
+- **`wasm`** — produces a `cdylib` Soroban contract. All host-only modules
+  are conditionally compiled out via `#[cfg(feature = "std")]` guards. The
+  WASM build uses `--no-default-features` to exclude `std` entirely.
+- **`mock-only`** — provides pre-built response fixtures for tests without
+  requiring a live anchor. Safe to combine with `std`. Never enabled in
+  production.
+- **`stress-tests`** — gates high-concurrency load tests excluded from normal
+  CI.
+
+### Shared code
+
+All environment-agnostic logic lives in `src/lib.rs` and modules reachable
+from it. The `src/contract.rs` Soroban entry point re-exports the public API
+surface and is available in both modes (the Soroban SDK compiles on any target).
+
+### Build optimisation
+
+The release profile (`Cargo.toml`) is tuned for WASM:
+- `opt-level = "z"` — minimise binary size
+- `lto = true`, `codegen-units = 1` — maximise inlining
+- `panic = "abort"` — no unwinding tables
+- `overflow-checks = true` — safety on-chain
+- `strip = "symbols"` — remove debug info
+
+The native binary inherits these optimisations, which is acceptable for a
+CLI tool.
+
+### Reproducible builds
+
+WASM builds pin `SOURCE_DATE_EPOCH` and use deterministic compiler flags so
+that the same commit always produces byte-identical `.wasm` output. The
+`Makefile` target `verify-reproducible` checks this in CI.
+
+## Consequences
+
+**Positive:**
+- Single source of truth for shared business logic — no duplication between
+  contract and CLI.
+- Feature-flag matrix CI validates all combinations (`feature-matrix.yml`).
+- WASM size is tightly controlled (350 KB target).
+- Reproducible builds give deployers confidence in the artifact.
+
+**Negative:**
+- Developers must remember `--no-default-features --features wasm` when
+  building for Soroban — the `Makefile` and CI scripts abstract this.
+- Feature-gate `#[cfg]` boilerplate in files that bridge the two modes.
+- The release profile is WASM-centric; native builds get aggressive LTO and
+  stripping that slow compilation.
+
+**Alternatives considered:**
+- **Separate crates** — would eliminate `#[cfg]` noise but introduce
+  dependency duplication and a harder release coordination problem. Rejected
+  because the shared surface is large.
+- **Workspace with two members** — cleaner separation but adds workspace
+  overhead and complicates cross-crate refactoring. Could be revisited if
+  the shared surface shrinks.

--- a/docs/adr/ADR-0003-contract-lifecycle-and-schema-versioning.md
+++ b/docs/adr/ADR-0003-contract-lifecycle-and-schema-versioning.md
@@ -1,0 +1,114 @@
+# ADR-0003: Contract Lifecycle and Schema Versioning
+
+- **Status:** Accepted
+- **Date:** 2026-07-29
+- **Author:** Project Maintainers
+- **Supersedes:** None
+
+## Context
+
+The AnchorKit Soroban contract is a long-lived on-chain program that may be
+upgraded multiple times after deployment. Upgrades can change the data layout
+(adding/removing/renaming fields in persisted structs), the contract logic, or
+both. Unlike a disposable proxy, every version of the contract shares the same
+persistent storage on the Soroban ledger.
+
+The project needed a lifecycle model that answers:
+
+1. How does the contract transition from uninitialised to operational?
+2. How are WASM upgrades performed safely?
+3. How do data schema changes work across upgrades?
+4. How are sessions (multi-operation workflows) managed on-chain?
+
+## Decision
+
+### 1. Explicit initialisation
+
+The contract has a two-phase boot: deploy then initialise. `initialize()` sets
+the admin address, writes an `INITIALIZED` flag, and records the initial schema
+version. `initialize()` is callable exactly once — the flag prevents re-initialisation
+after upgrades. Every public function checks `is_initialized()` and returns
+`NotInitialized` (code 23) if the flag is absent.
+
+### 2. Upgrade via WASM hash replacement
+
+`upgrade(new_wasm_hash)` atomically replaces the contract bytecode.
+It is gated to the primary admin only (no role/capability delegation) to
+prevent accidental privilege escalation. Each upgrade:
+- Increments the patch version
+- Records the old and new WASM hashes
+- Emits an `UpgradeEvent`
+- Writes an audit log entry
+
+The admin may roll back by re-deploying the previous WASM hash (kept in the
+release archive).
+
+### 3. Schema versioning separated from upgrades
+
+`migrate(new_schema_version, batch_size)` advances the on-chain schema
+version. It is deliberately a **separate call** from `upgrade` so that:
+
+- State transitions are explicit and auditable
+- A failed migration does not roll back the WASM upgrade
+- Batch migration can run across multiple invocations (for large datasets)
+
+Schema versions are monotonic (`SCHEMA_V1 = 1`, `SCHEMA_V2 = 2`). The
+contract rejects migration to a version the current binary does not
+understand (`UnsupportedCapabilityVersion`).
+
+### 4. Session lifecycle state machine
+
+Multi-operation workflows use an explicit state machine:
+
+```
+[Created] → [Active] → [Exhausted]
+    │           │            │
+    └─→ [Closed] ←───────────┘
+    │
+    └─→ [Expired] (ttl elapsed, any state)
+```
+
+- `Created`: session opened, no operations recorded
+- `Active`: at least one operation, more allowed
+- `Exhausted`: operation limit reached
+- `Closed`: explicitly closed by the initiator
+- `Expired`: TTL elapsed (computed at read time without writing)
+
+Invalid transitions are rejected with specific error codes.
+
+### 5. Admin capability model
+
+Rather than a single admin-or-not gate, the contract uses two layers of
+delegated authority:
+
+| Layer | Mechanism | Scope |
+|-------|-----------|-------|
+| Roles | `grant_role` / `revoke_role` | Coarse-grained category (KycAdmin, AttestorAdmin, CacheAdmin) |
+| Capabilities | `grant_capability` / `revoke_capability` | Fine-grained per-operation |
+
+The primary admin always passes every check. Roles and capabilities are
+additive — holding either is sufficient to invoke the protected operation.
+
+## Consequences
+
+**Positive:**
+- Safe upgrade path: WASM can change without data loss, and data can be
+  migrated independently.
+- Audit trail: every upgrade, migration, and admin action is logged.
+- Deterministic session semantics: callers can rely on lifecycle guarantees.
+- Fine-grained delegation reduces the attack surface of admin keys.
+
+**Negative:**
+- Migration complexity: batch migrations require multiple invocations for
+  large stores (mitigated by batched v1→v2 quote migration).
+- Session TTL is computed at read time (not eagerly expired), which means
+  expired sessions may consume storage until compacted.
+- The dual role/capability model adds conceptual overhead for new
+  integrators.
+
+**Alternatives considered:**
+- **Proxy pattern** — a separate proxy contract delegating to implementation
+  contracts. Rejected because Soroban's native `upgrade` is simpler and
+  cheaper; the proxy would add another contract to audit.
+- **Single admin gate** — simpler but offers no delegation. Rejected when
+  operational needs required scoped access for KYC and cache operations.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,37 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the AnchorKit project.
+
+An ADR captures a significant architectural decision made by the project team, including the context, the decision, and the consequences.
+
+## ADR Index
+
+| ID | Title | Status |
+|----|-------|--------|
+| [ADR-0001](ADR-0001-record-architecture-decisions.md) | Record Architecture Decisions | Accepted |
+| [ADR-0002](ADR-0002-dual-build-strategy.md) | Dual-Build Strategy | Accepted |
+| [ADR-0003](ADR-0003-contract-lifecycle-and-schema-versioning.md) | Contract Lifecycle and Schema Versioning | Accepted |
+
+## What is an ADR?
+
+An Architecture Decision Record is a short document that captures:
+
+- **Context** — the forces and circumstances that led to the decision
+- **Decision** — what was decided and why alternatives were rejected
+- **Consequences** — the trade-offs, risks, and follow-up work that result
+
+## How to write a new ADR
+
+1. Copy `ADR-0000-template.md` to `ADR-XXXX-title.md`
+2. Fill in the sections
+3. Update this index
+4. Open a PR for review
+
+## Status meanings
+
+| Status | Meaning |
+|--------|---------|
+| Proposed | Under discussion |
+| Accepted | Agreed and implemented |
+| Deprecated | Superseded by a later ADR |
+| Superseded | Replaced by a newer ADR |


### PR DESCRIPTION
## Summary

Add Architecture Decision Record (ADR) process and initial records covering the project's most important design choices.

## Changes

### New files

- **`docs/adr/README.md`** — ADR index with record listing, status reference, and contribution instructions
- **`docs/adr/ADR-0001-record-architecture-decisions.md`** — Defines the ADR process itself: format, review flow, numbering scheme, and status lifecycle
- **`docs/adr/ADR-0002-dual-build-strategy.md`** — Documents the single-crate dual-build approach (native CLI + Soroban WASM contract) driven by feature flags, including build optimisation, reproducible builds, and alternatives considered
- **`docs/adr/ADR-0003-contract-lifecycle-and-schema-versioning.md`** — Covers the contract lifecycle model: explicit initialisation, WASM upgrade via hash replacement, schema versioning separated from upgrades, session state machine, and the admin role/capability delegation model

### Modified files

- **`docs/CONTRIBUTING.md`** — Added Architecture Decision Records section linking to all ADRs, placed between Documentation Standards and Git Workflow
- **`docs/ONBOARDING.md`** — Added `docs/adr/` to the repo overview tree and an ADR reference in the References section

## Acceptance criteria

- [x] Repository contains ADRs in `docs/adr/`
- [x] ADRs are linked from contributor documentation (`CONTRIBUTING.md`, `ONBOARDING.md`)
- [x] Records capture the most important design decisions (build strategy, contract lifecycle)


Closes #694 