### PR TITLE
Harden SEP-6 amount bounds and SEP-24 interactive response normalization

### DIFF
--- a/src/sep24.rs
+++ b/src/sep24.rs
@@ -276,6 +276,39 @@ pub fn validate_transaction_id(id: &str) -> Result<(), AnchorKitError> {
     Ok(())
 }
 
+/// Reject a blank interactive redirect URL before any parsing or normalization.
+///
+/// The SEP-24 interactive flow cannot begin without a redirect URL, so an empty
+/// or whitespace-only value is rejected up front with a clear message rather
+/// than surfacing later as a generic parse error. This is the shared guard used
+/// by both the interactive deposit and interactive withdrawal normalizers so
+/// the two paths validate identically.
+fn require_redirect_url(url: &str) -> Result<(), AnchorKitError> {
+    if url.trim().is_empty() {
+        return Err(AnchorKitError::new(
+            ErrorCode::ValidationError,
+            "SEP-24 interactive redirect URL must not be blank",
+        ));
+    }
+    Ok(())
+}
+
+/// Require a non-blank anchor transaction ID without otherwise altering it.
+///
+/// SEP-24 transaction IDs are opaque, anchor-assigned tokens: later status
+/// lookups send the value back verbatim, so the normalizer must preserve it
+/// exactly. Only the required / non-empty check is enforced here — callers that
+/// want stricter structural checks can still opt into [`validate_transaction_id`].
+fn require_transaction_id(id: &str) -> Result<(), AnchorKitError> {
+    if id.trim().is_empty() {
+        return Err(AnchorKitError::new(
+            ErrorCode::ValidationError,
+            "SEP-24 transaction ID must not be empty",
+        ));
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Service functions
 // ---------------------------------------------------------------------------
@@ -324,9 +357,10 @@ pub fn initiate_interactive_deposit_with_origin(
     raw: RawInteractiveDepositResponse,
     expected_origin: Option<&str>,
 ) -> Result<InteractiveDepositResponse, AnchorKitError> {
+    require_redirect_url(&raw.url)?;
     let normalized_url = normalize_url(&raw.url)?;
     validate_interactive_url(&normalized_url, expected_origin)?;
-    validate_transaction_id(&raw.id)?;
+    require_transaction_id(&raw.id)?;
     Ok(InteractiveDepositResponse {
         url: normalized_url,
         id: raw.id,
@@ -375,9 +409,10 @@ pub fn initiate_interactive_withdrawal_with_origin(
     raw: RawInteractiveWithdrawalResponse,
     expected_origin: Option<&str>,
 ) -> Result<InteractiveWithdrawalResponse, AnchorKitError> {
+    require_redirect_url(&raw.url)?;
     let normalized_url = normalize_url(&raw.url)?;
     validate_interactive_url(&normalized_url, expected_origin)?;
-    validate_transaction_id(&raw.id)?;
+    require_transaction_id(&raw.id)?;
     Ok(InteractiveWithdrawalResponse {
         url: normalized_url,
         id: raw.id,
@@ -963,5 +998,88 @@ mod tests {
         };
         let result = fetch_sep24_transaction_status(raw).unwrap();
         assert_eq!(result.status, TransactionStatus::Error);
+    }
+
+    // ── #835 blank interactive redirect URL is rejected ──────────────────────
+
+    #[test]
+    fn test_require_redirect_url_rejects_blank() {
+        assert!(require_redirect_url("").is_err());
+        assert!(require_redirect_url("   ").is_err());
+        assert!(require_redirect_url("\t\n").is_err());
+        assert!(require_redirect_url("https://anchor.example.com/deposit").is_ok());
+    }
+
+    #[test]
+    fn test_initiate_interactive_deposit_rejects_whitespace_only_url() {
+        let raw = RawInteractiveDepositResponse {
+            url: "   ".to_string(),
+            id: "tx-123".to_string(),
+        };
+        assert!(initiate_interactive_deposit(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_interactive_withdrawal_rejects_whitespace_only_url() {
+        let raw = RawInteractiveWithdrawalResponse {
+            url: "   ".to_string(),
+            id: "tx-456".to_string(),
+        };
+        assert!(initiate_interactive_withdrawal(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_interactive_deposit_valid_url_unchanged() {
+        let raw = RawInteractiveDepositResponse {
+            url: "https://anchor.example.com/deposit".to_string(),
+            id: "tx-123".to_string(),
+        };
+        let result = initiate_interactive_deposit(raw).unwrap();
+        assert_eq!(result.url, "https://anchor.example.com/deposit");
+    }
+
+    // ── #837 opaque transaction IDs round-trip unchanged ─────────────────────
+
+    #[test]
+    fn test_initiate_interactive_deposit_preserves_opaque_id() {
+        let opaque = "tx--001__2024.11.30:anchor";
+        let raw = RawInteractiveDepositResponse {
+            url: "https://anchor.example.com/deposit".to_string(),
+            id: opaque.to_string(),
+        };
+        let result = initiate_interactive_deposit(raw).unwrap();
+        assert_eq!(result.id, opaque);
+        // URL normalization is unaffected by the ID change.
+        assert_eq!(result.url, "https://anchor.example.com/deposit");
+    }
+
+    #[test]
+    fn test_initiate_interactive_withdrawal_preserves_opaque_id() {
+        let opaque = "WD_2024-11-30/abc..99";
+        let raw = RawInteractiveWithdrawalResponse {
+            url: "https://anchor.example.com/withdraw".to_string(),
+            id: opaque.to_string(),
+        };
+        let result = initiate_interactive_withdrawal(raw).unwrap();
+        assert_eq!(result.id, opaque);
+        assert_eq!(result.url, "https://anchor.example.com/withdraw");
+    }
+
+    #[test]
+    fn test_initiate_interactive_deposit_still_rejects_blank_id() {
+        let raw = RawInteractiveDepositResponse {
+            url: "https://anchor.example.com/deposit".to_string(),
+            id: "   ".to_string(),
+        };
+        assert!(initiate_interactive_deposit(raw).is_err());
+    }
+
+    #[test]
+    fn test_initiate_interactive_withdrawal_still_rejects_blank_id() {
+        let raw = RawInteractiveWithdrawalResponse {
+            url: "https://anchor.example.com/withdraw".to_string(),
+            id: "".to_string(),
+        };
+        assert!(initiate_interactive_withdrawal(raw).is_err());
     }
 }

--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -518,6 +518,23 @@ fn validate_memo_pair(memo: Option<&str>, memo_type: Option<&str>) -> Result<(),
     Ok(())
 }
 
+/// Validate SEP-6 amount-bound ordering.
+///
+/// When **both** `min_amount` and `max_amount` are present an inverted range
+/// (`min_amount > max_amount`) cannot describe a usable offer and is rejected
+/// with [`Error::invalid_transaction_intent`]. Equal bounds and correctly
+/// ordered bounds pass. When either bound is absent no constraint is applied,
+/// preserving the previous behavior. The numeric values themselves are never
+/// altered.
+fn validate_amount_ordering(min_amount: Option<u64>, max_amount: Option<u64>) -> Result<(), Error> {
+    if let (Some(min), Some(max)) = (min_amount, max_amount) {
+        if min > max {
+            return Err(Error::invalid_transaction_intent());
+        }
+    }
+    Ok(())
+}
+
 // ── Service functions ─────────────────────────────────────────────────────────
 
 /// Normalize a raw anchor deposit response into a canonical [`DepositResponse`].
@@ -573,11 +590,7 @@ pub fn initiate_deposit(raw: RawDepositResponse) -> Result<DepositResponse, Erro
     if raw.transaction_id.is_empty() || raw.how.is_empty() {
         return Err(Error::invalid_transaction_intent());
     }
-    if let (Some(min), Some(max)) = (raw.min_amount, raw.max_amount) {
-        if min > max {
-            return Err(Error::invalid_transaction_intent());
-        }
-    }
+    validate_amount_ordering(raw.min_amount, raw.max_amount)?;
     validate_memo_pair(raw.stellar_memo.as_deref(), raw.stellar_memo_type.as_deref())?;
     let asset_code = raw.asset_code.as_deref()
         .map(normalize_asset_code)
@@ -652,11 +665,7 @@ pub fn initiate_withdrawal(raw: RawWithdrawalResponse) -> Result<WithdrawalRespo
     if raw.transaction_id.is_empty() || raw.account_id.is_empty() {
         return Err(Error::invalid_transaction_intent());
     }
-    if let (Some(min), Some(max)) = (raw.min_amount, raw.max_amount) {
-        if min > max {
-            return Err(Error::invalid_transaction_intent());
-        }
-    }
+    validate_amount_ordering(raw.min_amount, raw.max_amount)?;
     validate_memo_pair(raw.memo.as_deref(), raw.memo_type.as_deref())?;
     let asset_code = raw.asset_code.as_deref()
         .map(normalize_asset_code)
@@ -1452,5 +1461,79 @@ mod tests {
         ] {
             assert_eq!(TransactionStatus::from_str(input), *expected, "mismatch for '{}'", input);
         }
+    }
+
+    // ── #833 SEP-6 amount-bound ordering ─────────────────────────────────────
+
+    #[test]
+    fn test_validate_amount_ordering_semantics() {
+        // Ordered and equal bounds pass.
+        assert!(validate_amount_ordering(Some(10), Some(20)).is_ok());
+        assert!(validate_amount_ordering(Some(20), Some(20)).is_ok());
+        // Inverted bounds fail.
+        assert!(validate_amount_ordering(Some(21), Some(20)).is_err());
+        // Absent bounds impose no constraint.
+        assert!(validate_amount_ordering(None, Some(5)).is_ok());
+        assert!(validate_amount_ordering(Some(5), None).is_ok());
+        assert!(validate_amount_ordering(None, None).is_ok());
+    }
+
+    #[test]
+    fn test_initiate_deposit_ordered_bounds_accepted() {
+        let mut raw = raw_deposit();
+        raw.min_amount = Some(10);
+        raw.max_amount = Some(20);
+        let resp = initiate_deposit(raw).unwrap();
+        assert_eq!(resp.min_amount, Some(10));
+        assert_eq!(resp.max_amount, Some(20));
+    }
+
+    #[test]
+    fn test_initiate_deposit_absent_min_bound_retains_behavior() {
+        let mut raw = raw_deposit();
+        raw.min_amount = None;
+        raw.max_amount = Some(1);
+        let resp = initiate_deposit(raw).unwrap();
+        assert_eq!(resp.min_amount, None);
+        assert_eq!(resp.max_amount, Some(1));
+    }
+
+    #[test]
+    fn test_initiate_deposit_absent_max_bound_retains_behavior() {
+        let mut raw = raw_deposit();
+        raw.min_amount = Some(9_999_999);
+        raw.max_amount = None;
+        let resp = initiate_deposit(raw).unwrap();
+        assert_eq!(resp.min_amount, Some(9_999_999));
+        assert_eq!(resp.max_amount, None);
+    }
+
+    #[test]
+    fn test_initiate_deposit_both_bounds_absent_retains_behavior() {
+        let mut raw = raw_deposit();
+        raw.min_amount = None;
+        raw.max_amount = None;
+        assert!(initiate_deposit(raw).is_ok());
+    }
+
+    #[test]
+    fn test_initiate_withdrawal_ordered_bounds_accepted() {
+        let mut raw = raw_withdrawal();
+        raw.min_amount = Some(5);
+        raw.max_amount = Some(6);
+        assert!(initiate_withdrawal(raw).is_ok());
+    }
+
+    #[test]
+    fn test_initiate_withdrawal_absent_bounds_retain_behavior() {
+        let mut raw = raw_withdrawal();
+        raw.min_amount = None;
+        raw.max_amount = Some(1);
+        assert!(initiate_withdrawal(raw).is_ok());
+
+        let mut raw2 = raw_withdrawal();
+        raw2.min_amount = Some(1_000_000);
+        raw2.max_amount = None;
+        assert!(initiate_withdrawal(raw2).is_ok());
     }
 }

--- a/tests/sep24_origin_pinning_tests.rs
+++ b/tests/sep24_origin_pinning_tests.rs
@@ -107,4 +107,50 @@ mod sep24_origin_pinning_tests {
                 .is_err()
         );
     }
+
+    // ── #836 non-HTTPS (cleartext) redirect URLs are rejected ─────────────
+
+    #[test]
+    fn validate_interactive_url_rejects_http_scheme() {
+        assert!(validate_interactive_url("http://anchor.example.com/deposit", None).is_err());
+        assert!(validate_interactive_url("https://anchor.example.com/deposit", None).is_ok());
+    }
+
+    #[test]
+    fn deposit_with_http_redirect_url_rejected() {
+        let raw = RawInteractiveDepositResponse {
+            url: "http://anchor.example.com/deposit".into(),
+            id: "tx-001".into(),
+        };
+        assert!(
+            initiate_interactive_deposit_with_origin(raw, Some("https://anchor.example.com"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn withdrawal_with_http_redirect_url_rejected() {
+        let raw = RawInteractiveWithdrawalResponse {
+            url: "http://anchor.example.com/withdraw".into(),
+            id: "tx-002".into(),
+        };
+        assert!(
+            initiate_interactive_withdrawal_with_origin(raw, Some("https://anchor.example.com"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn https_redirect_url_accepted_after_scheme_check() {
+        let raw = RawInteractiveDepositResponse {
+            url: "https://anchor.example.com/deposit".into(),
+            id: "tx-003".into(),
+        };
+        let out = initiate_interactive_deposit_with_origin(
+            raw,
+            Some("https://anchor.example.com"),
+        )
+        .expect("https redirect must pass");
+        assert_eq!(out.url, "https://anchor.example.com/deposit");
+    }
 }


### PR DESCRIPTION
Addresses four SEP normalization gaps (#833, #835, #836, #837).

#833 Validate SEP-6 amount ordering
  - Extract the min/max relationship check from initiate_deposit and initiate_withdrawal into a single validate_amount_ordering helper.
  - Rejects only min_amount > max_amount when both bounds are present; equal and correctly ordered bounds pass, and an absent bound imposes no constraint. Numeric values are passed through unchanged.

#835 Require SEP-24 redirect URL
  - Add a shared require_redirect_url guard run before URL parsing in both initiate_interactive_deposit_with_origin and initiate_interactive_withdrawal_with_origin, so an empty or whitespace-only redirect URL fails with a clear message instead of a generic parse error. Valid URLs are unaffected and both interactive variants now validate identically. No new redirect type added.

#836 Reject SEP-24 non-HTTPS redirect
  - The existing HTTPS/domain validator already rejects cleartext redirect URLs; add explicit HTTP-rejection coverage for both interactive variants in tests/sep24_origin_pinning_tests.rs. URL path and query handling are untouched and no network request is introduced.

#837 Preserve SEP-24 transaction ID
  - Replace the lossy validate_transaction_id call in the interactive deposit and withdrawal normalizers with require_transaction_id, which enforces only the required / non-blank check. Opaque anchor IDs now round-trip exactly so later status lookups remain valid; blank IDs are still rejected. validate_transaction_id stays available for callers that want stricter structural checks.

Tests
  - src/sep6.rs: ordered-bound, equal-bound, single-absent-bound and both-absent fixtures for deposit and withdrawal, plus direct validate_amount_ordering coverage.
  - src/sep24.rs: blank / whitespace-only redirect URL rejection for both variants, opaque-ID round-trip fixtures with significant internal characters, and retained blank-ID rejection.
  - tests/sep24_origin_pinning_tests.rs: HTTP redirect rejection and HTTPS acceptance for the interactive deposit and withdrawal paths.

Note: the repository does not currently build on this base (pre-existing duplicate ErrorCode variants in src/errors.rs, a missing ErrorCode::InvalidRegistration referenced by src/contract.rs, and an Fn closure capture error in src/synthetic_probe.rs tests), so these changes could not be compiled or test-run locally. The edits are scoped to the SEP-6 and SEP-24 normalization paths and their tests only.

Closes #833 
Closes #835 
Closes #836 
Closes #837 
