### PR TITLE
fix(health): validate probe timeout, reject negative counts, emit recovery transition, guard counter underflow

### DIFF
--- a/src/anchor_health.rs
+++ b/src/anchor_health.rs
@@ -283,6 +283,73 @@ impl HealthWindow {
         let failures = self.routing_failure_count.min(self.routing_attempt_count);
         1.0 - (failures as f64 / self.routing_attempt_count as f64)
     }
+
+    /// Construct a [`HealthWindow`] from externally-parsed or signed counts.
+    ///
+    /// Returns `Err` when any count is negative, because a negative success or
+    /// latency count makes the aggregate mathematically meaningless and can
+    /// incorrectly classify an anchor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnchorKitError::validation_error`] for any negative argument.
+    pub fn new_checked(
+        started_at: u64,
+        ended_at: u64,
+        success_count: i64,
+        failure_count: i64,
+        p50_latency_ms: f64,
+        routing_failure_count: i64,
+        routing_attempt_count: i64,
+        recovery_time_seconds: u64,
+    ) -> Result<Self, crate::errors::AnchorKitError> {
+        if success_count < 0 {
+            return Err(crate::errors::AnchorKitError::validation_error(
+                "success_count must be non-negative",
+            ));
+        }
+        if failure_count < 0 {
+            return Err(crate::errors::AnchorKitError::validation_error(
+                "failure_count must be non-negative",
+            ));
+        }
+        if routing_failure_count < 0 {
+            return Err(crate::errors::AnchorKitError::validation_error(
+                "routing_failure_count must be non-negative",
+            ));
+        }
+        if routing_attempt_count < 0 {
+            return Err(crate::errors::AnchorKitError::validation_error(
+                "routing_attempt_count must be non-negative",
+            ));
+        }
+        Ok(HealthWindow {
+            started_at,
+            ended_at,
+            success_count: success_count as u64,
+            failure_count: failure_count as u64,
+            p50_latency_ms,
+            routing_failure_count: routing_failure_count as u64,
+            routing_attempt_count: routing_attempt_count as u64,
+            recovery_time_seconds,
+        })
+    }
+
+    /// Decrement the failure counter by one, saturating at zero.
+    ///
+    /// Uses saturating subtraction so the count never wraps around from zero
+    /// to `u64::MAX`, which would distort health classification.
+    pub fn decrement_failure(&mut self) {
+        self.failure_count = self.failure_count.saturating_sub(1);
+    }
+
+    /// Decrement the success counter by one, saturating at zero.
+    ///
+    /// Uses saturating subtraction so the count never wraps around from zero
+    /// to `u64::MAX`, which would distort health classification.
+    pub fn decrement_success(&mut self) {
+        self.success_count = self.success_count.saturating_sub(1);
+    }
 }
 
 /// The composite health score for a single observation window.
@@ -458,6 +525,97 @@ pub fn compute_trend(windows: &[HealthWindow]) -> HealthTrend {
         HealthTrend::Degrading
     } else {
         HealthTrend::Stable
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Health state transition events (#recovery-observability)
+// ---------------------------------------------------------------------------
+
+/// A discrete health-state transition event emitted when an anchor's
+/// classification changes between observations.
+///
+/// The `Recovery` variant is the observability signal that was previously
+/// missing: without it, a monitoring pipeline could not distinguish "still
+/// healthy" from "just recovered" and would silently miss recoveries.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HealthTransitionEvent {
+    /// Anchor transitioned from a non-healthy state to healthy (≥ 80).
+    Recovery {
+        /// Composite score of the previous (non-healthy) window.
+        previous_composite: f64,
+        /// Composite score of the current (healthy) window.
+        current_composite: f64,
+    },
+    /// Anchor transitioned from healthy to a non-healthy state.
+    Failure {
+        /// Composite score of the previous (healthy) window.
+        previous_composite: f64,
+        /// Composite score of the current (non-healthy) window.
+        current_composite: f64,
+    },
+    /// No state-boundary crossing; classification is unchanged.
+    NoChange,
+}
+
+impl HealthTransitionEvent {
+    /// Returns `true` when this event represents a recovery.
+    pub fn is_recovery(&self) -> bool {
+        matches!(self, HealthTransitionEvent::Recovery { .. })
+    }
+
+    /// Returns `true` when this event represents a new failure.
+    pub fn is_failure(&self) -> bool {
+        matches!(self, HealthTransitionEvent::Failure { .. })
+    }
+}
+
+/// Compare two consecutive composite scores and emit the appropriate
+/// [`HealthTransitionEvent`].
+///
+/// Callers should invoke this once per observation cycle, right after
+/// computing the new window score, and act on the returned event (e.g.
+/// increment a recovery counter, page an operator, clear an alert).
+///
+/// A healthy anchor has composite ≥ 80.  The function emits:
+/// - [`HealthTransitionEvent::Recovery`] on the first window where the anchor
+///   is healthy after having been non-healthy.
+/// - [`HealthTransitionEvent::Failure`] on the first window where the anchor
+///   is non-healthy after having been healthy.
+/// - [`HealthTransitionEvent::NoChange`] when the classification is unchanged,
+///   preventing duplicate recovery or failure signals for repeated observations.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::anchor_health::{detect_health_transition, HealthTransitionEvent};
+///
+/// // Recovery: was 40, now 85
+/// let ev = detect_health_transition(40.0, 85.0);
+/// assert!(ev.is_recovery());
+///
+/// // Failure: was 90, now 30
+/// let ev = detect_health_transition(90.0, 30.0);
+/// assert!(ev.is_failure());
+///
+/// // No change: both healthy
+/// let ev = detect_health_transition(85.0, 92.0);
+/// assert_eq!(ev, HealthTransitionEvent::NoChange);
+/// ```
+pub fn detect_health_transition(previous: f64, current: f64) -> HealthTransitionEvent {
+    const HEALTHY_THRESHOLD: f64 = 80.0;
+    let was_healthy = previous >= HEALTHY_THRESHOLD;
+    let is_healthy  = current  >= HEALTHY_THRESHOLD;
+    match (was_healthy, is_healthy) {
+        (false, true)  => HealthTransitionEvent::Recovery {
+            previous_composite: previous,
+            current_composite:  current,
+        },
+        (true, false)  => HealthTransitionEvent::Failure {
+            previous_composite: previous,
+            current_composite:  current,
+        },
+        _ => HealthTransitionEvent::NoChange,
     }
 }
 

--- a/src/synthetic_probe.rs
+++ b/src/synthetic_probe.rs
@@ -132,11 +132,35 @@ impl ProbeConfig {
     }
 
     /// Set the latency threshold (builder-style).
-    pub fn with_latency_threshold(mut self, ms: u64) -> Self {
+    ///
+    /// Returns `Err(AnchorKitError::validation_error)` when `ms` is zero
+    /// (a zero threshold immediately classifies every probe as slow) or when
+    /// `ms` exceeds [`MAX_PROBE_TIMEOUT_MS`] (prevents silent overflow when
+    /// the value is later converted to a `std::time::Duration`).
+    pub fn with_latency_threshold(mut self, ms: u64) -> Result<Self, AnchorKitError> {
+        if ms == 0 {
+            return Err(AnchorKitError::validation_error(
+                "probe latency threshold must be greater than zero",
+            ));
+        }
+        if ms > MAX_PROBE_TIMEOUT_MS {
+            return Err(AnchorKitError::validation_error(
+                &alloc::format!(
+                    "probe latency threshold {ms} ms exceeds maximum {MAX_PROBE_TIMEOUT_MS} ms"
+                ),
+            ));
+        }
         self.latency_threshold_ms = ms;
-        self
+        Ok(self)
     }
 }
+
+/// Maximum allowed probe latency threshold in milliseconds (1 hour).
+///
+/// Values above this are rejected by [`ProbeConfig::with_latency_threshold`]
+/// to prevent silent overflow when the threshold is converted to a
+/// `std::time::Duration` or compared against a `u32` timer register.
+pub const MAX_PROBE_TIMEOUT_MS: u64 = 3_600_000;
 
 // ---------------------------------------------------------------------------
 // ProbeOutcome
@@ -434,7 +458,8 @@ mod tests {
         let probes = alloc::vec![
             ProbeConfig::new(1, ProbeKind::Ping, "https://anchor.example.com")
                 .unwrap()
-                .with_latency_threshold(100),
+                .with_latency_threshold(100)
+                .unwrap(),
         ];
         let runner = SyntheticProbeRunner::new(probes);
         let reports = runner.run_all(
@@ -449,7 +474,8 @@ mod tests {
         let probes = alloc::vec![
             ProbeConfig::new(1, ProbeKind::Ping, "https://anchor.example.com")
                 .unwrap()
-                .with_latency_threshold(1000),
+                .with_latency_threshold(1000)
+                .unwrap(),
         ];
         let runner = SyntheticProbeRunner::new(probes);
         let reports = runner.run_all(

--- a/tests/anchor_health_metrics_tests.rs
+++ b/tests/anchor_health_metrics_tests.rs
@@ -291,3 +291,122 @@ mod anchor_health_metrics_tests {
         assert_eq!(mb.uptime_bps, 0);
     }
 }
+
+// ---------------------------------------------------------------------------
+// HealthWindow::new_checked — negative input rejection (issue #2)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod negative_count_rejection_tests {
+    use anchorkit::anchor_health::HealthWindow;
+
+    #[test]
+    fn negative_success_count_is_rejected() {
+        let err = HealthWindow::new_checked(0, 300, -1, 0, 0.0, 0, 0, 0).unwrap_err();
+        assert!(
+            err.message.contains("success_count"),
+            "expected rejection of negative success_count, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn negative_failure_count_is_rejected() {
+        let err = HealthWindow::new_checked(0, 300, 0, -5, 0.0, 0, 0, 0).unwrap_err();
+        assert!(
+            err.message.contains("failure_count"),
+            "expected rejection of negative failure_count, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn negative_routing_failure_count_is_rejected() {
+        let err = HealthWindow::new_checked(0, 300, 10, 0, 100.0, -2, 10, 0).unwrap_err();
+        assert!(
+            err.message.contains("routing_failure_count"),
+            "expected rejection of negative routing_failure_count, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn negative_routing_attempt_count_is_rejected() {
+        let err = HealthWindow::new_checked(0, 300, 10, 0, 100.0, 0, -1, 0).unwrap_err();
+        assert!(
+            err.message.contains("routing_attempt_count"),
+            "expected rejection of negative routing_attempt_count, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn zero_counts_are_accepted() {
+        let w = HealthWindow::new_checked(0, 300, 0, 0, 0.0, 0, 0, 0).unwrap();
+        assert_eq!(w.success_count, 0);
+        assert_eq!(w.failure_count, 0);
+    }
+
+    #[test]
+    fn positive_counts_are_accepted_and_exact() {
+        let w = HealthWindow::new_checked(100, 400, 95, 5, 200.0, 1, 10, 0).unwrap();
+        assert_eq!(w.success_count, 95);
+        assert_eq!(w.failure_count, 5);
+        assert_eq!(w.routing_failure_count, 1);
+        assert_eq!(w.routing_attempt_count, 10);
+        // Aggregation should still classify this window as healthy
+        use anchorkit::anchor_health::score_window;
+        let score = score_window(&w);
+        assert!(score.composite > 80.0, "healthy window should score >80, got {}", score.composite);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// detect_health_transition — recovery transition observability (issue #3)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod recovery_transition_tests {
+    use anchorkit::anchor_health::{detect_health_transition, HealthTransitionEvent};
+
+    #[test]
+    fn recovery_emits_exactly_one_signal() {
+        // First cycle: unhealthy → healthy
+        let ev = detect_health_transition(40.0, 85.0);
+        match &ev {
+            HealthTransitionEvent::Recovery { previous_composite, current_composite } => {
+                assert!((previous_composite - 40.0).abs() < 1e-9);
+                assert!((current_composite - 85.0).abs() < 1e-9);
+            }
+            _ => panic!("expected Recovery event, got {:?}", ev),
+        }
+    }
+
+    #[test]
+    fn repeated_healthy_observations_do_not_emit_duplicate_recovery() {
+        // Both previous and current are healthy → NoChange, not a duplicate Recovery
+        let ev = detect_health_transition(85.0, 92.0);
+        assert_eq!(ev, HealthTransitionEvent::NoChange,
+            "staying healthy must not produce a recovery event");
+    }
+
+    #[test]
+    fn failure_transition_is_unchanged() {
+        let ev = detect_health_transition(90.0, 30.0);
+        assert!(ev.is_failure(), "healthy→non-healthy must emit Failure, got {:?}", ev);
+    }
+
+    #[test]
+    fn no_change_when_both_unhealthy() {
+        let ev = detect_health_transition(30.0, 45.0);
+        assert_eq!(ev, HealthTransitionEvent::NoChange,
+            "both non-healthy must emit NoChange");
+    }
+
+    #[test]
+    fn boundary_at_exactly_80_is_healthy() {
+        // Crossing the boundary from 79.9 → 80.0 is a recovery
+        let ev = detect_health_transition(79.9, 80.0);
+        assert!(ev.is_recovery(), "crossing to 80.0 must be a recovery, got {:?}", ev);
+    }
+}

--- a/tests/health_check_tests.rs
+++ b/tests/health_check_tests.rs
@@ -313,3 +313,107 @@ fn test_freshness_score_influences_refresh_decision() {
     assert!(report_old.freshness_score < report_now.freshness_score,
         "aging should reduce score");
 }
+
+// ---------------------------------------------------------------------------
+// ProbeConfig::with_latency_threshold — timeout boundary validation (issue #1)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod probe_timeout_validation_tests {
+    use anchorkit::synthetic_probe::{ProbeConfig, ProbeKind, MAX_PROBE_TIMEOUT_MS};
+
+    #[test]
+    fn zero_threshold_is_rejected() {
+        let err = ProbeConfig::new(1, ProbeKind::Ping, "https://anchor.example.com")
+            .unwrap()
+            .with_latency_threshold(0)
+            .unwrap_err();
+        assert!(
+            err.message.contains("greater than zero"),
+            "expected zero-threshold error, got: {}",
+            err.message,
+        );
+    }
+
+    #[test]
+    fn threshold_above_max_is_rejected() {
+        let err = ProbeConfig::new(1, ProbeKind::Ping, "https://anchor.example.com")
+            .unwrap()
+            .with_latency_threshold(MAX_PROBE_TIMEOUT_MS + 1)
+            .unwrap_err();
+        assert!(
+            err.message.contains("exceeds maximum"),
+            "expected overflow error, got: {}",
+            err.message,
+        );
+    }
+
+    #[test]
+    fn threshold_at_max_boundary_is_accepted() {
+        let cfg = ProbeConfig::new(1, ProbeKind::Ping, "https://anchor.example.com")
+            .unwrap()
+            .with_latency_threshold(MAX_PROBE_TIMEOUT_MS)
+            .unwrap();
+        assert_eq!(cfg.latency_threshold_ms, MAX_PROBE_TIMEOUT_MS);
+    }
+
+    #[test]
+    fn small_valid_threshold_retains_exact_value() {
+        let cfg = ProbeConfig::new(1, ProbeKind::Ping, "https://anchor.example.com")
+            .unwrap()
+            .with_latency_threshold(500)
+            .unwrap();
+        assert_eq!(cfg.latency_threshold_ms, 500);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HealthWindow counter decrement — saturating at zero (issue #4)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod counter_underflow_tests {
+    use anchorkit::anchor_health::HealthWindow;
+
+    fn make_window(success: u64, failure: u64) -> HealthWindow {
+        HealthWindow {
+            started_at: 0,
+            ended_at: 300,
+            success_count: success,
+            failure_count: failure,
+            p50_latency_ms: 0.0,
+            routing_failure_count: 0,
+            routing_attempt_count: 0,
+            recovery_time_seconds: 0,
+        }
+    }
+
+    #[test]
+    fn decrement_failure_saturates_at_zero() {
+        let mut w = make_window(5, 0);
+        w.decrement_failure();
+        // Must not wrap to u64::MAX
+        assert_eq!(w.failure_count, 0, "zero failure count must not underflow");
+    }
+
+    #[test]
+    fn decrement_success_saturates_at_zero() {
+        let mut w = make_window(0, 5);
+        w.decrement_success();
+        assert_eq!(w.success_count, 0, "zero success count must not underflow");
+    }
+
+    #[test]
+    fn decrement_failure_positive_count_decrements_once() {
+        let mut w = make_window(5, 3);
+        w.decrement_failure();
+        assert_eq!(w.failure_count, 2);
+    }
+
+    #[test]
+    fn decrement_success_positive_count_decrements_once() {
+        let mut w = make_window(5, 3);
+        w.decrement_success();
+        assert_eq!(w.success_count, 4);
+    }
+}


### PR DESCRIPTION
 Summary

Fixes four boundary-safety issues in the health monitoring subsystem.
 Changes

810 — Probe timeout zero/overflow** (`src/synthetic_probe.rs`)
`ProbeConfig::with_latency_threshold` now returns `Result<Self, AnchorKitError>`.
Zero is rejected (causes immediate slow-success misclassification) and values above
`MAX_PROBE_TIMEOUT_MS` (3 600 000 ms) are rejected to prevent conversion overflow.

811 — Negative counts in health aggregation** (`src/anchor_health.rs`)
Added `HealthWindow::new_checked` — accepts `i64` counts and rejects any negative
value via the existing `validation_error` path before aggregation. Non-negative
values retain their exact results unchanged.

812 — Missing recovery transition metric** (`src/anchor_health.rs`)
Added `HealthTransitionEvent` enum and `detect_health_transition(previous, current)`.
Emits exactly one `Recovery` event on the first healthy window after a non-healthy one.
Repeated healthy observations emit `NoChange` — no duplicates. Failure behavior unchanged.

813 — Counter underflow at zero** (`src/anchor_health.rs`)
Added `HealthWindow::decrement_failure()` and `decrement_success()` using
`saturating_sub(1)`. A counter at zero stays at zero instead of wrapping to `u64::MAX`.

Tests
- `tests/health_check_tests.rs` — probe timeout boundary cases (#810, #813)
- `tests/anchor_health_metrics_tests.rs` — negative count rejection and recovery transition (#811, #812)

Closes #810
Closes #811
Closes #812
Closes #813
