### PR TITLE
fix: named TTL constant, zero pagination limit, empty attestor token, cursor bound

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1717,6 +1717,12 @@ const MAX_JWT_MAX_LEN: u32 = 16384;
 /// Default lifetime for an approved KYC record before the approval expires.
 const KYC_EXPIRY_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days
 
+/// Maximum validity window for a submitted quote (30 days in seconds).
+/// Quotes whose `valid_until` field exceeds `now + MAX_QUOTE_VALIDITY_SECONDS`
+/// are rejected to prevent unbounded validity windows that make routing
+/// unpredictable.
+const MAX_QUOTE_VALIDITY_SECONDS: u64 = 30 * 24 * 60 * 60;
+
 fn current_kyc_status(env: &Env, record: &KycRecord) -> KycStatus {
     if let Some(expiry) = record.expiry {
         if env.ledger().timestamp() > expiry {
@@ -5657,8 +5663,7 @@ impl AnchorKitContract {
         }
         // Reject quotes expiring more than 30 days in the future to prevent
         // unbounded validity windows that make routing unpredictable.
-        const MAX_QUOTE_VALIDITY: u64 = 30 * 24 * 60 * 60;
-        if valid_until.saturating_sub(now) > MAX_QUOTE_VALIDITY {
+        if valid_until.saturating_sub(now) > MAX_QUOTE_VALIDITY_SECONDS {
             panic_with_error!(&env, ErrorCode::InvalidQuote);
         }
         let inst = env.storage().instance();

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -5057,6 +5057,17 @@ impl AnchorKitContract {
             .unwrap_or_else(|| Vec::new(&env));
 
         let total = all_ids.len() as u64;
+
+        // #799: a cursor equal to or beyond the collection boundary returns an
+        // empty page immediately, preventing index underflow in the range arithmetic
+        // below.
+        if offset >= total {
+            return AttestationPage {
+                records: Vec::new(&env),
+                next_offset: total,
+                total,
+            };
+        }
         let mut records = Vec::new(&env);
         let mut skipped: u64 = 0;
         let mut next_offset = total; // default: last page

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -5031,6 +5031,13 @@ impl AnchorKitContract {
         filter: Option<AttestationFilter>,
     ) -> AttestationPage {
         const PAGE_CAP: u64 = 50;
+
+        // #800: reject a zero limit — it produces an ambiguous empty page that
+        // is indistinguishable from a genuine end-of-results signal.
+        if limit == 0 {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
+
         let effective_limit = limit.min(PAGE_CAP);
 
         // Read the global ATIDX index — it holds every attestation ID in

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -3201,6 +3201,12 @@ impl AnchorKitContract {
     /// AnchorKitContract::register_attestor(env, attestor, token, issuer, pubkey);
     /// ```
     pub fn register_attestor(env: Env, attestor: Address, sep10_token: String, sep10_issuer: Address, public_key: BytesN<32>) {
+        // Reject a blank SEP-10 token immediately — an empty identifier makes
+        // authentication impossible to diagnose and would cause a confusing
+        // JWT-verification error later.  Fail fast before any state mutation.
+        if sep10_token.len() == 0 {
+            panic_with_error!(&env, ErrorCode::InvalidRegistration);
+        }
         // Accept via primary admin, AttestorAdmin role, OR ManageAttestors capability.
         if !Self::has_role_internal(&env, &attestor, AdminRole::AttestorAdmin)
             && !Self::has_capability_internal(&env, &attestor, AdminCapability::ManageAttestors)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -172,6 +172,11 @@ pub enum ErrorCode {
     InvalidSloConfig          = 75,
     /// No SLO has been configured for this anchor.
     SloNotConfigured          = 76,
+
+    // Registration input errors (77)
+    /// Registration was rejected because a required text field is blank
+    /// (e.g. the SEP-10 token supplied to `register_attestor` is empty).
+    InvalidRegistration       = 77,
 }
 
 impl ErrorCode {
@@ -256,6 +261,7 @@ impl ErrorCode {
             ErrorCode::SloViolation              => "Service level objective was violated",
             ErrorCode::InvalidSloConfig          => "SLO configuration is invalid",
             ErrorCode::SloNotConfigured          => "No SLO has been configured for this anchor",
+            ErrorCode::InvalidRegistration       => "Registration rejected: a required text field is blank",
         }
     }
 }

--- a/tests/attestation_pagination_tests.rs
+++ b/tests/attestation_pagination_tests.rs
@@ -391,4 +391,21 @@ mod attestation_pagination_tests {
         let page = client.get_attestations_paginated(&0u64, &200u64, &None);
         assert!(page.records.len() <= 50, "page returned more than 50 records");
     }
+
+    // -----------------------------------------------------------------------
+    // #800 — Zero limit is rejected
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn zero_limit_is_rejected() {
+        let env = make_env();
+        let (client, _, _) = setup(&env);
+
+        // A zero limit must be rejected before any storage access.
+        let result = client.try_get_attestations_paginated(&0u64, &0u64, &None);
+        assert!(
+            result.is_err(),
+            "expected error for zero limit, but got Ok"
+        );
+    }
 }

--- a/tests/attestation_pagination_tests.rs
+++ b/tests/attestation_pagination_tests.rs
@@ -408,4 +408,46 @@ mod attestation_pagination_tests {
             "expected error for zero limit, but got Ok"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // #799 — Cursor beyond collection boundary returns empty page
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cursor_beyond_end_returns_empty_page() {
+        let env = make_env();
+        let (client, attestor, sk) = setup(&env);
+        let subject = Address::generate(&env);
+
+        // Submit 3 attestations so total == 3.
+        for seed in 0u8..3 {
+            let ph = unique_payload(&env, seed);
+            let sig = sign_payload(&env, &sk, &ph);
+            client.submit_attestation(
+                &attestor,
+                &subject,
+                &(1_000_001u64 + seed as u64),
+                &ph,
+                &sig,
+            );
+        }
+
+        // A cursor exactly at the boundary (offset == total) must return empty.
+        let page_at_boundary = client.get_attestations_paginated(&3u64, &10u64, &None);
+        assert_eq!(
+            page_at_boundary.records.len(),
+            0,
+            "expected empty page when offset == total"
+        );
+        assert_eq!(page_at_boundary.total, 3);
+
+        // A cursor well past the end must also return empty without panic.
+        let page_past_end = client.get_attestations_paginated(&1000u64, &10u64, &None);
+        assert_eq!(
+            page_past_end.records.len(),
+            0,
+            "expected empty page when offset >> total"
+        );
+        assert_eq!(page_past_end.total, 3);
+    }
 }

--- a/tests/attestor_role_tests.rs
+++ b/tests/attestor_role_tests.rs
@@ -590,3 +590,95 @@ mod rate_limit_role_override_tests {
         });
     }
 }
+
+// ── #798 — Reject empty attestor registration identifier ─────────────────────
+
+#[cfg(test)]
+mod empty_attestor_registration_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env, String,
+    };
+
+    use anchorkit::contract::{AnchorKitContract, AnchorKitContractClient};
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set(LedgerInfo {
+            timestamp: 1_000_000,
+            protocol_version: 21,
+            sequence_number: 0,
+            network_id: Default::default(),
+            base_reserve: 0,
+            min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
+            max_entry_ttl: 6_312_000,
+        });
+        env
+    }
+
+    fn setup(env: &Env) -> AnchorKitContractClient {
+        let contract_id = env.register_contract(None, AnchorKitContract);
+        let client = AnchorKitContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        client
+    }
+
+    /// An empty SEP-10 token must be rejected before any state mutation.
+    #[test]
+    fn empty_sep10_token_is_rejected() {
+        let env = make_env();
+        let client = setup(&env);
+
+        let attestor = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let empty_token = String::from_str(&env, "");
+        let pk = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+
+        let result = client.try_register_attestor(&attestor, &empty_token, &issuer, &pk);
+        assert!(
+            result.is_err(),
+            "expected registration to be rejected with an empty sep10_token, but it succeeded"
+        );
+
+        // The attestor must not have been registered despite the call.
+        assert!(
+            !client.is_attestor(&attestor),
+            "attestor must not be registered after a failed call"
+        );
+    }
+
+    /// A valid token must still register successfully (regression guard).
+    ///
+    /// NOTE: This test uses mock_all_auths so it bypasses actual JWT
+    /// verification; it only confirms the empty-string guard does not
+    /// incorrectly block non-empty tokens.
+    #[test]
+    fn non_empty_sep10_token_passes_blank_guard() {
+        let env = make_env();
+        let client = setup(&env);
+
+        let attestor = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        // A minimal non-empty string — JWT verification is mocked out.
+        let token = String::from_str(&env, "eyJhbGciOiJFZERTQSJ9.e30.sig");
+        let pk = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+
+        // With mock_all_auths, JWT verification is skipped, so this should succeed.
+        let result = client.try_register_attestor(&attestor, &token, &issuer, &pk);
+        // We accept either Ok (mocked env skips JWT check) or Err from JWT
+        // verification — the important thing is it did NOT fail with
+        // InvalidRegistration due to the blank-guard.
+        // We specifically check it's NOT the InvalidRegistration error (code 77).
+        if let Err(e) = result {
+            let code = e.unwrap();
+            assert_ne!(
+                code,
+                anchorkit::errors::ErrorCode::InvalidRegistration,
+                "non-empty token must not be rejected by the blank-field guard"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR resolves four maintenance and bug-fix issues in `src/contract.rs`.

---

### #801 — Named storage TTL constant

Promoted the function-local `const MAX_QUOTE_VALIDITY` inside
`submit_quote_with_reason` to a module-level private constant
`MAX_QUOTE_VALIDITY_SECONDS`, placed near the other policy constants
(`KYC_EXPIRY_SECONDS`, `REPLAY_TTL`, etc.).

Generated storage expiration is unchanged.

---

### #800 — Reject zero pagination limit

Added a one-line boundary guard in `get_attestations_paginated` that
panics with `ValidationError` when `limit == 0`. A zero limit produces
an empty page indistinguishable from end-of-results.

Positive limits are unaffected; ordering, count, and cursor encoding are
unchanged.

Test added: `zero_limit_is_rejected` in `tests/attestation_pagination_tests.rs`.

---

### #798 — Reject empty attestor registration identifier

Added a blank-field guard at the very top of `register_attestor` that
panics with the new `InvalidRegistration` error (code 77) when
`sep10_token` is empty, before any state mutation occurs.

Also added `InvalidRegistration` to `ErrorCode` with a descriptive
`default_message`.

Test added: `empty_sep10_token_is_rejected` in `tests/attestor_role_tests.rs`.

---

### #799 — Enforce pagination cursor bound

Added an explicit early-return in `get_attestations_paginated`: when
`offset >= total` the function immediately returns an empty
`AttestationPage` with `next_offset == total`, preventing range
arithmetic on an out-of-bounds cursor.

Valid cursors and page ordering are unaffected; no storage writes occur.

Test added: `cursor_beyond_end_returns_empty_page` in `tests/attestation_pagination_tests.rs`.

---

## What was tested

- All four changes are behaviour-preserving for valid inputs
- New tests cover each rejection/guard path
- No storage writes occur on any error/early-return path

Closes #801
Closes #800
Closes #798
Closes #799