### PR TITLE
 test(retry,sep10): lock in zero-delay and JWT structural guards, name backoff cap constant 

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -78,12 +78,17 @@ pub struct RetryConfig {
     pub jitter_policy: JitterPolicy,
 }
 
+/// Default delay cap in milliseconds for [`RetryConfig::default`] — bounds how
+/// large the exponential backoff is allowed to grow before retries stop
+/// waiting any longer between attempts.
+const DEFAULT_MAX_DELAY_MS: u64 = 5_000;
+
 impl Default for RetryConfig {
     fn default() -> Self {
         RetryConfig {
             max_attempts: 3,
             base_delay_ms: 100,
-            max_delay_ms: 5_000,
+            max_delay_ms: DEFAULT_MAX_DELAY_MS,
             backoff_multiplier: 2,
             strategy: BackoffStrategy::default(),
             jitter_policy: JitterPolicy::default(),
@@ -845,6 +850,37 @@ mod retry_tests {
         let mut js = MockJitterSource::new(vec![999]);
         assert_eq!(config.delay_for_attempt(0, &mut js), 0);
         assert_eq!(config.delay_for_attempt(1, &mut js), 0);
+    }
+
+    /// Issue #762: an explicit zero `base_delay_ms` must be preserved end to
+    /// end — `sleep_fn` should observe `0` on every retry, not a positive
+    /// default substituted in its place.
+    #[test]
+    fn test_explicit_zero_base_delay_reaches_sleep_fn() {
+        let config = RetryConfig::new(3, 0, 1_000, 2);
+        assert_eq!(config.base_delay_ms, 0, "explicit zero must be stored as-is");
+
+        let mut recorded: Vec<u64> = Vec::new();
+        let mut js = MockJitterSource::new(vec![0]);
+        let _ = retry_with_backoff(
+            &config,
+            |_| Err::<i32, _>(TestError::Transient),
+            is_retryable_test,
+            |ms| recorded.push(ms),
+            &mut js,
+        );
+
+        assert_eq!(recorded.len(), 2);
+        assert!(recorded.iter().all(|&ms| ms == 0), "recorded delays: {recorded:?}");
+
+        // The default configuration (no explicit zero given) must remain
+        // unaffected by the change above.
+        let default_config = RetryConfig::default();
+        assert_eq!(default_config.base_delay_ms, 100);
+
+        // A positive explicit value must also be unaffected.
+        let positive_config = RetryConfig::new(3, 250, 1_000, 2);
+        assert_eq!(positive_config.base_delay_ms, 250);
     }
 
     /// Total delay (including jitter) never exceeds max_delay_ms.

--- a/tests/sep10_hardening_tests.rs
+++ b/tests/sep10_hardening_tests.rs
@@ -54,6 +54,95 @@ mod sep10_hardening_tests {
     }
 
     // -----------------------------------------------------------------------
+    // Issue #766: empty and whitespace-only tokens are rejected up front,
+    // before any base64/JSON decoding is attempted.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_empty_token() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+
+        let token = String::from_str(&env, "");
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt(&env, &token, &pk, None).is_err(),
+                "empty token must be rejected"
+            );
+        });
+    }
+
+    #[test]
+    fn rejects_whitespace_only_token() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+
+        let token = String::from_str(&env, "   ");
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt(&env, &token, &pk, None).is_err(),
+                "whitespace-only token must be rejected"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #767: a token must have exactly three dot-separated parts.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_four_part_token() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        // An otherwise well-formed token with one extra trailing segment.
+        let jwt = build_sep10_jwt(&sk, &sub_str, 5_000);
+        let four_part_jwt = format!("{}.extra", jwt);
+        let token = String::from_str(&env, &four_part_jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt(&env, &token, &pk, None).is_err(),
+                "four-part token must be rejected"
+            );
+        });
+    }
+
+    #[test]
+    fn accepts_structurally_valid_three_part_token() {
+        let env = make_env();
+        let contract_id = make_contract_id(&env);
+        ledger(&env, 1_000);
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk = Bytes::from_slice(&env, sk.verifying_key().as_bytes());
+        let sub = Address::generate(&env).to_string();
+        let sub_str: std::string::String = sub.to_string();
+
+        let jwt = build_sep10_jwt(&sk, &sub_str, 5_000);
+        let token = String::from_str(&env, &jwt);
+
+        env.as_contract(&contract_id, || {
+            assert!(
+                verify_sep10_jwt(&env, &token, &pk, None).is_ok(),
+                "structurally valid three-part token must reach verification"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
     // iat: must be present (already tested upstream — confirm still rejected)
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
Title:



Summary
Locked in zero-delay retry behavior with a regression test and named the RetryConfig default max-delay literal as a constant.
Locked in JWT empty-input and exact-three-part structural checks with regression tests in the SEP-10 hardening suite.
No production logic changed in sep10_jwt.rs: the empty-token guard and exact dot-count check were already correct, so this closes the tickets by adding the requested coverage rather than "fixing" behavior that already worked.
Changes
src/retry.rs
Added DEFAULT_MAX_DELAY_MS: u64 = 5_000 beside impl Default for RetryConfig, replacing the bare 5_000 cap literal (#765). No behavior change.
Added test_explicit_zero_base_delay_reaches_sleep_fn, asserting an explicit base_delay_ms: 0 reaches sleep_fn as 0 on every retry, while the default (100ms) and a positive value are unaffected (#762).
tests/sep10_hardening_tests.rs
Added rejects_empty_token / rejects_whitespace_only_token, confirming verify_sep10_jwt rejects empty/whitespace-only input before any decoding (#766).
Added rejects_four_part_token / accepts_structurally_valid_three_part_token, confirming exact three-part structure is enforced while a valid token still verifies (#767).
Testing
 cargo fmt — clean on both touched files (verified via rustfmt --check directly; cargo fmt on the whole workspace shows unrelated pre-existing drift in other files)
 cargo test — blocked in this environment, unrelated to this change: ed25519-dalek v3.0.0 vs soroban-env-host v21.2.1 (SigningKey::generate / ChaCha20Rng: CryptoRng) fails to compile for any test target, before reaching these files. Confirmed pre-existing by testing on main with these changes stashed.
 cargo build --lib — produces the same 8 pre-existing errors with and without this change (unrelated: missing jsonschema in [dependencies], two missing ErrorCode variants, bool/Result<bool, _> mismatches in contract.rs). No new errors introduced by this PR.
Manual review: traced delay_for_attempt / base_delay_for_attempt for all backoff strategies and jitter policies, and the SEP-10 token-splitting loop, to confirm the described defects don't reproduce against current main before adding coverage.
Related issues
closes #762
closes #765
closes #766
closes #767

Checklist
 Branch name follows the convention (<type>/<description>)
 PR title follows Conventional Commits format (feat(scope): subject)
 Public API changes reflected in api_snapshots/ — n/a, no public API changed
 CHANGELOG.md updated — n/a, no user-facing behavior changed
 Documentation updated — n/a
 Security review — n/a, touches JWT/retry code but adds only test coverage and a private constant rename; no logic change
