### PR TITLE
Harden webhook verification and operational metrics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ pub use response_validator::{
     check_transaction_status_compatibility,
 };
 #[cfg(not(feature = "wasm"))]
-pub use webhook::{deliver_webhook, deliver_webhook_traced, dlq_entries_for_trace, get_dead_letter_webhooks, query_dlq, verify_webhook_signature, WebhookDeliveryConfig, DlqEntry};
+pub use webhook::{deliver_webhook, deliver_webhook_metered, deliver_webhook_traced, dlq_entries_for_trace, get_dead_letter_webhooks, query_dlq, verify_webhook_signature, WebhookDeliveryConfig, DlqEntry, MAX_WEBHOOK_BODY_BYTES};
 #[cfg(not(feature = "wasm"))]
 pub use stellar_toml::{ParsedCurrency, ParsedStellarToml, parse_stellar_toml, fetch_stellar_toml_url};
 #[cfg(not(feature = "wasm"))]

--- a/src/structured_log.rs
+++ b/src/structured_log.rs
@@ -323,7 +323,7 @@ impl StructuredLogger {
         timestamp: u64,
         fields: &[(&str, FieldValue)],
     ) -> bool {
-        if level < self.min_level {
+        if level < self.min_level || event.trim().is_empty() {
             return false;
         }
         let seq = self.seq.get();
@@ -517,6 +517,17 @@ mod tests {
         );
         let line = &logger.json_lines()[0];
         assert!(line.contains("quote \\\" backslash \\\\ newline \\n"));
+    }
+
+    #[test]
+    fn blank_event_names_are_rejected_without_output() {
+        let logger = StructuredLogger::new();
+        assert!(!logger.info("", 1, &[]));
+        assert!(!logger.info("   ", 2, &[]));
+        assert!(logger.is_empty());
+        assert!(logger.json_lines().is_empty());
+        assert!(logger.info("valid.event", 3, &[]));
+        assert_eq!(logger.records()[0].seq, 0);
     }
 
     #[test]

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -29,6 +29,9 @@ use crate::{
 // HMAC-SHA256 signing helpers
 // ---------------------------------------------------------------------------
 
+/// Maximum webhook body accepted by the signature verifier (1 MiB).
+pub const MAX_WEBHOOK_BODY_BYTES: usize = 1024 * 1024;
+
 /// Compute HMAC-SHA256(`key`, `payload`) and return a lowercase hex string.
 fn sign_payload(key: &[u8], payload: &str) -> String {
     use hmac::{Hmac, Mac};
@@ -50,6 +53,10 @@ fn sign_payload(key: &[u8], payload: &str) -> String {
 /// The comparison is done byte-by-byte in constant time to prevent timing
 /// attacks.
 pub fn verify_webhook_signature(payload: &str, signature_header: &str, key: &[u8]) -> bool {
+    // Reject oversized untrusted input before parsing or computing HMAC.
+    if payload.len() > MAX_WEBHOOK_BODY_BYTES {
+        return false;
+    }
     let hex_digest = match signature_header.strip_prefix("sha256=") {
         Some(h) => h,
         None => return false,
@@ -677,6 +684,54 @@ where
         sleep_fn,
         now_fn,
     )
+}
+
+/// Deliver a webhook with delivery, attempt, success, failure, and DLQ metrics.
+pub fn deliver_webhook_metered<H, S, T>(
+    config: &WebhookDeliveryConfig,
+    payload: &str,
+    dlq: &mut BTreeMap<String, Vec<DlqEntry>>,
+    http_post: H,
+    sleep_fn: S,
+    now_fn: T,
+    metrics: &crate::metrics::MetricsRegistry,
+) -> Result<(), AnchorKitError>
+where
+    H: Fn(&str, &str, Option<&str>) -> Result<u16, String>,
+    S: FnMut(u64),
+    T: Fn() -> u64,
+{
+    use crate::metrics::names;
+
+    metrics.incr(names::WEBHOOK_DELIVERIES);
+    let entries_before = dlq.values().map(Vec::len).sum::<usize>();
+    let result = deliver_webhook(
+        config,
+        payload,
+        dlq,
+        |url, body, signature| {
+            metrics.incr(names::WEBHOOK_ATTEMPTS);
+            http_post(url, body, signature)
+        },
+        sleep_fn,
+        now_fn,
+    );
+    match &result {
+        Ok(()) => metrics.incr(names::WEBHOOK_SUCCESSES),
+        Err(_) => {
+            metrics.incr(names::WEBHOOK_FAILURES);
+            let entries_after = dlq.values().map(Vec::len).sum::<usize>();
+            metrics.incr_by(
+                names::WEBHOOK_DLQ_ENTRIES,
+                entries_after.saturating_sub(entries_before) as u64,
+            );
+        }
+    }
+    metrics.set_gauge(
+        names::WEBHOOK_DLQ_DEPTH,
+        dlq.values().map(Vec::len).sum::<usize>() as u64,
+    );
+    result
 }
 
 /// Derive a deterministic delivery trace for callers that supplied none.

--- a/tests/metrics_tests.rs
+++ b/tests/metrics_tests.rs
@@ -55,6 +55,14 @@ mod metrics_tests {
     }
 
     #[test]
+    fn counter_increment_at_maximum_remains_saturated() {
+        let metrics = MetricsRegistry::new();
+        metrics.incr_by("max.counter", u64::MAX);
+        metrics.incr("max.counter");
+        assert_eq!(metrics.counter("max.counter"), u64::MAX);
+    }
+
+    #[test]
     fn gauge_set_and_overwrite() {
         let metrics = MetricsRegistry::new();
         assert_eq!(metrics.gauge("queue.depth"), None);
@@ -113,6 +121,15 @@ mod metrics_tests {
         assert_eq!(metrics.counter(&names::calls(names::CONTRACT_CALL)), 3);
         assert_eq!(metrics.counter(&names::successes(names::CONTRACT_CALL)), 2);
         assert_eq!(metrics.counter(&names::failures(names::CONTRACT_CALL)), 1);
+    }
+
+    #[test]
+    fn failed_call_increments_failure_once_without_success() {
+        let metrics = MetricsRegistry::new();
+        metrics.record_call("request", false);
+        assert_eq!(metrics.counter("request.calls"), 1);
+        assert_eq!(metrics.counter("request.failures"), 1);
+        assert_eq!(metrics.counter("request.successes"), 0);
     }
 
     #[test]

--- a/tests/webhook_middleware_tests.rs
+++ b/tests/webhook_middleware_tests.rs
@@ -7,7 +7,10 @@ mod webhook_middleware_tests {
     use anchorkit::{
         errors::ErrorCode,
         retry::RetryConfig,
-        webhook::{deliver_webhook, get_dead_letter_webhooks, verify_webhook_signature, DlqEntry, WebhookDeliveryConfig},
+        webhook::{
+            deliver_webhook, get_dead_letter_webhooks, verify_webhook_signature, DlqEntry,
+            WebhookDeliveryConfig, MAX_WEBHOOK_BODY_BYTES,
+        },
     };
 
     fn config(max_retries: u32) -> WebhookDeliveryConfig {
@@ -246,7 +249,37 @@ mod webhook_middleware_tests {
     }
 
     // -----------------------------------------------------------------------
-    // 9. verify_webhook_signature — wrong key returns false
+    // 9. verify_webhook_signature — body limit is checked before HMAC
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_verify_rejects_oversized_body_but_accepts_limit() {
+        let key = b"secret";
+        let at_limit = "a".repeat(MAX_WEBHOOK_BODY_BYTES);
+        let oversized = "a".repeat(MAX_WEBHOOK_BODY_BYTES + 1);
+        let signature = Arc::new(Mutex::new(String::new()));
+        let captured = signature.clone();
+        let mut dlq: BTreeMap<String, Vec<DlqEntry>> = BTreeMap::new();
+        let result = deliver_webhook(
+            &signed_config(1, key.to_vec()),
+            &at_limit,
+            &mut dlq,
+            move |_url, _body, sig| {
+                if let Some(sig) = sig {
+                    *captured.lock().unwrap() = sig.to_string();
+                }
+                Ok(200)
+            },
+            |_| {},
+            || 0,
+        );
+        assert!(result.is_ok());
+        let signature = signature.lock().unwrap().clone();
+        assert!(verify_webhook_signature(&at_limit, &signature, key));
+        assert!(!verify_webhook_signature(&oversized, &signature, key));
+    }
+
+    // -----------------------------------------------------------------------
+    // 10. verify_webhook_signature — wrong key returns false
     // -----------------------------------------------------------------------
     #[test]
     fn test_verify_wrong_key_fails() {


### PR DESCRIPTION
## Summary

This PR bundles four focused hardening fixes:

- Bound webhook bodies before parsing or computing HMAC, while preserving exact valid body bytes and accepting payloads at the limit.
- Keep metrics counters monotonic with saturating arithmetic at `u64::MAX`.
- Instrument metered webhook delivery attempts and classify the final failure exactly once, including DLQ growth and depth.
- Reject empty and whitespace-only structured-log event names before serialization or sequence advancement.

## Validation

- `git diff --check` passes.
- Added regression coverage for the body limit, counter saturation, failed classification, and blank structured events.
- Focused Cargo tests were attempted with Rust 1.88.0; the repository currently fails earlier on pre-existing duplicate `ErrorCode` variants and Soroban dependency/test utility incompatibilities.

Closes #855
Closes #856
Closes #857
Closes #858
