### PR TITLE
fix: rate-limiter overflow & denial error, dead branch removal, replay-key byte preservation

### DIFF
--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -274,7 +274,10 @@ impl RateLimiter {
         
         // Check if limit is exceeded
         if state.submission_count >= config.max_submissions {
-            return Err(AnchorKitError::rate_limit_exceeded());
+            return Err(AnchorKitError::new(
+                crate::errors::ErrorCode::RateLimitExceeded,
+                "Request throttled: rate-limit window capacity exhausted; retry after the window expires",
+            ));
         }
 
         // Opt-in burst-control gate (#630). A no-op when no BurstControlConfig
@@ -290,8 +293,8 @@ impl RateLimiter {
             Self::check_fairness(env, config, &state, &fairness_config, current_ledger)?;
         }
 
-        // Increment counter and save state
-        state.submission_count += 1;
+        // Increment counter and save state; saturating_add prevents wrapping to zero.
+        state.submission_count = state.submission_count.saturating_add(1);
         env.storage().persistent().set(&state_key, &state);
 
         Ok(())
@@ -584,33 +587,20 @@ impl RateLimiter {
     
     /// Check if a rate-limit window has expired.
     ///
-    /// Uses `checked_sub` instead of `saturating_sub` so that a sequence
-    /// anomaly where `current < window_start` (e.g. due to a ledger rollback
-    /// or corrupted stored state) is treated as **not expired** rather than
-    /// silently wrapping to 0 and comparing against `window_length`.
-    ///
-    /// # Safe-default rationale
-    ///
-    /// When `current_ledger < window_start_ledger` the subtraction overflows.
-    /// Saturating to 0 makes the condition `0 >= window_length` false for any
-    /// positive `window_length`, so the old behaviour was accidentally correct.
-    /// Using `checked_sub` makes the intent explicit: we detect the underflow
-    /// and deliberately return `false` (window not expired), preserving the
-    /// existing rate-limit state so an attestor cannot exploit the anomaly to
-    /// bypass their quota.
+    /// `window_start_ledger` is always set to `env.ledger().sequence()` at
+    /// state creation or window reset, so `current_ledger >= window_start_ledger`
+    /// is guaranteed by the preceding state normalization. `saturating_sub`
+    /// makes that invariant explicit: if `current < window_start` (which cannot
+    /// happen in practice), the subtraction saturates to 0 and `validate_config`
+    /// ensures `window_length > 0`, so the expression is still `false` — the
+    /// window is treated as not expired and the existing submission count is
+    /// preserved.
     pub(crate) fn is_window_expired(
         current_ledger: u32,
         window_start_ledger: u32,
         window_length: u32,
     ) -> bool {
-        match current_ledger.checked_sub(window_start_ledger) {
-            Some(delta) => delta >= window_length,
-            // current < window_start: ledger sequence anomaly or stored-state
-            // inconsistency. Treat as window not yet expired so the existing
-            // submission count is preserved and the attestor cannot exploit
-            // the anomaly to bypass their rate limit.
-            None => false,
-        }
+        current_ledger.saturating_sub(window_start_ledger) >= window_length
     }
     
     /// Generate collision-resistant storage key for per-attestor rate limit state.
@@ -1174,6 +1164,40 @@ mod tests {
         // State must still show exactly max_submissions
         let state = env.as_contract(&contract_id, &|| RateLimiter::get_state(&env, &attestor));
         assert_eq!(state.submission_count, 2);
+    }
+
+    /// Verify that the stored counter saturates at max_submissions rather than
+    /// wrapping to zero when the window is full. Forces the state directly to
+    /// u32::MAX and confirms that a subsequent denied request leaves the counter
+    /// unchanged (saturating_add(1) on u32::MAX stays u32::MAX, not 0).
+    #[test]
+    fn test_counter_saturates_at_u32_max() {
+        let env = Env::default();
+        let attestor = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let config = RateLimitConfig { max_submissions: 5, window_length: 100 };
+        let contract_address = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+        let contract_id = env.register_contract(&contract_address, crate::contract::AnchorKitContract);
+
+        // Artificially write a state with submission_count at u32::MAX to
+        // simulate a counter that has been driven to its integer ceiling.
+        env.as_contract(&contract_id, &|| {
+            let key = RateLimiter::state_key(&env, &attestor);
+            env.storage().persistent().set(&key, &RateLimitState {
+                submission_count: u32::MAX,
+                window_start_ledger: 0,
+            });
+        });
+
+        // The next call must be rejected (count >= max_submissions).
+        let result = env.as_contract(&contract_id, &|| {
+            RateLimiter::check_and_increment(&env, &attestor, &config)
+        });
+        assert!(result.is_err(), "over-limit call must be rejected");
+        assert_eq!(result.unwrap_err().code, ErrorCode::RateLimitExceeded);
+
+        // The counter must remain at u32::MAX — it must not have wrapped to 0.
+        let state = env.as_contract(&contract_id, &|| RateLimiter::get_state(&env, &attestor));
+        assert_eq!(state.submission_count, u32::MAX, "counter must saturate, not wrap");
     }
 
     // -------------------------------------------------------------------------

--- a/src/replay_detection.rs
+++ b/src/replay_detection.rs
@@ -10,6 +10,7 @@
 //! metrics or logs when a duplicate request is rejected.
 
 use soroban_sdk::{contracttype, Address, Bytes, Env};
+use crate::deterministic_hash::make_storage_key;
 
 /// Structured log entry for a replay detection event.
 #[derive(Clone, Debug)]
@@ -115,13 +116,21 @@ pub fn record_replay_detection(
     // Using temporary storage avoids unbounded growth of instance storage:
     // each counter lives for REPLAY_ATTEMPT_TTL ledgers then is pruned
     // automatically by the Soroban runtime.
-    let attempt_key = (soroban_sdk::symbol_short!("RPLYAT"), request_id.clone());
+    //
+    // make_storage_key length-prefixes each segment before hashing, so
+    // distinct byte sequences always produce distinct 32-byte keys regardless
+    // of input length — no truncation or text normalization can collapse them.
+    let mut id_raw = alloc::vec::Vec::with_capacity(request_id.len() as usize);
+    for i in 0..request_id.len() {
+        id_raw.push(request_id.get(i).unwrap_or(0));
+    }
+    let attempt_key = make_storage_key(env, &[b"RPLYAT", &id_raw]);
     let mut attempt_count: u32 = env
         .storage()
         .temporary()
         .get::<_, u32>(&attempt_key)
         .unwrap_or(0);
-    attempt_count += 1;
+    attempt_count = attempt_count.saturating_add(1);
 
     // Update global metrics
     metrics.total_replay_attempts += 1;
@@ -187,7 +196,11 @@ pub fn get_replay_metrics(env: &Env) -> ReplayMetrics {
 /// was never written (the USED key in persistent storage is the authoritative
 /// replay guard; this counter is for observability only).
 pub fn get_replay_count_for_id(env: &Env, request_id: &Bytes) -> u64 {
-    let attempt_key = (soroban_sdk::symbol_short!("RPLYAT"), request_id.clone());
+    let mut id_raw = alloc::vec::Vec::with_capacity(request_id.len() as usize);
+    for i in 0..request_id.len() {
+        id_raw.push(request_id.get(i).unwrap_or(0));
+    }
+    let attempt_key = make_storage_key(env, &[b"RPLYAT", &id_raw]);
     env.storage()
         .temporary()
         .get::<_, u32>(&attempt_key)
@@ -361,6 +374,26 @@ mod tests {
         assert!(event_opt.is_some());
         let event = event_opt.unwrap();
         assert_eq!(event.attempt_number, 1);
+    }
+
+    /// Two byte-distinct request_ids must map to separate attempt counters.
+    /// This pins the byte-preservation guarantee of the make_storage_key-based
+    /// attempt key: [0xAA] and [0xAA, 0x00] differ by a single trailing byte
+    /// and must never share a counter.
+    #[test]
+    fn test_distinct_request_ids_have_separate_counters() {
+        let (env, cid) = make_test_env();
+        let actor = Address::generate(&env);
+        let id_a = Bytes::from_slice(&env, &[0xAA]);
+        let id_b = Bytes::from_slice(&env, &[0xAA, 0x00]);
+
+        env.as_contract(&cid, || { record_replay_detection(&env, &id_a, &actor); });
+
+        let count_a = env.as_contract(&cid, || get_replay_count_for_id(&env, &id_a));
+        let count_b = env.as_contract(&cid, || get_replay_count_for_id(&env, &id_b));
+
+        assert_eq!(count_a, 1, "id_a must have one attempt recorded");
+        assert_eq!(count_b, 0, "id_b must be unaffected by id_a's recording");
     }
 
     /// Verify that per-ID counters do NOT accumulate in instance storage.


### PR DESCRIPTION
## Summary

- **#776** – Replace `submission_count += 1` with `saturating_add(1)` so the counter never wraps to zero under sustained load; adds `test_counter_saturates_at_u32_max` boundary test.
- **#777** – Improve the exhausted-window error message from the generic `"Rate limit exceeded"` to `"Request throttled: rate-limit window capacity exhausted; retry after the window expires"` so operators can distinguish throttling from configuration failures. Error code remains `RateLimitExceeded`.
- **#778** – Remove the unreachable `None => false` arm from `is_window_expired`. Because `window_start_ledger` is always set to `env.ledger().sequence()` at state creation/reset, `current_ledger >= window_start_ledger` is guaranteed by the preceding normalization; replacing `checked_sub`/`match` with `saturating_sub` makes the invariant explicit with no observable behaviour change.
- **#779** – Switch the per-ID attempt key in `replay_detection.rs` from a raw `(Symbol, Bytes)` tuple to `make_storage_key`, which length-prefixes every segment before hashing into a fixed 32-byte key. This prevents truncation or implicit normalization from collapsing distinct byte sequences; adds `test_distinct_request_ids_have_separate_counters` to pin the guarantee. Also applies `saturating_add` to the attempt counter.

## Test plan

- [ ] `cargo test rate_limiter` — all existing limiter tests pass; `test_counter_saturates_at_u32_max` passes
- [ ] `cargo test replay` — all existing replay tests pass; `test_distinct_request_ids_have_separate_counters` passes
- [ ] `cargo clippy -- -D warnings` on both changed files — no new warnings
- [ ] Verify existing window-boundary tests (`test_window_not_expired_when_current_less_than_start`, `test_window_expired_at_exact_length`, `test_window_rollover_at_exact_boundary`) still pass unchanged

closes #776
closes #777
closes #778
closes #779