### PR TITLE
docs/feat: add roadmap, triage, release checklist, and branch/PR hygiene

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Summary
+
+<!-- What does this PR do and why? One to three bullet points. -->
+
+-
+
+## Changes
+
+<!-- List the key files or components changed. -->
+
+-
+
+## Testing
+
+<!-- How was this tested? Check all that apply. -->
+
+- [ ] `cargo test` passes
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
+- [ ] WASM build passes (`cargo build --target wasm32-unknown-unknown`)
+- [ ] Manual testing (describe below)
+
+<!-- Describe any manual testing steps or edge cases verified. -->
+
+## Related issues
+
+<!-- Use "closes #<number>" to auto-close issues on merge. -->
+
+closes #
+
+## Checklist
+
+- [ ] Branch name follows the convention (`<type>/<description>`) — see [branch-pr-hygiene.md](../docs/branch-pr-hygiene.md)
+- [ ] PR title follows Conventional Commits format (`feat(scope): subject`)
+- [ ] Public API changes are reflected in `api_snapshots/` (run `./scripts/snapshot_api.sh` if needed)
+- [ ] `CHANGELOG.md` updated (for user-facing changes)
+- [ ] Documentation updated (for new behavior or config options)
+- [ ] Security review done if touching auth, crypto, HTTP integrations, or deployment — see [SECURITY_REVIEW_CHECKLIST.md](../docs/SECURITY_REVIEW_CHECKLIST.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -140,6 +140,22 @@ pub fn my_function(param1: Type1, param2: Type2) -> ReturnType {
 }
 ```
 
+## Roadmap and milestones
+
+The project roadmap is maintained in [ROADMAP.md](ROADMAP.md). It describes current milestone phases, planned work, and how to link issues to milestones.
+
+## Issue triage
+
+New issues are triaged and prioritized according to the process in [TRIAGE.md](TRIAGE.md). If you are picking up an issue, check the priority labels and milestone assignment there.
+
+## Branch and PR hygiene
+
+Branch naming conventions, PR workflow, and local automation are documented in [branch-pr-hygiene.md](branch-pr-hygiene.md). Run the branch name validator before pushing:
+
+```bash
+./scripts/validate-branch-name.sh
+```
+
 ## Architecture Decision Records
 
 Important architectural decisions are captured as Architecture Decision Records
@@ -218,6 +234,16 @@ Run a specific test:
 ```bash
 cargo test test_name
 ```
+
+## Release checklist
+
+Before tagging a release, run the automated checklist:
+
+```bash
+./scripts/release-checklist.sh <version>
+```
+
+Full documentation is in [release-checklist.md](release-checklist.md).
 
 ## CI/CD Pipeline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,85 @@
+# SorobanAnchor Roadmap
+
+This document tracks the project's milestone phases and strategic priorities. It is updated as the backlog is refined and issues are triaged.
+
+For the issue triage and prioritization process, see [TRIAGE.md](TRIAGE.md).
+
+## How to use this roadmap
+
+- Each milestone groups related issues and features into a coherent release target.
+- Issues are linked to milestones via [GitHub Milestones](../../milestones).
+- To propose a new item, open an issue and a maintainer will triage and assign it to a milestone during the next review cycle.
+- Status key: `[ ]` planned · `[~]` in progress · `[x]` done
+
+---
+
+## Milestone 0 — Foundation (current)
+
+Goal: stable core library, reproducible builds, CI, and contributor infrastructure.
+
+- [x] Core contract: attestations, sessions, SEP-10 JWT, SEP-6 normalization
+- [x] Multi-asset routing across corridors
+- [x] Rate limiting and retry/backoff
+- [x] Reproducible WASM builds and dual-build strategy (ADR-0002)
+- [x] Schema versioning and contract lifecycle (ADR-0003)
+- [x] CI pipeline: fmt, clippy, tests, WASM build, dependency audit
+- [x] Architecture Decision Records (ADRs)
+- [x] API contract snapshots and changelog generation
+- [x] Contributor documentation and security review checklist
+- [~] Roadmap and milestone tracking (#696)
+- [~] Issue triage and prioritization workflow (#697)
+- [~] Release checklist automation (#698)
+- [~] Branch and PR hygiene automation (#699)
+
+---
+
+## Milestone 1 — Reliability and Observability
+
+Goal: production-grade reliability, structured observability, and expanded SEP coverage.
+
+- [ ] Structured logging with trace propagation across all critical paths
+- [ ] Live smoke tests against testnet anchors
+- [ ] Ledger boundary and replay protection hardening
+- [ ] SEP-31 cross-border payment normalization
+- [ ] Vendor status mapping and circuit breaker
+- [ ] Coverage thresholds enforced in CI (≥ 80 % line coverage)
+- [ ] Fuzz targets for config parsing, domain validation, JWT, and JSON responses
+
+---
+
+## Milestone 2 — Developer Experience
+
+Goal: lower the barrier to integration and contribution.
+
+- [ ] CLI examples and interactive playground UI
+- [ ] Generated API docs published to GitHub Pages
+- [ ] Cross-language usage guide (JS/TS bindings)
+- [ ] Mock mode and offline mode documented end-to-end
+- [ ] Onboarding guide covering first-time contributor path
+- [ ] Storybook for UI components
+
+---
+
+## Milestone 3 — Production Readiness (v1.0)
+
+Goal: stable public API, security audit, and first tagged release.
+
+- [ ] Stable public API surface with semver guarantees
+- [ ] External security audit and remediation
+- [ ] Release signing and artifact verification
+- [ ] Upgrade playbook from pre-1.0 builds
+- [ ] Migration guide for schema changes
+- [ ] Full governance and security policy published
+
+---
+
+## Linking issues to milestones
+
+1. Open or find the relevant issue on GitHub.
+2. In the issue sidebar, click **Milestone** and select the target milestone.
+3. Add the appropriate priority label (see [TRIAGE.md](TRIAGE.md)).
+4. Reference the issue in commits with `closes #<number>` so it closes automatically on merge.
+
+## Updating this document
+
+Maintainers should update milestone status after each sprint review. Move items from `[ ]` to `[~]` when work starts and to `[x]` when merged. Add new items under the appropriate milestone as the backlog is refined.

--- a/docs/TRIAGE.md
+++ b/docs/TRIAGE.md
@@ -1,0 +1,99 @@
+# Issue Triage and Prioritization Workflow
+
+This document defines how issues are categorized, prioritized, and assigned in SorobanAnchor so that high-value work is addressed first and the backlog stays healthy.
+
+## Overview
+
+Triage runs on a rolling basis. Any maintainer can triage new issues. The goal is to give every issue a **type label**, a **priority label**, and a **milestone assignment** within five business days of opening.
+
+---
+
+## Step-by-step triage process
+
+### 1. Is the issue actionable?
+
+| Situation | Action |
+|-----------|--------|
+| Duplicate | Add `duplicate` label, link to the original, close |
+| Not reproducible / missing info | Add `needs-info`, ask the reporter for details |
+| Out of scope | Add `wontfix`, explain why, close politely |
+| Valid — proceed | Continue to step 2 |
+
+### 2. Assign a type label
+
+| Label | When to use |
+|-------|-------------|
+| `bug` | Incorrect behavior, regression, or security flaw |
+| `enhancement` | New feature or improvement to existing behavior |
+| `docs` | Documentation gap or error |
+| `chore` | Dependency updates, CI tweaks, tooling |
+| `question` | Needs clarification before it can be acted on |
+
+### 3. Assign a priority label
+
+Use the rubric below to pick exactly one priority:
+
+| Label | Definition | Examples |
+|-------|------------|---------|
+| `P0 — critical` | Production broken, data loss, or security vulnerability | Auth bypass, contract state corruption |
+| `P1 — high` | Major feature broken or blocking a release | CI always red, WASM build fails |
+| `P2 — medium` | Important improvement, not blocking | Missing SEP coverage, coverage gap |
+| `P3 — low` | Nice-to-have, long-tail cleanup | Typo in docs, minor UX polish |
+
+**Prioritization rubric — ask these questions in order:**
+
+1. **Security impact?** → P0 immediately; follow the [security policy](governance-and-security.md).
+2. **Blocking a release or another team?** → P1.
+3. **Degraded functionality that has a workaround?** → P2.
+4. **Everything else.** → P3.
+
+### 4. Assign to a milestone
+
+Consult the [ROADMAP.md](ROADMAP.md) and assign the issue to the earliest milestone where it fits. If it does not fit any current milestone, leave it unassigned and add the `backlog` label.
+
+### 5. Assign an owner (optional)
+
+If a maintainer is ready to work on the issue immediately, self-assign it. Otherwise, leave it unassigned so contributors can pick it up.
+
+---
+
+## Weekly triage review
+
+Maintainers run a short (≤ 30 min) triage meeting or async thread to:
+
+- Review all new issues opened since the last cycle.
+- Promote or demote priorities based on changed circumstances.
+- Move stale `P3` issues older than 90 days to `backlog` or close as `wontfix`.
+- Confirm milestone assignments ahead of each release.
+
+---
+
+## Labels reference
+
+| Label | Purpose |
+|-------|---------|
+| `P0 — critical` | Must fix immediately |
+| `P1 — high` | Fix in current milestone |
+| `P2 — medium` | Fix in next milestone |
+| `P3 — low` | Fix when capacity allows |
+| `bug` | Incorrect behavior |
+| `enhancement` | New or improved feature |
+| `docs` | Documentation work |
+| `chore` | Maintenance |
+| `question` | Needs clarification |
+| `good first issue` | Suitable for new contributors |
+| `help wanted` | Extra attention needed |
+| `needs-info` | Awaiting reporter response |
+| `duplicate` | Already tracked elsewhere |
+| `wontfix` | Out of scope or intentional |
+| `backlog` | Valid but unscheduled |
+
+---
+
+## Contributor guide
+
+- **Reporting a bug:** Use the bug report template and include reproduction steps, expected vs. actual behavior, and environment details.
+- **Requesting a feature:** Describe the use case and why existing behavior does not satisfy it.
+- **Picking up an issue:** Comment "I'd like to work on this" so it can be assigned to you. Start from issues labeled `good first issue` or `help wanted`.
+
+For the full contribution workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/branch-pr-hygiene.md
+++ b/docs/branch-pr-hygiene.md
@@ -1,0 +1,120 @@
+# Branch and PR Hygiene
+
+This document defines branch naming conventions, PR workflow, and the automation that supports them. Following these guidelines keeps the repository clean and makes reviews faster.
+
+## Branch naming
+
+All branches must follow this pattern:
+
+```
+<type>/<short-description>
+```
+
+| Type | When to use |
+|------|-------------|
+| `feat/` | New feature or enhancement |
+| `fix/` | Bug fix |
+| `docs/` | Documentation only |
+| `chore/` | Maintenance, dependency updates, CI changes |
+| `refactor/` | Code restructuring without behavior change |
+| `test/` | Test-only changes |
+| `release/` | Release preparation |
+
+**Rules:**
+- Use lowercase and hyphens, no underscores or spaces.
+- Keep the description short (≤ 40 characters after the prefix).
+- Include the issue number when one exists: `feat/add-roadmap-696`.
+
+**Valid examples:**
+```
+feat/add-roadmap-696
+fix/jwt-expiry-parsing
+docs/triage-workflow-697
+chore/update-cargo-deps
+```
+
+**Invalid examples:**
+```
+feature_new_thing        # wrong type prefix and uses underscores
+Fix/JwtExpiry            # uppercase
+my-branch                # no type prefix
+```
+
+To validate your branch name before pushing, run:
+
+```bash
+./scripts/validate-branch-name.sh
+```
+
+---
+
+## Pull request workflow
+
+### Before opening a PR
+
+1. Run the full validation suite locally:
+   ```bash
+   make check
+   ```
+2. Ensure your branch is up to date with `main`:
+   ```bash
+   git fetch origin && git rebase origin/main
+   ```
+3. Verify your branch name follows the convention above.
+
+### Opening a PR
+
+- The [PR template](.github/pull_request_template.md) is filled in automatically — complete every section.
+- Title format: `<type>(<scope>): <subject>` following [Conventional Commits](CONTRIBUTING.md#commit-message-format).
+- Link the issue(s) being addressed using `closes #<number>` in the PR description so they close automatically on merge.
+- Keep PRs focused: one logical change per PR. Split unrelated fixes into separate PRs.
+
+### Review expectations
+
+- A PR needs **one** maintainer approval to merge, or **two** for changes touching auth, crypto, or deployment (see [Governance and Security](governance-and-security.md)).
+- Address all review comments or explain why they do not apply.
+- Do not force-push to a PR branch that is under review — add fixup commits instead.
+
+### Merging
+
+- Prefer **squash and merge** for feature and fix branches to keep `main` history linear.
+- Use **merge commit** only for release branches.
+- Delete the source branch after merging — GitHub can be configured to do this automatically.
+
+---
+
+## Keeping branches clean
+
+- **Delete merged branches** promptly. GitHub's "delete branch on merge" setting automates this.
+- **Do not leave stale branches** open for more than 30 days without activity. Maintainers may close PRs with no activity after this period with a `stale` label warning.
+- **Rebase, don't merge** `main` into your feature branch — this avoids noisy merge commits.
+
+---
+
+## Automation
+
+### Branch name validator
+
+`scripts/validate-branch-name.sh` checks the current branch name against the naming convention. Run it manually or add it to your local pre-push hook:
+
+```bash
+# Add to your local pre-push hook
+echo './scripts/validate-branch-name.sh' >> .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+### PR template
+
+`.github/pull_request_template.md` is loaded automatically when you open a PR on GitHub. It prompts for a summary, test plan, and issue references.
+
+### Setup hooks
+
+To install all recommended local git hooks at once:
+
+```bash
+./scripts/setup-hooks.sh
+```
+
+---
+
+For the full contribution guide, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,99 @@
+# Release Checklist
+
+This document describes the automated release checklist and how maintainers run it before every release.
+
+## Quick start
+
+```bash
+./scripts/release-checklist.sh <version>
+```
+
+Example:
+
+```bash
+./scripts/release-checklist.sh 0.3.0
+```
+
+The script will walk through every prerequisite, report pass/fail for each step, and exit non-zero if any check fails. Fix all failures before tagging the release.
+
+---
+
+## What the checklist covers
+
+| Step | Check |
+|------|-------|
+| Git state | Working tree is clean (no uncommitted changes) |
+| Branch | On `main` and up to date with `origin/main` |
+| Version | `Cargo.toml` version matches the supplied version argument |
+| Changelog | `CHANGELOG.md` contains an entry for the new version |
+| Formatting | `cargo fmt --all -- --check` passes |
+| Linting | `cargo clippy --all-targets --all-features -- -D warnings` passes |
+| Tests | `cargo test` passes |
+| WASM build | `cargo build --target wasm32-unknown-unknown` succeeds |
+| Dependency audit | `cargo audit` reports no vulnerabilities |
+| API snapshot | No unexpected diff in `api_snapshots/` |
+
+---
+
+## Running individual steps
+
+If you need to re-run a single step after fixing an issue:
+
+```bash
+# Format check only
+cargo fmt --all -- --check
+
+# Lint only
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Tests only
+cargo test
+
+# WASM build only
+cargo build --target wasm32-unknown-unknown
+
+# Dependency audit only
+cargo audit
+
+# API snapshot diff only
+./scripts/diff_api_snapshot.sh
+```
+
+---
+
+## After the checklist passes
+
+1. Tag the release:
+   ```bash
+   git tag -s v<version> -m "Release v<version>"
+   git push origin v<version>
+   ```
+
+2. Package the release artifacts:
+   ```bash
+   ./scripts/package_release.sh
+   ```
+
+3. Sign and verify artifacts:
+   ```bash
+   ./scripts/sign_release.sh
+   ./scripts/verify_release.sh
+   ```
+
+4. Publish the GitHub Release with the changelog entry and attach the signed artifacts.
+
+For the full signing and verification process, see [release-signing.md](release-signing.md).  
+For reproducible build verification, see [REPRODUCIBLE_BUILDS.md](REPRODUCIBLE_BUILDS.md).
+
+---
+
+## Troubleshooting
+
+**`cargo audit` reports a vulnerability**  
+Update the affected crate (`cargo update -p <crate>`) or add a temporary advisory ignore with justification in `deny.toml`. Do not release with unacknowledged vulnerabilities.
+
+**API snapshot diff is unexpected**  
+Review `api_snapshots/` with `./scripts/diff_api_snapshot.sh`. If the change is intentional, update the snapshot with `./scripts/snapshot_api.sh` and document the change in `CHANGELOG.md`.
+
+**WASM build fails**  
+Check that no `std`-only dependencies were introduced. Run `./scripts/validate_no_std_compliance.sh` for details.

--- a/scripts/release-checklist.sh
+++ b/scripts/release-checklist.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Release checklist automation for SorobanAnchor.
+# Usage: ./scripts/release-checklist.sh <version>
+# See docs/release-checklist.md for full documentation.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; FAILURES=$((FAILURES + 1)); }
+info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+FAILURES=0
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 0.3.0"
+    exit 1
+fi
+
+VERSION="$1"
+info "Running release checklist for v${VERSION}"
+echo "-------------------------------------------"
+
+# 1. Git working tree is clean
+if git diff --quiet && git diff --cached --quiet; then
+    pass "Working tree is clean"
+else
+    fail "Working tree has uncommitted changes — commit or stash them first"
+fi
+
+# 2. On main branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" == "main" ]]; then
+    pass "On main branch"
+else
+    fail "Not on main branch (current: ${CURRENT_BRANCH})"
+fi
+
+# 3. Up to date with origin/main
+git fetch origin main --quiet 2>/dev/null || true
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main 2>/dev/null || echo "unknown")
+if [[ "$LOCAL" == "$REMOTE" ]]; then
+    pass "Branch is up to date with origin/main"
+else
+    fail "Branch is behind origin/main — pull first"
+fi
+
+# 4. Cargo.toml version matches
+CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+if [[ "$CARGO_VERSION" == "$VERSION" ]]; then
+    pass "Cargo.toml version matches (${VERSION})"
+else
+    fail "Cargo.toml version is '${CARGO_VERSION}', expected '${VERSION}'"
+fi
+
+# 5. CHANGELOG.md has an entry for this version
+if grep -q "\[${VERSION}\]\|## ${VERSION}\|# ${VERSION}" CHANGELOG.md 2>/dev/null; then
+    pass "CHANGELOG.md contains entry for v${VERSION}"
+else
+    fail "CHANGELOG.md has no entry for v${VERSION} — update it before releasing"
+fi
+
+# 6. Formatting
+info "Checking formatting..."
+if cargo fmt --all -- --check 2>&1; then
+    pass "cargo fmt check passed"
+else
+    fail "Formatting issues found — run 'cargo fmt --all' to fix"
+fi
+
+# 7. Linting
+info "Running clippy..."
+if cargo clippy --all-targets --all-features -- -D warnings 2>&1; then
+    pass "cargo clippy passed"
+else
+    fail "Clippy warnings found — fix them before releasing"
+fi
+
+# 8. Tests
+info "Running tests..."
+if cargo test 2>&1; then
+    pass "cargo test passed"
+else
+    fail "Tests failed — fix them before releasing"
+fi
+
+# 9. WASM build
+info "Building WASM target..."
+if cargo build --target wasm32-unknown-unknown 2>&1; then
+    pass "WASM build succeeded"
+else
+    fail "WASM build failed — check no_std compliance"
+fi
+
+# 10. Dependency audit
+if command -v cargo-audit &>/dev/null; then
+    info "Running dependency audit..."
+    if cargo audit 2>&1; then
+        pass "cargo audit: no vulnerabilities"
+    else
+        fail "Vulnerabilities found — resolve them before releasing"
+    fi
+else
+    info "cargo-audit not installed — skipping (install with: cargo install cargo-audit)"
+fi
+
+# 11. API snapshot diff
+if [[ -f scripts/diff_api_snapshot.sh ]]; then
+    info "Checking API snapshot diff..."
+    if bash scripts/diff_api_snapshot.sh 2>&1; then
+        pass "API snapshot has no unexpected diff"
+    else
+        fail "Unexpected API snapshot diff — review and update if intentional"
+    fi
+else
+    info "diff_api_snapshot.sh not found — skipping API snapshot check"
+fi
+
+echo "-------------------------------------------"
+if [[ $FAILURES -eq 0 ]]; then
+    echo -e "${GREEN}All checks passed. Ready to release v${VERSION}.${NC}"
+    echo ""
+    echo "Next steps:"
+    echo "  git tag -s v${VERSION} -m 'Release v${VERSION}'"
+    echo "  git push origin v${VERSION}"
+    echo "  ./scripts/package_release.sh"
+    echo "  ./scripts/sign_release.sh"
+    exit 0
+else
+    echo -e "${RED}${FAILURES} check(s) failed. Fix the issues above before releasing.${NC}"
+    exit 1
+fi

--- a/scripts/validate-branch-name.sh
+++ b/scripts/validate-branch-name.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Validates the current git branch name against the project naming convention.
+# See docs/branch-pr-hygiene.md for the full convention.
+
+set -euo pipefail
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+PATTERN='^(feat|fix|docs|chore|refactor|test|release)/[a-z0-9][a-z0-9-]{0,39}$'
+EXEMPT='^(main|master|HEAD)$'
+
+if [[ "$BRANCH" =~ $EXEMPT ]]; then
+    exit 0
+fi
+
+if [[ "$BRANCH" =~ $PATTERN ]]; then
+    echo "Branch name OK: ${BRANCH}"
+    exit 0
+else
+    echo "ERROR: Branch name '${BRANCH}' does not follow the convention."
+    echo ""
+    echo "Required format: <type>/<short-description>"
+    echo "Allowed types:   feat, fix, docs, chore, refactor, test, release"
+    echo "Rules:           lowercase, hyphens only, description ≤ 40 chars"
+    echo ""
+    echo "Valid examples:"
+    echo "  feat/add-roadmap-696"
+    echo "  fix/jwt-expiry-parsing"
+    echo "  docs/triage-workflow-697"
+    echo ""
+    echo "See docs/branch-pr-hygiene.md for details."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds a project roadmap with milestone phases and status tracking
- Defines an issue triage and prioritization workflow (P0–P3 rubric, labels, weekly review)
- Adds automated release checklist script with pass/fail reporting for all release prerequisites
- Adds PR template, branch name validator script, and branch/PR hygiene guide

## Changes

- `docs/ROADMAP.md` — milestone phases and how to link issues
- `docs/TRIAGE.md` — triage process, priority rubric, label reference
- `docs/release-checklist.md` — release checklist documentation
- `scripts/release-checklist.sh` — automated release prerequisite validator
- `docs/branch-pr-hygiene.md` — branch naming conventions and PR workflow
- `scripts/validate-branch-name.sh` — branch name linter
- `.github/pull_request_template.md` — PR template auto-loaded on GitHub
- `docs/CONTRIBUTING.md` — links to all new docs

## Related issues

closes #696
closes #697
closes #698
closes #699