### PR TITLE
fix: bound logs and archive lifecycle operations

### DIFF
--- a/src/request_record.rs
+++ b/src/request_record.rs
@@ -254,6 +254,9 @@ impl RequestRecordStore {
 
     // ── Export / archival (#680) ─────────────────────────────────────────────
 
+    /// Maximum number of records returned by one export page.
+    pub const MAX_EXPORT_PAGE_SIZE: usize = 100;
+
     /// Export a paginated batch of active records starting at `start_cursor`.
     ///
     /// `batch_size` is capped at 100 to prevent unbounded allocations.
@@ -290,8 +293,7 @@ impl RequestRecordStore {
     /// assert!(!tail.has_more);
     /// ```
     pub fn export_batch(&self, start_cursor: usize, batch_size: usize) -> ExportBatch {
-        const MAX_BATCH: usize = 100;
-        let effective_size = batch_size.min(MAX_BATCH);
+        let effective_size = batch_size.min(Self::MAX_EXPORT_PAGE_SIZE);
 
         if start_cursor >= self.records.len() {
             return ExportBatch {
@@ -301,7 +303,9 @@ impl RequestRecordStore {
             };
         }
 
-        let end = (start_cursor + effective_size).min(self.records.len());
+        let end = start_cursor
+            .saturating_add(effective_size)
+            .min(self.records.len());
         let records = self.records[start_cursor..end].to_vec();
         let next_cursor = end;
         let has_more = next_cursor < self.records.len();
@@ -362,8 +366,7 @@ impl RequestRecordStore {
     ///
     /// Same pagination contract as [`export_batch`](Self::export_batch).
     pub fn archive_export(&self, start_cursor: usize, batch_size: usize) -> ExportBatch {
-        const MAX_BATCH: usize = 100;
-        let effective_size = batch_size.min(MAX_BATCH);
+        let effective_size = batch_size.min(Self::MAX_EXPORT_PAGE_SIZE);
 
         if start_cursor >= self.archive.len() {
             return ExportBatch {
@@ -373,7 +376,9 @@ impl RequestRecordStore {
             };
         }
 
-        let end = (start_cursor + effective_size).min(self.archive.len());
+        let end = start_cursor
+            .saturating_add(effective_size)
+            .min(self.archive.len());
         let records = self.archive[start_cursor..end].to_vec();
         let next_cursor = end;
         let has_more = next_cursor < self.archive.len();

--- a/src/streaming_monitor.rs
+++ b/src/streaming_monitor.rs
@@ -35,6 +35,8 @@ pub enum PollResult {
     Pending(TransactionState),
     /// Transaction completed; `stellar_tx_id` is the on-chain Stellar tx hash.
     Completed { stellar_tx_id: alloc::string::String },
+    /// The remote stream ended cleanly (EOF).
+    Eof,
     /// Transaction failed with a human-readable reason.
     Failed { reason: alloc::string::String },
 }
@@ -397,6 +399,21 @@ impl StreamingTransactionMonitor {
                         });
                     }
                     on_event(TransactionStatusUpdate::Failed { reason });
+                    return;
+                }
+                Ok(PollResult::Eof) => {
+                    if let Some(prev) = last_state {
+                        let ts = timestamp_fn();
+                        self.record_transition(prev, TransactionState::Completed, ts, &cycle_trace);
+                        on_event(TransactionStatusUpdate::StateChanged {
+                            from: prev,
+                            to: TransactionState::Completed,
+                            timestamp: ts,
+                        });
+                    }
+                    on_event(TransactionStatusUpdate::Completed {
+                        stellar_tx_id: alloc::string::String::new(),
+                    });
                     return;
                 }
                 Ok(PollResult::Completed { stellar_tx_id }) => {
@@ -1045,8 +1062,38 @@ mod tests {
         assert_eq!(parents, cycle_spans);
     }
 
-    /// Recorded transitions carry the trace, so the transition history can be
-    /// joined against the delivery and retry logs.
+    #[test]
+    fn eof_closes_monitor_once_and_notifies_consumer() {
+        let mut monitor = StreamingTransactionMonitor::new(7, 0);
+        let mut calls = 0;
+        let mut events = Vec::new();
+        monitor.run(
+            |_id| {
+                calls += 1;
+                if calls == 1 {
+                    Ok(PollResult::Pending(TransactionState::InProgress))
+                } else {
+                    Ok(PollResult::Eof)
+                }
+            },
+            |event| events.push(event),
+            |_| {},
+            || 1_000,
+        );
+        assert_eq!(calls, 2);
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], TransactionStatusUpdate::StateChanged { to: TransactionState::InProgress, .. }));
+        assert_eq!(
+            events[1],
+            TransactionStatusUpdate::Completed {
+                stellar_tx_id: alloc::string::String::new()
+            }
+        );
+        let transitions = monitor.get_transitions();
+        assert_eq!(transitions.len(), 2);
+        assert_eq!(transitions[1].to, TransactionState::Completed);
+    }
+
     #[test]
     fn test_recorded_transitions_carry_the_trace() {
         let request = TraceContext::root_from_seed("sep24:deposit-3");

--- a/src/structured_log.rs
+++ b/src/structured_log.rs
@@ -262,6 +262,13 @@ impl LogRecord {
 /// Default maximum number of buffered records before the oldest are dropped.
 pub const DEFAULT_LOG_CAPACITY: usize = 1024;
 
+/// Maximum number of attributes retained in one structured log record.
+///
+/// Attributes beyond this limit are ignored at append time so a caller cannot
+/// create an unbounded record. The first attributes retain their original order
+/// and value encoding.
+pub const MAX_LOG_ATTRIBUTES: usize = 16;
+
 /// In-memory structured logger with level filtering and a bounded buffer.
 ///
 /// Interior mutability (`RefCell`/`Cell`) allows logging through a shared
@@ -335,6 +342,7 @@ impl StructuredLogger {
             event: event.to_string(),
             fields: fields
                 .iter()
+                .take(MAX_LOG_ATTRIBUTES)
                 .map(|(k, v)| (k.to_string(), v.clone()))
                 .collect(),
         };
@@ -540,6 +548,19 @@ mod tests {
         assert_eq!(records[0].event, "second");
         assert_eq!(records[1].event, "third");
         assert_eq!(logger.dropped(), 1);
+    }
+
+    #[test]
+    fn attribute_count_is_capped_without_changing_order_or_values() {
+        let logger = StructuredLogger::new();
+        let fields: Vec<(&str, FieldValue)> = (0..MAX_LOG_ATTRIBUTES + 1)
+            .map(|i| (if i == MAX_LOG_ATTRIBUTES { "overflow" } else { "field" }, (i as u64).into()))
+            .collect();
+        assert!(logger.info("bounded", 0, &fields));
+        let record = &logger.records()[0];
+        assert_eq!(record.fields.len(), MAX_LOG_ATTRIBUTES);
+        assert_eq!(record.fields[0].1, FieldValue::U64(0));
+        assert!(record.field("overflow").is_none());
     }
 
     #[test]

--- a/src/transaction_archive.rs
+++ b/src/transaction_archive.rs
@@ -156,6 +156,11 @@ impl TransactionArchiveManager {
                 "transaction_ids must not be empty",
             ));
         }
+        if transaction_ids.iter().any(|id| id.trim().is_empty()) {
+            return Err(AnchorKitError::validation_error(
+                "transaction_ids must not contain blank IDs",
+            ));
+        }
 
         let commitment = compute_archive_commitment(transaction_ids);
         let archive = TransactionArchive {
@@ -252,6 +257,16 @@ mod tests {
         let mut mgr = TransactionArchiveManager::new();
         let err = mgr.archive(&[], 1000, "batch-1".into(), None).unwrap_err();
         assert_eq!(err.code, ErrorCode::ValidationError);
+    }
+
+    #[test]
+    fn archive_manager_blank_ids_rejected_before_storage() {
+        let mut mgr = TransactionArchiveManager::new();
+        let err = mgr
+            .archive(&ids(&["txn-001", "   "]), 1000, "batch-1".into(), None)
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValidationError);
+        assert_eq!(mgr.archive_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR consolidates four defensive fixes for logging, streaming, and archive operations.

## Changes

- Enforces a deterministic 16-attribute cap when appending structured log records while preserving the first attributes, their order, and value encoding.
- Adds an explicit clean EOF result for the streaming monitor and routes it through the terminal completion transition and consumer notification path without changing transport-error handling.
- Rejects blank transaction IDs before archive storage using the existing validation error.
- Centralizes the existing 100-record export page cap and uses overflow-safe cursor arithmetic for active and archived exports, preserving ordering and continuation semantics.
- Adds focused regression tests for over-limit attributes, EOF completion, and blank archive IDs.

## Validation

`git diff --check` passes. Fixture and source-level checks were completed. Rust formatting and tests could not be run in the sandbox because `cargo`, `rustfmt`, and `rustc` are unavailable.

Closes #860
Closes #861
Closes #864
Closes #865