### PR TITLE
fix(request_provenance): bound provenance metadata length to prevent.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,11 @@ pub use trace_context::{TraceContext, TraceError, TRACEPARENT_HEADER, TRACE_ID_H
 pub use request_deduplication::{DeduplicationStore, DeduplicationKey, DeduplicationResult, DeduplicationStats, execute_deduplicated};
 pub use retry_budget::{RetryBudget, RetryBudgetConfig, BudgetExhaustedError, execute_with_budget};
 pub use distributed_correlation::{CorrelationContext, CorrelationError, CORRELATION_ID_HEADER, ORIGIN_SERVICE_HEADER, HOP_COUNT_HEADER, BAGGAGE_HEADER};
-pub use request_provenance::{ProvenanceRecord, PROVENANCE_ID_HEADER, PARENT_ID_HEADER, DEPTH_HEADER, ORIGIN_HEADER, OPERATION_HEADER};
+pub use request_provenance::{
+    ProvenanceRecord, ProvenanceError,
+    PROVENANCE_ID_HEADER, PARENT_ID_HEADER, DEPTH_HEADER, ORIGIN_HEADER, OPERATION_HEADER, METADATA_HEADER,
+    MAX_METADATA_LEN,
+};
 pub use deterministic_hash::{compute_payload_hash, verify_payload_hash};
 pub use contract::{AnchorKitContract, AnchorTomlProvenance, EndpointUpdated, CacheConfig};
 pub use contract::{AttestorRevocationRecord};

--- a/src/request_provenance.rs
+++ b/src/request_provenance.rs
@@ -52,6 +52,32 @@ use alloc::format;
 // ProvenanceRecord
 // ---------------------------------------------------------------------------
 
+/// Maximum allowed length in bytes for custom provenance metadata strings.
+pub const MAX_METADATA_LEN: usize = 1024;
+
+/// Backward-compatible alias for [`MAX_METADATA_LEN`].
+pub const MAX_METADATA_LENGTH: usize = MAX_METADATA_LEN;
+
+/// Errors that can arise during provenance validation or construction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProvenanceError {
+    /// Metadata exceeds the maximum allowed length (`MAX_METADATA_LEN`).
+    MetadataTooLong {
+        len: usize,
+        max: usize,
+    },
+}
+
+impl core::fmt::Display for ProvenanceError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ProvenanceError::MetadataTooLong { len, max } => {
+                write!(f, "provenance metadata length {len} exceeds limit of {max} bytes")
+            }
+        }
+    }
+}
+
 /// Provenance and lineage record for a single request.
 ///
 /// Attach one of these to every request that enters the system so that
@@ -68,6 +94,8 @@ pub struct ProvenanceRecord {
     origin_service: String,
     /// Optional label for the operation being performed.
     operation: Option<String>,
+    /// Optional custom metadata attached to this record (bounded by [`MAX_METADATA_LEN`]).
+    metadata: Option<String>,
     /// Unix timestamp (seconds) when this record was created.
     created_at: u64,
 }
@@ -90,6 +118,7 @@ impl ProvenanceRecord {
             ancestors: Vec::new(),
             origin_service: svc,
             operation: Some(op),
+            metadata: None,
             created_at,
         }
     }
@@ -107,8 +136,21 @@ impl ProvenanceRecord {
             ancestors: Vec::new(),
             origin_service: origin_service.into(),
             operation: Some(operation.into()),
+            metadata: None,
             created_at,
         }
+    }
+
+    /// Create a root record with custom metadata attached, validating that its
+    /// length does not exceed [`MAX_METADATA_LEN`].
+    pub fn root_with_metadata(
+        origin_service: impl Into<String>,
+        operation: impl Into<String>,
+        metadata: impl Into<String>,
+        created_at: u64,
+    ) -> Result<Self, ProvenanceError> {
+        let root = Self::root(origin_service, operation, created_at);
+        root.with_metadata(metadata)
     }
 
     /// Derive a child record from this one.
@@ -137,6 +179,7 @@ impl ProvenanceRecord {
             ancestors,
             origin_service: svc,
             operation: Some(op),
+            metadata: None,
             created_at,
         }
     }
@@ -158,8 +201,55 @@ impl ProvenanceRecord {
             ancestors,
             origin_service: child_service.into(),
             operation: Some(operation.into()),
+            metadata: None,
             created_at,
         }
+    }
+
+    /// Derive a child record with custom metadata attached, validating that its
+    /// length does not exceed [`MAX_METADATA_LEN`].
+    pub fn child_with_metadata(
+        &self,
+        child_service: impl Into<String>,
+        operation: impl Into<String>,
+        metadata: impl Into<String>,
+        created_at: u64,
+    ) -> Result<Self, ProvenanceError> {
+        let child = self.child(child_service, operation, created_at);
+        child.with_metadata(metadata)
+    }
+
+    /// Validate that a metadata string does not exceed [`MAX_METADATA_LEN`].
+    pub fn validate_metadata(metadata: &str) -> Result<(), ProvenanceError> {
+        if metadata.len() > MAX_METADATA_LEN {
+            Err(ProvenanceError::MetadataTooLong {
+                len: metadata.len(),
+                max: MAX_METADATA_LEN,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Return `true` if `metadata` is within the maximum permitted length.
+    pub fn is_metadata_valid(metadata: &str) -> bool {
+        metadata.len() <= MAX_METADATA_LEN
+    }
+
+    /// Attach metadata to this record, validating that its length does not exceed [`MAX_METADATA_LEN`].
+    pub fn with_metadata(mut self, metadata: impl Into<String>) -> Result<Self, ProvenanceError> {
+        let meta = metadata.into();
+        Self::validate_metadata(&meta)?;
+        self.metadata = Some(meta);
+        Ok(self)
+    }
+
+    /// Set or update metadata on this record, validating length against [`MAX_METADATA_LEN`].
+    pub fn set_metadata(&mut self, metadata: impl Into<String>) -> Result<(), ProvenanceError> {
+        let meta = metadata.into();
+        Self::validate_metadata(&meta)?;
+        self.metadata = Some(meta);
+        Ok(())
     }
 
     // ── Accessors ──────────────────────────────────────────────────────────
@@ -204,6 +294,11 @@ impl ProvenanceRecord {
         self.operation.as_deref()
     }
 
+    /// Custom metadata attached to this record, if set.
+    pub fn metadata(&self) -> Option<&str> {
+        self.metadata.as_deref()
+    }
+
     /// Unix timestamp (seconds) when this record was created.
     pub fn created_at(&self) -> u64 {
         self.created_at
@@ -219,17 +314,29 @@ impl ProvenanceRecord {
     /// Produce a compact log-friendly summary.
     ///
     /// ```text
-    /// req=<id> parent=<id|none> depth=<n> svc=<name> op=<op>
+    /// req=<id> parent=<id|none> depth=<n> svc=<name> op=<op> [meta=<meta>]
     /// ```
     pub fn log_fields(&self) -> String {
-        format!(
-            "req={} parent={} depth={} svc={} op={}",
-            self.request_id,
-            self.parent_id.as_deref().unwrap_or("none"),
-            self.depth(),
-            self.origin_service,
-            self.operation.as_deref().unwrap_or("unknown"),
-        )
+        if let Some(ref meta) = self.metadata {
+            format!(
+                "req={} parent={} depth={} svc={} op={} meta={}",
+                self.request_id,
+                self.parent_id.as_deref().unwrap_or("none"),
+                self.depth(),
+                self.origin_service,
+                self.operation.as_deref().unwrap_or("unknown"),
+                meta,
+            )
+        } else {
+            format!(
+                "req={} parent={} depth={} svc={} op={}",
+                self.request_id,
+                self.parent_id.as_deref().unwrap_or("none"),
+                self.depth(),
+                self.origin_service,
+                self.operation.as_deref().unwrap_or("unknown"),
+            )
+        }
     }
 
     /// Serialize to a list of `(header_name, header_value)` pairs for HTTP propagation.
@@ -241,6 +348,7 @@ impl ProvenanceRecord {
     /// | `X-Request-Depth` | Depth as decimal |
     /// | `X-Request-Origin` | Originating service |
     /// | `X-Request-Operation` | Operation label |
+    /// | `X-Request-Metadata` | Custom metadata (if set) |
     pub fn to_headers(&self) -> Vec<(String, String)> {
         let mut headers = Vec::new();
         headers.push((PROVENANCE_ID_HEADER.to_string(), self.request_id.clone()));
@@ -253,18 +361,23 @@ impl ProvenanceRecord {
         if let Some(ref op) = self.operation {
             headers.push((OPERATION_HEADER.to_string(), op.clone()));
         }
+        if let Some(ref meta) = self.metadata {
+            headers.push((METADATA_HEADER.to_string(), meta.clone()));
+        }
         headers
     }
 
     /// Parse a [`ProvenanceRecord`] from HTTP headers.
     ///
-    /// Returns `None` when the required `X-Request-Provenance-Id` header is absent.
+    /// Returns `None` when the required `X-Request-Provenance-Id` header is absent,
+    /// or if any metadata header exceeds [`MAX_METADATA_LEN`].
     pub fn from_headers(headers: &[(String, String)]) -> Option<Self> {
         let mut request_id: Option<String> = None;
         let mut parent_id: Option<String> = None;
         let mut depth: usize = 0;
         let mut origin_service = String::new();
         let mut operation: Option<String> = None;
+        let mut metadata: Option<String> = None;
 
         for (name, value) in headers {
             let n = name.as_str();
@@ -280,6 +393,11 @@ impl ProvenanceRecord {
                 origin_service = value.clone();
             } else if n.eq_ignore_ascii_case(OPERATION_HEADER) {
                 operation = Some(value.clone());
+            } else if n.eq_ignore_ascii_case(METADATA_HEADER) {
+                if value.len() > MAX_METADATA_LEN {
+                    return None; // Reject over-limit metadata
+                }
+                metadata = Some(value.clone());
             }
         }
 
@@ -293,6 +411,7 @@ impl ProvenanceRecord {
             ancestors: Vec::new(),
             origin_service,
             operation,
+            metadata,
             created_at: 0, // not propagated via headers
         })
     }
@@ -312,6 +431,8 @@ pub const DEPTH_HEADER: &str = "X-Request-Depth";
 pub const ORIGIN_HEADER: &str = "X-Request-Origin";
 /// `X-Request-Operation`
 pub const OPERATION_HEADER: &str = "X-Request-Operation";
+/// `X-Request-Metadata`
+pub const METADATA_HEADER: &str = "X-Request-Metadata";
 
 // ---------------------------------------------------------------------------
 // Private helpers
@@ -437,5 +558,102 @@ mod tests {
         let child = r.child_with_id("child-id-001", "svc2", "op2", 1);
         assert_eq!(child.request_id(), "child-id-001");
         assert_eq!(child.parent_id(), Some("my-id-000"));
+    }
+
+    // ── Metadata Bounding Tests (#786) ───────────────────────────────────────
+
+    #[test]
+    fn metadata_at_limit_is_accepted() {
+        let at_limit = "x".repeat(MAX_METADATA_LEN);
+        assert_eq!(at_limit.len(), 1024);
+        assert!(ProvenanceRecord::is_metadata_valid(&at_limit));
+        assert!(ProvenanceRecord::validate_metadata(&at_limit).is_ok());
+
+        let root = ProvenanceRecord::root("gateway", "deposit", 1000)
+            .with_metadata(&at_limit)
+            .expect("metadata exactly at limit must be accepted");
+
+        assert_eq!(root.metadata(), Some(at_limit.as_str()));
+    }
+
+    #[test]
+    fn metadata_over_limit_is_rejected() {
+        let over_limit = "x".repeat(MAX_METADATA_LEN + 1);
+        assert_eq!(over_limit.len(), 1025);
+        assert!(!ProvenanceRecord::is_metadata_valid(&over_limit));
+
+        let err = ProvenanceRecord::validate_metadata(&over_limit)
+            .expect_err("metadata over limit must return an error");
+        assert_eq!(
+            err,
+            ProvenanceError::MetadataTooLong {
+                len: 1025,
+                max: MAX_METADATA_LEN,
+            }
+        );
+
+        let root = ProvenanceRecord::root("gateway", "deposit", 1000);
+        let res = root.with_metadata(&over_limit);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn metadata_builder_and_child_methods() {
+        let meta = "tenant=stellar,flow=kyc";
+        let root = ProvenanceRecord::root_with_metadata("gateway", "deposit", meta, 1000)
+            .expect("valid metadata must be accepted");
+        assert_eq!(root.metadata(), Some(meta));
+
+        let child_meta = "step=anchor-verify";
+        let child = root
+            .child_with_metadata("anchor", "sep6", child_meta, 1001)
+            .expect("valid child metadata must be accepted");
+        assert_eq!(child.metadata(), Some(child_meta));
+        assert_eq!(child.parent_id(), Some(root.request_id()));
+
+        let mut record = ProvenanceRecord::root("svc", "op", 0);
+        assert!(record.metadata().is_none());
+        record.set_metadata("updated=true").unwrap();
+        assert_eq!(record.metadata(), Some("updated=true"));
+    }
+
+    #[test]
+    fn metadata_header_round_trip() {
+        let meta = "origin_ip=127.0.0.1,auth=jwt";
+        let root = ProvenanceRecord::root("gateway", "deposit", 1000)
+            .with_metadata(meta)
+            .unwrap();
+        let headers = root.to_headers();
+
+        let meta_header = headers
+            .iter()
+            .find(|(k, _)| k == METADATA_HEADER)
+            .map(|(_, v)| v.as_str());
+        assert_eq!(meta_header, Some(meta));
+
+        let parsed = ProvenanceRecord::from_headers(&headers).unwrap();
+        assert_eq!(parsed.metadata(), Some(meta));
+    }
+
+    #[test]
+    fn metadata_over_limit_in_headers_rejected() {
+        let over_limit = "x".repeat(MAX_METADATA_LEN + 1);
+        let headers = alloc::vec![
+            (PROVENANCE_ID_HEADER.to_string(), "abc123".to_string()),
+            (ORIGIN_HEADER.to_string(), "gateway".to_string()),
+            (METADATA_HEADER.to_string(), over_limit),
+        ];
+
+        let parsed = ProvenanceRecord::from_headers(&headers);
+        assert!(parsed.is_none(), "from_headers must reject over-limit metadata");
+    }
+
+    #[test]
+    fn log_fields_includes_metadata_when_present() {
+        let r = ProvenanceRecord::root("gateway", "deposit", 1000)
+            .with_metadata("user_id=42")
+            .unwrap();
+        let fields = r.log_fields();
+        assert!(fields.contains("meta=user_id=42"));
     }
 }


### PR DESCRIPTION
 ### Description
    Bounds the metadata length on `ProvenanceRecord` in `src/request_provenance.rs` to prevent unbounded memory and log            pressure or exceeding downstream serialization limits.

    ### Changes
    - Introduced named limit `MAX_METADATA_LEN` (1024 bytes) and `METADATA_HEADER` (`"X-Request-Metadata"`).
    - Added `ProvenanceError::MetadataTooLong { len, max }` for explicit length validation failures without silent truncation.
    - Added `validate_metadata`, `is_metadata_valid`, `with_metadata`, `set_metadata`, `root_with_metadata`, and
  `child_with_metadata` methods.
    - Enforced metadata length bounds during HTTP header parsing (`from_headers`).
    - Added unit tests covering:
      - Exactly-at-limit metadata (1024 bytes) accepted
      - Over-limit metadata (1025 bytes) rejected with `ProvenanceError::MetadataTooLong`
      - Rejection of over-limit metadata in header parsing
      - Builder methods, child propagation, and log field formatting

 Closes #786 