### PR TITLE
Probe latency/204 handling and outbound HTTPS + auth-log hardening

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -125,6 +125,13 @@ pub struct OutboundRequestOptions {
     pub credentials: Option<RequestCredentials>,
 }
 
+/// `Debug` keeps secret-bearing fields out of formatted output: the HMAC
+/// `signing_key` is shown only as a presence marker, and `credentials` is
+/// rendered through [`RequestCredentials`]'s own redacting `Debug`, so an
+/// `Authorization` (bearer/basic) or custom auth header value never appears —
+/// even when options are logged on an outbound failure. Non-secret fields
+/// (idempotency key, trace, Basic username, custom header name) stay visible
+/// for diagnostics. The header actually sent on the wire is unaffected.
 impl core::fmt::Debug for OutboundRequestOptions {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("OutboundRequestOptions")
@@ -150,6 +157,15 @@ impl OutboundRequestOptions {
     /// Attach an HMAC-SHA256 signing key to this options set.
     pub fn with_signing_key(mut self, key: &[u8]) -> Self {
         self.signing_key = Some(key.to_vec());
+        self
+    }
+
+    /// Attach an explicit [`RequestCredentials`] value to this options set.
+    ///
+    /// The `with_bearer_token` / `with_basic_auth` / `with_header_credential`
+    /// helpers are shorthands for the common variants.
+    pub fn with_credentials(mut self, credentials: RequestCredentials) -> Self {
+        self.credentials = Some(credentials);
         self
     }
 
@@ -520,8 +536,27 @@ pub fn post_with_options<H>(
 where
     H: FnMut(&str, &str, &[(String, String)]) -> Result<u16, String>,
 {
+    // Enforce the HTTPS transport requirement at the client boundary so a
+    // direct caller cannot bypass it by handing us a cleartext endpoint.
+    // This is a scheme-only guard: host shape, path, and IP-literal checks
+    // remain the job of the shared domain validator and are not duplicated
+    // here.
+    if !is_https_endpoint(url) {
+        return Err("outbound request rejected: endpoint URL must use the https:// scheme".into());
+    }
     let headers = opts.map(|o| o.build_headers(body)).unwrap_or_default();
     http_post(url, body, &headers)
+}
+
+/// Returns `true` when `url` uses the `https://` scheme (case-insensitive).
+///
+/// Used to keep cleartext HTTP endpoints out of [`post_with_options`] and
+/// [`post_with_options_metered`]; mirrors the scheme handling in
+/// [`ProxyConfig::select_proxy_url`].
+fn is_https_endpoint(url: &str) -> bool {
+    url.get(.."https://".len())
+        .map(|s| s.eq_ignore_ascii_case("https://"))
+        .unwrap_or(false)
 }
 
 /// Like [`post_with_options`], additionally recording request metrics.

--- a/src/synthetic_probe.rs
+++ b/src/synthetic_probe.rs
@@ -58,7 +58,7 @@ extern crate alloc;
 
 use alloc::string::String;
 use alloc::vec::Vec;
-use crate::anchor_health::{HealthWindow, EndpointOutcome};
+use crate::anchor_health::{HealthWindow, EndpointOutcome, classify_http_status};
 use crate::errors::AnchorKitError;
 
 // ---------------------------------------------------------------------------
@@ -199,6 +199,26 @@ impl ProbeResult {
             probe_id,
             outcome: ProbeOutcome::Failure(reason.into()),
             latency_ms,
+        }
+    }
+
+    /// Build a result from an observed HTTP status code and the round-trip
+    /// latency measured around the request.
+    ///
+    /// Status classification defers to the shared
+    /// [`classify_http_status`](crate::anchor_health::classify_http_status)
+    /// success-range policy, so any `2xx` — including a bodyless
+    /// `204 No Content` liveness response — is treated as healthy, and
+    /// non-success statuses keep their existing `HTTP <code>` failure reason.
+    ///
+    /// On the success path the measured `latency_ms` is recorded so operators
+    /// can tell a fast healthy endpoint from a barely responsive one; the same
+    /// value is carried on the failure path for context. Units match the
+    /// neighbouring `latency_ms` field (milliseconds).
+    pub fn from_http_status(probe_id: u64, status: u16, latency_ms: u64) -> Self {
+        match classify_http_status(status) {
+            EndpointOutcome::Success => ProbeResult::success(probe_id, latency_ms),
+            EndpointOutcome::Failure(reason) => ProbeResult::failure(probe_id, latency_ms, reason),
         }
     }
 
@@ -496,6 +516,36 @@ mod tests {
     fn probe_result_is_not_ok_for_failure() {
         let r = ProbeResult::failure(1, 0, "timeout");
         assert!(!r.is_ok());
+    }
+
+    // ── ProbeResult::from_http_status (#822 latency, #823 204-as-success) ─────
+
+    #[test]
+    fn from_http_status_200_records_measured_latency() {
+        // #822: a successful probe exposes the elapsed latency, not a placeholder.
+        let r = ProbeResult::from_http_status(7, 200, 37);
+        assert!(r.is_ok());
+        assert_eq!(r.outcome, ProbeOutcome::Success);
+        assert_eq!(r.latency_ms, 37);
+    }
+
+    #[test]
+    fn from_http_status_204_is_success_without_a_body() {
+        // #823: a compliant liveness endpoint may answer 204 with no body.
+        let r = ProbeResult::from_http_status(7, 204, 12);
+        assert!(r.is_ok());
+        assert_eq!(r.outcome, ProbeOutcome::Success);
+        assert_eq!(r.latency_ms, 12);
+    }
+
+    #[test]
+    fn from_http_status_non_2xx_keeps_existing_failure_classification() {
+        let r = ProbeResult::from_http_status(7, 503, 90);
+        assert!(!r.is_ok());
+        match r.outcome {
+            ProbeOutcome::Failure(reason) => assert!(reason.contains("503"), "got: {reason}"),
+            other => panic!("expected failure, got {other:?}"),
+        }
     }
 
     // ── probe_results_to_health_window ───────────────────────────────────────

--- a/tests/outbound_proxy_credentials_tests.rs
+++ b/tests/outbound_proxy_credentials_tests.rs
@@ -130,6 +130,39 @@ fn custom_header_credentials_are_injected() {
     );
 }
 
+// ── Transport policy: cleartext HTTP endpoints are rejected (#824) ───────────
+
+#[test]
+fn cleartext_http_endpoint_is_rejected_before_transport() {
+    let opts = OutboundRequestOptions::default().with_bearer_token("sep10-jwt");
+    let mut transport_ran = false;
+    let result = post_with_options(
+        "http://anchor.example.com/webhook",
+        r#"{"event":"deposit_completed"}"#,
+        Some(&opts),
+        |_url, _body, _hdrs| {
+            transport_ran = true;
+            Ok(200u16)
+        },
+    );
+    assert!(result.is_err(), "cleartext http:// endpoint must be rejected");
+    assert!(
+        !transport_ran,
+        "the request must be rejected before any transport/network activity"
+    );
+}
+
+#[test]
+fn https_endpoint_is_unchanged_by_the_scheme_guard() {
+    let result = post_with_options(
+        "https://anchor.example.com/webhook",
+        "{}",
+        None,
+        |_url, _body, _hdrs| Ok(204u16),
+    );
+    assert_eq!(result, Ok(204), "https:// endpoints still reach the transport");
+}
+
 // ── Invalid configurations are rejected ──────────────────────────────────────
 
 #[test]

--- a/tests/safe_logging_tests.rs
+++ b/tests/safe_logging_tests.rs
@@ -269,4 +269,60 @@ mod safe_logging_tests {
             "ProxyConfig debug should keep the proxy URL visible, got: {debug_output}"
         );
     }
+
+    // ── #825: Authorization header redaction in OutboundRequestOptions debug ───
+
+    /// `OutboundRequestOptions` debug output must never contain the bearer
+    /// token that becomes the outbound `Authorization` header, while leaving
+    /// non-secret fields (the idempotency key) visible for diagnostics.
+    #[test]
+    fn test_outbound_request_options_debug_redacts_authorization_token() {
+        use anchorkit::http_client::OutboundRequestOptions;
+
+        let opts = OutboundRequestOptions::with_idempotency_key("txn-825")
+            .with_signing_key(b"hmac-signing-secret")
+            .with_bearer_token("sep10-jwt-bearer-secret");
+
+        let debug_output = format!("{opts:?}");
+
+        assert!(
+            !debug_output.contains("sep10-jwt-bearer-secret"),
+            "debug output must not expose the Authorization bearer token, got: {debug_output}"
+        );
+        assert!(
+            !debug_output.contains("hmac-signing-secret"),
+            "debug output must not expose the HMAC signing key, got: {debug_output}"
+        );
+        assert!(
+            debug_output.contains("<redacted>"),
+            "debug output must contain the redaction marker, got: {debug_output}"
+        );
+        assert!(
+            debug_output.contains("txn-825"),
+            "the idempotency key is not sensitive and must remain visible, got: {debug_output}"
+        );
+    }
+
+    /// A custom `Authorization` header supplied verbatim must also be redacted
+    /// in debug output, while the header name stays visible.
+    #[test]
+    fn test_outbound_request_options_debug_redacts_custom_authorization_header() {
+        use anchorkit::http_client::{OutboundRequestOptions, RequestCredentials};
+
+        let opts = OutboundRequestOptions::default().with_credentials(RequestCredentials::Header {
+            name: "Authorization".to_string(),
+            value: "Bearer verbatim-header-secret".to_string(),
+        });
+
+        let debug_output = format!("{opts:?}");
+
+        assert!(
+            !debug_output.contains("verbatim-header-secret"),
+            "debug output must not expose a verbatim Authorization value, got: {debug_output}"
+        );
+        assert!(
+            debug_output.contains("Authorization"),
+            "the header name is not sensitive and must remain visible, got: {debug_output}"
+        );
+    }
 }


### PR DESCRIPTION
Addresses four boundary-hardening issues across the synthetic probe and HTTP client layers.

#822 Emit probe latency
  Add ProbeResult::from_http_status(probe_id, status, latency_ms), the
  seam between a request and a probe observation. On the success path it
  records the measured round-trip latency (milliseconds, matching the
  existing latency_ms field) so operators can tell a fast healthy
  endpoint from a barely responsive one. No metrics schema change.

#823 Map probe 204 as success
  from_http_status classifies via anchor_health::classify_http_status,
  the shared 2xx success-range policy, so a compliant liveness endpoint
  that answers 204 with no body is reported healthy. Non-success codes
  keep their existing "HTTP <code>" failure reason; no body is required.

#824 Reject cleartext HTTP anchor URLs
  post_with_options (and therefore post_with_options_metered) now reject
  any endpoint URL whose scheme is not https:// before the transport
  closure runs, so a direct caller cannot bypass the HTTPS policy. This
  is a scheme-only guard (new helper is_https_endpoint) and does not
  duplicate the domain validator's host/path/IP checks.

#825 Redact Authorization header in debug output
  Document and lock the OutboundRequestOptions Debug contract: the HMAC
  signing key and any Authorization/bearer/basic/custom auth value stay
  out of formatted output (via RequestCredentials' redacting Debug),
  while non-secret fields (idempotency key, Basic username, header name)
  remain visible. The header sent on the wire is unchanged.

Prerequisite: restore OutboundRequestOptions::with_credentials, which the outbound proxy/credentials tests and docs/proxy-and-credentials.md already reference but a prior refactor had dropped, leaving that test target uncompilable.

Tests: probe success/204/non-2xx assertions in synthetic_probe; cleartext rejection + https pass-through in outbound_proxy_credentials_tests; Authorization redaction regression tests in safe_logging_tests.

Closes #825 
Closes #824 
Closes #823 
Closes #822 

