### PR TITLE
Fix compaction overflow/empty-batch and artifact digest/URL credential issues

### DIFF
--- a/src/artifact_provenance.rs
+++ b/src/artifact_provenance.rs
@@ -195,6 +195,16 @@ impl<'a> ProvenanceVerifier<'a> {
     }
 }
 
+fn url_has_credentials(url: &str) -> bool {
+    if let Some(pos) = url.find("://") {
+        let rest = &url[pos + 3..];
+        let authority_end = rest.find('/').unwrap_or(rest.len());
+        rest[..authority_end].contains('@')
+    } else {
+        false
+    }
+}
+
 fn check_field(expected: Option<&str>, actual: Option<&str>) -> FieldVerdict {
     match (expected, actual) {
         (None, _) => FieldVerdict::NotChecked,
@@ -237,7 +247,7 @@ impl ProvenanceStore {
     /// # Errors
     ///
     /// Returns [`AnchorKitError`] with [`ErrorCode::ValidationError`] when
-    /// `artifact_name` or `content_hash` is empty.
+    /// `artifact_name` or `content_hash` is empty or malformed.
     pub fn record(
         &mut self,
         artifact_name: String,
@@ -249,6 +259,9 @@ impl ProvenanceStore {
         }
         if content_hash.is_empty() {
             return Err(AnchorKitError::validation_error("content_hash must not be empty"));
+        }
+        if content_hash.chars().any(|c| c.is_ascii_whitespace()) {
+            return Err(AnchorKitError::validation_error("content_hash must not contain whitespace"));
         }
 
         let provenance = ArtifactProvenance {
@@ -281,6 +294,14 @@ impl ProvenanceStore {
         build_env: Option<Vec<(String, String)>>,
         signature: Option<String>,
     ) -> Result<(), AnchorKitError> {
+        if let Some(ref repo) = source_repository {
+            if url_has_credentials(repo) {
+                return Err(AnchorKitError::validation_error(
+                    "source_repository must not contain URL credentials",
+                ));
+            }
+        }
+
         let record = self
             .records
             .iter_mut()
@@ -470,6 +491,57 @@ mod tests {
             .verify();
         assert!(!report.passed);
         assert_eq!(report.source_revision, FieldVerdict::Missing);
+    }
+
+    // --- #868: malformed digest ---
+
+    #[test]
+    fn record_malformed_hash_rejected() {
+        let mut store = ProvenanceStore::new();
+        let err = store
+            .record("artifact.wasm".into(), "   ".into(), 0)
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValidationError);
+    }
+
+    // --- #869: credential-bearing source URL ---
+
+    #[test]
+    fn update_source_repository_with_credentials_rejected() {
+        let mut store = ProvenanceStore::new();
+        store.record("a.wasm".into(), "h1".into(), 0).unwrap();
+        let err = store
+            .update(
+                0,
+                None,
+                Some("https://user:pass@github.com/org/repo".into()),
+                None,
+                None,
+                None,
+            )
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValidationError);
+    }
+
+    #[test]
+    fn update_ordinary_source_repository_accepted() {
+        let mut store = ProvenanceStore::new();
+        store.record("a.wasm".into(), "h1".into(), 0).unwrap();
+        store
+            .update(
+                0,
+                None,
+                Some("https://github.com/org/repo".into()),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let p = store.get_by_id(0).unwrap();
+        assert_eq!(
+            p.source_repository.as_deref(),
+            Some("https://github.com/org/repo")
+        );
     }
 
     #[test]

--- a/src/transaction_compaction.rs
+++ b/src/transaction_compaction.rs
@@ -285,11 +285,11 @@ pub fn compact_history(
         }
 
         let (completed, pending, error) = classify_status(&rec.status);
-        if completed { completed_count += 1; }
-        if pending { pending_count += 1; }
-        if error { error_count += 1; }
+        if completed { completed_count = completed_count.saturating_add(1); }
+        if pending { pending_count = pending_count.saturating_add(1); }
+        if error { error_count = error_count.saturating_add(1); }
 
-        total_count += 1;
+        total_count = total_count.saturating_add(1);
         total_volume = total_volume.saturating_add(rec.amount);
         if rec.amount > max_amount { max_amount = rec.amount; }
         if rec.amount < min_amount { min_amount = rec.amount; }
@@ -476,6 +476,30 @@ mod tests {
         let result = compact_history(&records, &cfg).unwrap();
         assert_eq!(result.aggregate.earliest_timestamp, 1000);
         assert_eq!(result.aggregate.latest_timestamp, 5000);
+    }
+
+    // --- #866: empty batch creates no summary ---
+
+    #[test]
+    fn empty_batch_creates_no_summary() {
+        let cfg = CompactionConfig::default();
+        let result = compact_history(&[], &cfg).unwrap();
+        assert!(result.windows.is_empty());
+        assert_eq!(result.aggregate.window_count, 0);
+        assert_eq!(result.aggregate.total_count, 0);
+    }
+
+    // --- #867: large batch count does not overflow ---
+
+    #[test]
+    fn large_batch_count_does_not_overflow() {
+        let records: Vec<RawTransactionRecord> = (0u64..1000)
+            .map(|i| rec(&alloc::format!("t{}", i), i * 10, "completed", 1))
+            .collect();
+        let cfg = CompactionConfig { window_seconds: 1_000_000, retain_boundary_ids: false };
+        let result = compact_history(&records, &cfg).unwrap();
+        assert_eq!(result.windows[0].total_count, 1000);
+        assert_eq!(result.aggregate.total_count, 1000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#866 Avoid Compaction Empty Batch** — early-return guard before summary construction was already in place; adds a focused test (`empty_batch_creates_no_summary`) explicitly asserting that empty input produces no window records.
- **#867 Prevent Compaction Count Overflow** — replaces bare `+=` with `saturating_add` on all four `u32` per-window counters (`total_count`, `completed_count`, `pending_count`, `error_count`) to match the existing saturating policy on `total_volume`; adds a 1 000-record boundary test.
- **#868 Require Artifact Digest** — adds a whitespace check on `content_hash` in `ProvenanceStore::record` so blank/malformed digests (e.g. `"   "`) are refused before storage; adds `record_malformed_hash_rejected` test.
- **#869 Redact Artifact Source URL Credentials** — adds `url_has_credentials` helper that detects userinfo (`@` in the URL authority component) and rejects credential-bearing `source_repository` values in `ProvenanceStore::update`; adds tests for both the rejected and the accepted (ordinary URL) paths.

## Test plan

- [ ] `record_malformed_hash_rejected` — whitespace-only hash returns `ValidationError`
- [ ] `update_source_repository_with_credentials_rejected` — `https://user:pass@host/…` returns `ValidationError`
- [ ] `update_ordinary_source_repository_accepted` — plain HTTPS URL is stored unchanged
- [ ] `empty_batch_creates_no_summary` — empty slice produces zero windows
- [ ] `large_batch_count_does_not_overflow` — 1 000-record batch yields `total_count == 1000`
- [ ] All pre-existing provenance and compaction tests continue to pass

closes #866
closes #867
closes #868
closes #869