### PR TITLE
fix: reject blank TOML issuers/secrets and dedupe discovery endpoints

### DIFF
--- a/src/stellar_toml.rs
+++ b/src/stellar_toml.rs
@@ -108,6 +108,37 @@ impl ParsedStellarToml {
     pub fn find_currency(&self, code: &str) -> Option<&ParsedCurrency> {
         self.currencies.iter().find(|c| c.code == code)
     }
+
+    /// Returns the anchor's discovered SEP service endpoints as
+    /// `(label, url)` pairs, deduplicated by URL in first-seen order.
+    ///
+    /// Anchors sometimes point multiple SEP endpoint fields at the same URL
+    /// (for example a combined SEP-6/SEP-31 server). Returning every field
+    /// verbatim would cause callers to probe the same host repeatedly and
+    /// would obscure which distinct service types are actually available.
+    /// Only the first field — in declaration order — that advertises a given
+    /// URL is retained, so its label and position are preserved; later
+    /// fields pointing at the same URL are dropped.
+    pub fn discovered_endpoints(&self) -> Vec<(&'static str, String)> {
+        let candidates: [(&'static str, &Option<String>); 6] = [
+            ("TRANSFER_SERVER", &self.transfer_server),
+            ("TRANSFER_SERVER_SEP0024", &self.transfer_server_sep0024),
+            ("KYC_SERVER", &self.kyc_server),
+            ("WEB_AUTH_ENDPOINT", &self.web_auth_endpoint),
+            ("DIRECT_PAYMENT_SERVER", &self.direct_payment_server),
+            ("ANCHOR_QUOTE_SERVER", &self.anchor_quote_server),
+        ];
+
+        let mut endpoints: Vec<(&'static str, String)> = Vec::new();
+        for (label, url) in candidates {
+            if let Some(url) = url {
+                if !endpoints.iter().any(|(_, seen_url)| seen_url == url) {
+                    endpoints.push((label, url.clone()));
+                }
+            }
+        }
+        endpoints
+    }
 }
 
 /// Constructs the well-known stellar.toml URL for a given domain.
@@ -190,7 +221,14 @@ pub fn parse_stellar_toml(raw: &str) -> Result<ParsedStellarToml, AnchorKitError
                     });
                     match key {
                         "code" => cur.code = value,
-                        "issuer" => cur.issuer = Some(value),
+                        "issuer" => {
+                            if value.trim().is_empty() {
+                                return Err(AnchorKitError::validation_error(
+                                    "CURRENCIES block has empty issuer field",
+                                ));
+                            }
+                            cur.issuer = Some(value);
+                        }
                         "status" => cur.status = Some(value),
                         _ => {}
                     }

--- a/src/stellar_toml_tests.rs
+++ b/src/stellar_toml_tests.rs
@@ -183,6 +183,94 @@ code = "EURC"
 }
 
 #[test]
+fn test_currency_blank_issuer_rejected() {
+    let raw = r#"
+[[CURRENCIES]]
+code = "USDC"
+issuer = ""
+"#;
+    assert!(parse_stellar_toml(raw).is_err());
+}
+
+#[test]
+fn test_currency_whitespace_only_issuer_rejected() {
+    let raw = r#"
+[[CURRENCIES]]
+code = "USDC"
+issuer = "   "
+"#;
+    assert!(parse_stellar_toml(raw).is_err());
+}
+
+#[test]
+fn test_currency_without_issuer_still_parses() {
+    let raw = r#"
+[[CURRENCIES]]
+code = "USDC"
+"#;
+    let parsed = parse_stellar_toml(raw).unwrap();
+    assert_eq!(parsed.currencies.len(), 1);
+    assert!(parsed.currencies[0].issuer.is_none());
+}
+
+#[test]
+fn test_currency_valid_issuer_still_parses() {
+    let raw = r#"
+[[CURRENCIES]]
+code = "USDC"
+issuer = "GAISSUER"
+"#;
+    let parsed = parse_stellar_toml(raw).unwrap();
+    assert_eq!(parsed.currencies[0].issuer.as_deref(), Some("GAISSUER"));
+}
+
+// ---------------------------------------------------------------------------
+// Discovered endpoint deduplication (#848)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_discovered_endpoints_deduplicates_repeated_url() {
+    // KYC_SERVER and WEB_AUTH_ENDPOINT point at the same host as
+    // TRANSFER_SERVER; only the first-seen (TRANSFER_SERVER) entry for that
+    // URL should survive.
+    let raw = r#"
+TRANSFER_SERVER = "https://api.example.com"
+KYC_SERVER = "https://api.example.com"
+WEB_AUTH_ENDPOINT = "https://auth.example.com"
+"#;
+    let parsed = parse_stellar_toml(raw).unwrap();
+    let endpoints = parsed.discovered_endpoints();
+    assert_eq!(
+        endpoints,
+        vec![
+            ("TRANSFER_SERVER", "https://api.example.com".to_string()),
+            ("WEB_AUTH_ENDPOINT", "https://auth.example.com".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_discovered_endpoints_preserves_order_and_labels_when_unique() {
+    let parsed = parse_stellar_toml(VALID_TOML).unwrap();
+    let endpoints = parsed.discovered_endpoints();
+    assert_eq!(
+        endpoints,
+        vec![
+            ("TRANSFER_SERVER", "https://api.example.com".to_string()),
+            ("TRANSFER_SERVER_SEP0024", "https://api.example.com/sep24".to_string()),
+            ("KYC_SERVER", "https://kyc.example.com".to_string()),
+            ("WEB_AUTH_ENDPOINT", "https://auth.example.com".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_discovered_endpoints_empty_when_no_endpoints_declared() {
+    let parsed = parse_stellar_toml(r#"SIGNING_KEY = "GSIGN123""#).unwrap();
+    assert!(parsed.discovered_endpoints().is_empty());
+}
+
+#[test]
 fn test_currency_block_without_code_is_dropped() {
     let raw = r#"
 [[CURRENCIES]]

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -50,6 +50,12 @@ fn sign_payload(key: &[u8], payload: &str) -> String {
 /// The comparison is done byte-by-byte in constant time to prevent timing
 /// attacks.
 pub fn verify_webhook_signature(payload: &str, signature_header: &str, key: &[u8]) -> bool {
+    // An empty signing secret would make HMAC verification meaningless: any
+    // signature computed against a blank key could be reproduced by anyone,
+    // so reject it outright before doing any HMAC work.
+    if key.is_empty() {
+        return false;
+    }
     let hex_digest = match signature_header.strip_prefix("sha256=") {
         Some(h) => h,
         None => return false,

--- a/tests/webhook_middleware_tests.rs
+++ b/tests/webhook_middleware_tests.rs
@@ -269,4 +269,32 @@ mod webhook_middleware_tests {
         let sig = sig_captured.lock().unwrap().clone();
         assert!(!verify_webhook_signature(payload, &sig, b"wrong-key"));
     }
+
+    // -----------------------------------------------------------------------
+    // 10. verify_webhook_signature — empty secret is rejected before HMAC work
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_verify_empty_secret_fails() {
+        let key = b"secret";
+        let payload = r#"{"event":"test"}"#;
+        let sig_captured: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+        let sc = sig_captured.clone();
+        let mut dlq: BTreeMap<String, Vec<DlqEntry>> = BTreeMap::new();
+        let _ = deliver_webhook(
+            &signed_config(1, key.to_vec()),
+            payload,
+            &mut dlq,
+            move |_url, _body, sig| {
+                if let Some(s) = sig { *sc.lock().unwrap() = s.to_string(); }
+                Ok(200)
+            },
+            |_| {},
+            || 0u64,
+        );
+        let sig = sig_captured.lock().unwrap().clone();
+
+        // A blank secret must never validate a signature, even one produced
+        // with a real key.
+        assert!(!verify_webhook_signature(payload, &sig, b""));
+    }
 }


### PR DESCRIPTION
94. Reject TOML Empty Issuer Fixes #849

97. Reject Empty Webhook Secret Fixes #852

93. Reject Duplicate TOML Endpoints Fixes #848

96. Preserve Vendor Error Status Fixes #851

## Summary

<!-- What does this PR do and why? One to three bullet points. -->

-

## Changes

<!-- List the key files or components changed. -->

-

## Testing

<!-- How was this tested? Check all that apply. -->

- [ ] `cargo test` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] WASM build passes (`cargo build --target wasm32-unknown-unknown`)
- [ ] Manual testing (describe below)

<!-- Describe any manual testing steps or edge cases verified. -->

## Related issues

<!-- Use "closes #<number>" to auto-close issues on merge. -->

closes #

## Checklist

- [ ] Branch name follows the convention (`<type>/<description>`) — see [branch-pr-hygiene.md](../docs/branch-pr-hygiene.md)
- [ ] PR title follows Conventional Commits format (`feat(scope): subject`)
- [ ] Public API changes are reflected in `api_snapshots/` (run `./scripts/snapshot_api.sh` if needed)
- [ ] `CHANGELOG.md` updated (for user-facing changes)
- [ ] Documentation updated (for new behavior or config options)
- [ ] Security review done if touching auth, crypto, HTTP integrations, or deployment — see [SECURITY_REVIEW_CHECKLIST.md](../docs/SECURITY_REVIEW_CHECKLIST.md)
