### PR TITLE
Harden outbound HTTP client and SEP-6 status validation

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -731,6 +731,60 @@ pub fn is_transport_error_retryable(kind: TransportErrorKind) -> bool {
     matches!(kind, TransportErrorKind::Timeout | TransportErrorKind::DnsFailure)
 }
 
+/// Retry classification for an HTTP response status code.
+///
+/// This is the response-status counterpart to [`TransportErrorKind`]: it lets
+/// callers branch on whether a completed HTTP exchange should be retried under
+/// their configured policy instead of hard-coding status checks at each call
+/// site.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum HttpStatusClass {
+    /// 2xx / 3xx — the exchange completed without a server- or client-side error.
+    Success,
+    /// A transient failure. Retrying the same request may succeed. Covers
+    /// `408 Request Timeout`, `429 Too Many Requests` (rate limiting is
+    /// inherently temporary), and the transient `500`, `502`, `503`, `504`
+    /// server errors.
+    Retryable,
+    /// A permanent failure. The request will keep failing until it is changed
+    /// (most `4xx` client errors and non-transient `5xx` such as `501`).
+    Permanent,
+}
+
+/// Classify an HTTP response status code into an [`HttpStatusClass`].
+///
+/// `429 Too Many Requests` maps to [`HttpStatusClass::Retryable`] — rate
+/// limiting is a transient condition, not a permanent server error — so callers
+/// applying [`is_http_status_retryable`] back off and retry rather than failing
+/// the operation outright. Only the status code is inspected; any response body
+/// or headers the caller has already captured are left untouched.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::http_client::{classify_http_status_code, HttpStatusClass};
+///
+/// assert_eq!(classify_http_status_code(200), HttpStatusClass::Success);
+/// assert_eq!(classify_http_status_code(429), HttpStatusClass::Retryable);
+/// assert_eq!(classify_http_status_code(503), HttpStatusClass::Retryable);
+/// assert_eq!(classify_http_status_code(404), HttpStatusClass::Permanent);
+/// ```
+pub fn classify_http_status_code(status: u16) -> HttpStatusClass {
+    match status {
+        200..=399 => HttpStatusClass::Success,
+        408 | 429 | 500 | 502 | 503 | 504 => HttpStatusClass::Retryable,
+        _ => HttpStatusClass::Permanent,
+    }
+}
+
+/// Returns `true` when an HTTP response status should trigger a retry.
+///
+/// Convenience predicate over [`classify_http_status_code`]; `true` exactly when
+/// the status classifies as [`HttpStatusClass::Retryable`] (including `429`).
+pub fn is_http_status_retryable(status: u16) -> bool {
+    matches!(classify_http_status_code(status), HttpStatusClass::Retryable)
+}
+
 // ---------------------------------------------------------------------------
 // ProxyConfig
 // ---------------------------------------------------------------------------
@@ -1051,11 +1105,42 @@ pub fn build_client(
     proxy: Option<&ProxyConfig>,
     timeout_secs: u64,
 ) -> Result<reqwest::blocking::Client, String> {
+    let timeout = if timeout_secs > 0 {
+        Some(std::time::Duration::from_secs(timeout_secs))
+    } else {
+        None
+    };
+    build_client_with_timeout(proxy, timeout)
+}
+
+/// Shared client construction for the seconds-based [`build_client`] and the
+/// millisecond-precise webhook delivery path.
+///
+/// `timeout` is the total per-request budget as an already-constructed
+/// [`Duration`](std::time::Duration); `None` disables the timeout. Building the
+/// `Duration` at the call site keeps each conversion next to the public option
+/// that names its unit (see [`webhook_timeout`]) instead of forcing every
+/// caller through a seconds-only integer boundary that silently truncates
+/// sub-second budgets.
+///
+/// The redirect chain is always bounded explicitly by
+/// [`ConnectionPolicy::default()`]'s `max_redirects` rather than left to
+/// `reqwest`'s built-in default, so a dependency-side change to that default
+/// cannot widen (or an explicit builder tweak elsewhere disable) the cap.
+#[cfg(feature = "std")]
+fn build_client_with_timeout(
+    proxy: Option<&ProxyConfig>,
+    timeout: Option<std::time::Duration>,
+) -> Result<reqwest::blocking::Client, String> {
     let mut builder = reqwest::blocking::Client::builder();
 
-    if timeout_secs > 0 {
-        builder = builder.timeout(std::time::Duration::from_secs(timeout_secs));
+    if let Some(timeout) = timeout {
+        builder = builder.timeout(timeout);
     }
+
+    // Enforce the configured redirect limit at construction time.
+    let redirect_cap = ConnectionPolicy::default().max_redirects;
+    builder = builder.redirect(reqwest::redirect::Policy::limited(redirect_cap));
 
     if let Some(cfg) = proxy {
         builder = apply_proxy_config(builder, cfg)?;
@@ -1064,6 +1149,29 @@ pub fn build_client(
     builder
         .build()
         .map_err(|e| alloc::format!("failed to build HTTP client: {}", e))
+}
+
+/// Default total request timeout for webhook delivery when the caller leaves
+/// [`WebhookDeliveryConfig::timeout_ms`](crate::webhook::WebhookDeliveryConfig::timeout_ms)
+/// at `0` ("unset").
+#[cfg(feature = "std")]
+const DEFAULT_WEBHOOK_TIMEOUT_SECS: u64 = 30;
+
+/// Convert the public millisecond `timeout_ms` webhook option into a
+/// [`Duration`](std::time::Duration).
+///
+/// The value is interpreted as **milliseconds** — the unit named by the option
+/// and the config schema — so fractional-second budgets are preserved exactly
+/// rather than being floored (and, for values below `1000`, rounded up) by an
+/// integer division to whole seconds. `0` selects
+/// [`DEFAULT_WEBHOOK_TIMEOUT_SECS`].
+#[cfg(feature = "std")]
+fn webhook_timeout(timeout_ms: u64) -> std::time::Duration {
+    if timeout_ms == 0 {
+        std::time::Duration::from_secs(DEFAULT_WEBHOOK_TIMEOUT_SECS)
+    } else {
+        std::time::Duration::from_millis(timeout_ms)
+    }
 }
 
 /// Validate `cfg` and register its proxies on a reqwest client builder.
@@ -1289,13 +1397,7 @@ pub fn deliver_webhook_with_proxy(
     proxy: Option<&ProxyConfig>,
     now_fn: impl Fn() -> u64,
 ) -> Result<(), crate::errors::AnchorKitError> {
-    let timeout_secs = if config.timeout_ms > 0 {
-        (config.timeout_ms / 1000).max(1)
-    } else {
-        30
-    };
-
-    let client = build_client(proxy, timeout_secs)
+    let client = build_client_with_timeout(proxy, Some(webhook_timeout(config.timeout_ms)))
         .map_err(|e| {
             crate::errors::AnchorKitError::with_context(
                 crate::errors::ErrorCode::WebhookDeliveryFailed,
@@ -1377,19 +1479,14 @@ pub fn deliver_webhook_with_proxy_traced(
     proxy: Option<&ProxyConfig>,
     now_fn: impl Fn() -> u64,
 ) -> Result<(), crate::errors::AnchorKitError> {
-    let timeout_secs = if config.timeout_ms > 0 {
-        (config.timeout_ms / 1000).max(1)
-    } else {
-        30
-    };
-
-    let client = build_client(proxy, timeout_secs).map_err(|e| {
-        crate::errors::AnchorKitError::with_context(
-            crate::errors::ErrorCode::WebhookDeliveryFailed,
-            "failed to build HTTP client for webhook delivery",
-            &e,
-        )
-    })?;
+    let client = build_client_with_timeout(proxy, Some(webhook_timeout(config.timeout_ms)))
+        .map_err(|e| {
+            crate::errors::AnchorKitError::with_context(
+                crate::errors::ErrorCode::WebhookDeliveryFailed,
+                "failed to build HTTP client for webhook delivery",
+                &e,
+            )
+        })?;
 
     crate::webhook::deliver_webhook_traced(
         config,
@@ -2476,5 +2573,118 @@ mod tests {
         let json = r#"{"proxy_url":"http://proxy.corp:3128","proxy_password":"oops"}"#;
         let result: Result<ProxyConfig, _> = serde_json::from_str(json);
         assert!(result.is_err(), "unknown fields (likely typos) must be rejected");
+    }
+
+    // ── Issue #828: HTTP 429 is a retryable status ────────────────────────────
+
+    #[test]
+    fn http_status_429_is_retryable() {
+        assert_eq!(classify_http_status_code(429), HttpStatusClass::Retryable);
+        assert!(is_http_status_retryable(429), "rate limiting is transient");
+    }
+
+    #[test]
+    fn http_status_permanent_codes_stay_permanent() {
+        for status in [400u16, 401, 403, 404, 405, 409, 410, 422, 451, 501, 505] {
+            assert_eq!(
+                classify_http_status_code(status),
+                HttpStatusClass::Permanent,
+                "HTTP {status} should classify as permanent"
+            );
+            assert!(!is_http_status_retryable(status));
+        }
+    }
+
+    #[test]
+    fn http_status_success_and_transient_server_errors() {
+        for status in [200u16, 201, 204, 301, 302, 304, 399] {
+            assert_eq!(classify_http_status_code(status), HttpStatusClass::Success);
+            assert!(!is_http_status_retryable(status));
+        }
+        for status in [408u16, 500, 502, 503, 504] {
+            assert_eq!(classify_http_status_code(status), HttpStatusClass::Retryable);
+            assert!(is_http_status_retryable(status));
+        }
+    }
+
+    // ── Issue #827: webhook timeout keeps its millisecond unit ────────────────
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn webhook_timeout_preserves_millisecond_unit() {
+        use std::time::Duration;
+        // 0 means "unset" → default budget.
+        assert_eq!(webhook_timeout(0), Duration::from_secs(DEFAULT_WEBHOOK_TIMEOUT_SECS));
+        // Whole-second values are unchanged.
+        assert_eq!(webhook_timeout(30_000), Duration::from_secs(30));
+        assert_eq!(webhook_timeout(5_000), Duration::from_secs(5));
+        // Sub-second and non-whole-second values are preserved exactly, not
+        // truncated (250ms used to become 1s, 1500ms used to become 1s).
+        assert_eq!(webhook_timeout(1_500), Duration::from_millis(1_500));
+        assert_eq!(webhook_timeout(250), Duration::from_millis(250));
+        assert_eq!(webhook_timeout(1), Duration::from_millis(1));
+    }
+
+    // ── Issue #826: the redirect chain is bounded at client construction ──────
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn build_client_bounds_the_redirect_chain() {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let hits = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hits_srv = std::sync::Arc::clone(&hits);
+
+        // A mock server that answers *every* request with a 302 back to itself:
+        // an endless redirect chain if the client does not cap it.
+        let response = b"HTTP/1.1 302 Found\r\nLocation: /a\r\nContent-Length: 0\r\n\r\n";
+        let server = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        hits_srv.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        let mut buf = [0u8; 512];
+                        let _read = stream.read(&mut buf);
+                        let _ = stream.write_all(response);
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let client = build_client(None, 5).expect("client builds");
+        let result = client.get(alloc::format!("http://{addr}/start")).send();
+        let _ = server.join();
+
+        let err = result.expect_err("an endless redirect chain must be stopped, not followed");
+        assert!(
+            err.is_redirect() || err.to_string().to_lowercase().contains("redirect"),
+            "expected a redirect-limit error, got: {err}"
+        );
+
+        let cap = ConnectionPolicy::default().max_redirects;
+        let total = hits.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            (2..=cap + 1).contains(&total),
+            "requests should stop at the configured redirect cap ({cap}); saw {total}"
+        );
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn build_client_still_allows_redirects_within_the_cap() {
+        // The cap bounds the chain; it does not disable redirects and it does
+        // not touch a direct request. The default policy keeps a non-zero
+        // allowance, and clients still build with and without a timeout.
+        assert!(ConnectionPolicy::default().max_redirects >= 1);
+        assert!(build_client(None, 5).is_ok());
+        assert!(build_client(None, 0).is_ok());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,8 @@ pub use response_validator::{
     AnchorInfoResponse, DepositResponse as ValidatorDepositResponse, QuoteResponse,
     Sep38QuoteResponse, WithdrawResponse, TransactionStatusResponseValidated,
     SchemaVersion, VALIDATOR_SCHEMA_V1,
+    // Issue #831: unknown SEP-6 status strings classify as Unknown, never success
+    Sep6StatusClass, sep6_status_class,
     // Issue #661: response shape compatibility checks for older anchors
     CompatibilityLevel, CompatibilityReport,
     check_deposit_compatibility, check_withdraw_compatibility,

--- a/src/response_validator.rs
+++ b/src/response_validator.rs
@@ -123,28 +123,58 @@ pub struct TransactionStatusResponseValidated {
 
 // ── Status validators ─────────────────────────────────────────────────────────
 
-/// Returns `true` when `status` is a recognised SEP-6 transaction status.
-fn is_valid_sep6_status(status: &str) -> bool {
+/// Coarse classification of a SEP-6 transaction `status` string.
+///
+/// The default arm of [`sep6_status_class`] is [`Sep6StatusClass::Unknown`]: a
+/// status the current vocabulary does not recognise — for example one a newer
+/// anchor introduces — is never optimistically treated as a completed or
+/// otherwise successful operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Sep6StatusClass {
+    /// Terminal success: the transfer finished (`completed`).
+    Completed,
+    /// Terminal non-success: the transfer will not complete as requested
+    /// (`refunded`, `expired`, `error`).
+    Failed,
+    /// Still in flight — waiting on the user, the anchor, or the network.
+    Pending,
+    /// Not a recognised SEP-6 status.
+    Unknown,
+}
+
+/// Classify a SEP-6 transaction `status` string.
+///
+/// Recognised values map to [`Completed`](Sep6StatusClass::Completed),
+/// [`Failed`](Sep6StatusClass::Failed) or [`Pending`](Sep6StatusClass::Pending);
+/// every other value falls through the default arm to
+/// [`Unknown`](Sep6StatusClass::Unknown).
+pub fn sep6_status_class(status: &str) -> Sep6StatusClass {
     match status {
+        "completed" => Sep6StatusClass::Completed,
+        "refunded" | "expired" | "error" => Sep6StatusClass::Failed,
         "pending_external"
         | "pending_anchor"
         | "pending_trust"
         | "pending_user"
         | "pending_user_transfer_start"
         | "pending_user_transfer_complete"
-        | "completed"
-        | "refunded"
-        | "expired"
         | "incomplete"
         | "pending"
         | "no_market"
         | "too_small"
         | "too_large"
         | "pending_stellar"
-        | "waiting_customer_action"
-        | "error" => true,
-        _ => false,
+        | "waiting_customer_action" => Sep6StatusClass::Pending,
+        _ => Sep6StatusClass::Unknown,
     }
+}
+
+/// Returns `true` when `status` is a recognised SEP-6 transaction status.
+///
+/// Equivalent to `sep6_status_class(status) != Sep6StatusClass::Unknown`: an
+/// unrecognised status is rejected rather than assumed valid.
+fn is_valid_sep6_status(status: &str) -> bool {
+    !matches!(sep6_status_class(status), Sep6StatusClass::Unknown)
 }
 
 /// Returns `true` when `status` is a recognised quote status.
@@ -1675,5 +1705,47 @@ mod tests {
     fn test_tx_status_compat_incompatible_empty_txn_id() {
         let r = check_transaction_status_compatibility("", "completed", "withdrawal");
         assert_eq!(r.level, CompatibilityLevel::Incompatible);
+    }
+
+    // ── Issue #831: unknown status must not be treated as a success ───────────
+
+    #[test]
+    fn test_sep6_status_class_covers_full_vocabulary() {
+        // Every status is_valid_sep6_status accepts must classify as a concrete
+        // (non-Unknown) class, and the terminal ones keep their meaning.
+        for status in &[
+            "pending_external", "pending_anchor", "pending_trust", "pending_user",
+            "pending_user_transfer_start", "pending_user_transfer_complete", "completed",
+            "refunded", "expired", "incomplete", "pending", "no_market", "too_small",
+            "too_large", "pending_stellar", "waiting_customer_action", "error",
+        ] {
+            assert_ne!(sep6_status_class(status), Sep6StatusClass::Unknown, "{status}");
+            assert!(is_valid_sep6_status(status), "'{status}' must stay recognised");
+        }
+        assert_eq!(sep6_status_class("completed"), Sep6StatusClass::Completed);
+        assert_eq!(sep6_status_class("refunded"), Sep6StatusClass::Failed);
+        assert_eq!(sep6_status_class("expired"), Sep6StatusClass::Failed);
+        assert_eq!(sep6_status_class("error"), Sep6StatusClass::Failed);
+        assert_eq!(sep6_status_class("pending_anchor"), Sep6StatusClass::Pending);
+    }
+
+    #[test]
+    fn test_sep6_status_class_unknown_is_not_completed() {
+        // A status a newer anchor might introduce must classify as Unknown,
+        // never Completed, and must not pass validation.
+        for unknown in ["pending_regulatory_review", "settled", "", "COMPLETED"] {
+            assert_eq!(sep6_status_class(unknown), Sep6StatusClass::Unknown, "{unknown}");
+            assert!(!is_valid_sep6_status(unknown), "{unknown}");
+        }
+    }
+
+    #[test]
+    fn test_validators_reject_unknown_status_regression() {
+        // Deposit / withdraw / transaction-status validators must all fail
+        // closed on an unrecognised status rather than accept it as valid.
+        let unknown = "pending_regulatory_review";
+        assert!(validate_deposit_response("d1", unknown, "GADDR...", 0, 0).is_err());
+        assert!(validate_withdraw_response("w1", unknown, 0).is_err());
+        assert!(validate_transaction_status_response("t1", unknown, "deposit").is_err());
     }
 }


### PR DESCRIPTION
Addresses four hardening issues across the outbound HTTP path and the response validator. All changes are behaviour-preserving for the normal case and add focused regression tests.

#826 Cap HTTP redirects
- Route build_client through a shared build_client_with_timeout helper that always applies reqwest::redirect::Policy::limited with the existing ConnectionPolicy::default().max_redirects (3) instead of silently inheriting reqwest's built-in default. The webhook delivery path now goes through the same helper, so it is bounded too.
- No custom redirect client, no proxy-behaviour change, no new dependency. Tests use a loopback mock server to assert the chain stops at the configured cap, plus a non-networked test confirming redirects within the cap and direct requests are unaffected.

#827 Preserve HTTP timeout units
- The webhook timeout conversion divided the millisecond `timeout_ms` option by 1000 into whole seconds, so sub-second budgets were floored and values below 1000ms were rounded up to 1s. Introduce webhook_timeout(), which maps the option to a Duration with from_millis, preserving the unit named by the option and the config schema. `timeout_ms == 0` still selects the 30s default.
- Deterministic duration assertions cover zero, whole-second and fractional-second values.

#828 Map HTTP 429 to a retryable classification
- Add HttpStatusClass plus classify_http_status_code / is_http_status_ retryable to http_client, the response-status counterpart to the existing transport-error classification. 429 (and 408/500/502/503/504) classify as Retryable; other 4xx and non-transient 5xx stay Permanent.
- Only the status code is inspected; response bodies and headers are untouched. Tests cover 429, permanent codes and transient server codes.

#831 Reject unknown SEP-6 status
- Replace the boolean is_valid_sep6_status match with sep6_status_class, whose default arm is Sep6StatusClass::Unknown. is_valid_sep6_status is now `!= Unknown`, so an unrecognised status (for example one a newer anchor introduces) is never treated as valid/successful. The known vocabulary and every existing mapping are unchanged; no new statuses are added.
- Regression tests confirm the full known vocabulary still classifies as non-Unknown and that deposit/withdraw/transaction-status validators fail closed on an unknown status.

Closes #831 
Closes #828 
Closes #827 
Closes #826 
