### PR TITLE
fix: self-route filter, empty route rejection, drift event emission, address normalization

### DIFF
--- a/src/deployment_drift.rs
+++ b/src/deployment_drift.rs
@@ -12,12 +12,17 @@
 //! - [`DeploymentSnapshot`] captures the observed state at a point in time.
 //! - [`detect_drift`] compares the two and returns a [`DriftReport`] listing
 //!   every [`DriftItem`] — fields that are missing, changed, or unexpected.
+//! - [`detect_drift_logged`] is a thin wrapper that additionally emits a
+//!   structured `deployment.drift_detected` warning through a
+//!   [`StructuredLogger`] whenever drift is found.
 //! - [`DriftSeverity`] classifies each drift item so operators can triage
 //!   critical divergences from cosmetic ones.
 
 extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
+
+use crate::structured_log::{StructuredLogger, LogLevel, events};
 
 // ---------------------------------------------------------------------------
 // Spec and snapshot types
@@ -217,8 +222,16 @@ pub fn detect_drift(spec: &DeploymentSpec, snapshot: &DeploymentSnapshot) -> Dri
     }
 
     // ── Admin address ────────────────────────────────────────────────────────
+    //
+    // Addresses are compared in normalized form (trimmed + uppercased) so that
+    // equivalent representations — e.g. a lowercase copy of a G-address or one
+    // with stray whitespace — do not produce a false-positive drift item.
+    // Original (un-modified) strings are preserved in the DriftItem output so
+    // that report formatting is unchanged.
     match (&spec.expected_admin, &snapshot.observed_admin) {
-        (Some(exp), Some(obs)) if exp != obs => {
+        (Some(exp), Some(obs))
+            if exp.trim().to_ascii_uppercase() != obs.trim().to_ascii_uppercase() =>
+        {
             items.push(DriftItem {
                 field: "admin".into(),
                 severity: DriftSeverity::Critical,
@@ -328,6 +341,78 @@ pub fn detect_drift(spec: &DeploymentSpec, snapshot: &DeploymentSnapshot) -> Dri
         medium_count,
         low_count,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Logged variant
+// ---------------------------------------------------------------------------
+
+/// Like [`detect_drift`], but emits a structured log entry through `logger`
+/// when drift is detected.
+///
+/// Positive drift (any item found) produces exactly one
+/// `deployment.drift_detected` warning carrying the environment name, total
+/// item count, and critical item count as fields.  A clean result emits
+/// nothing.  Result values are identical to [`detect_drift`]: calling code
+/// that already inspects the returned [`DriftReport`] requires no changes.
+///
+/// # Arguments
+///
+/// * `spec` — The intended deployment state.
+/// * `snapshot` — The observed deployment state.
+/// * `logger` — A [`StructuredLogger`] for the current workflow.
+/// * `timestamp` — Unix timestamp (seconds) to attach to the log entry.
+///
+/// # Examples
+///
+/// ```rust
+/// use anchorkit::deployment_drift::{
+///     ConfigEntry, DeploymentSpec, DeploymentSnapshot, detect_drift_logged,
+/// };
+/// use anchorkit::structured_log::StructuredLogger;
+///
+/// let spec = DeploymentSpec {
+///     environment: "testnet".into(),
+///     expected_version: "0.1.0".into(),
+///     expected_network: "Test SDF Network ; September 2015".into(),
+///     expected_admin: Some("GABC123".into()),
+///     expected_config: vec![],
+/// };
+///
+/// let mut snapshot_drifted = DeploymentSnapshot {
+///     environment: "testnet".into(),
+///     captured_at: 9999,
+///     observed_version: "0.2.0".into(), // drifted
+///     observed_network: "Test SDF Network ; September 2015".into(),
+///     observed_admin: Some("GABC123".into()),
+///     observed_config: vec![],
+/// };
+///
+/// let logger = StructuredLogger::new();
+/// let report = detect_drift_logged(&spec, &snapshot_drifted, &logger, 9999);
+/// assert!(!report.is_clean);
+/// assert_eq!(logger.len(), 1); // one warning emitted
+/// ```
+pub fn detect_drift_logged(
+    spec: &DeploymentSpec,
+    snapshot: &DeploymentSnapshot,
+    logger: &StructuredLogger,
+    timestamp: u64,
+) -> DriftReport {
+    let report = detect_drift(spec, snapshot);
+    if !report.is_clean {
+        logger.log(
+            LogLevel::Warn,
+            events::DEPLOYMENT_DRIFT_DETECTED,
+            timestamp,
+            &[
+                ("environment", spec.environment.as_str().into()),
+                ("item_count", (report.items.len() as u64).into()),
+                ("critical_count", (report.critical_count as u64).into()),
+            ],
+        );
+    }
+    report
 }
 
 // ---------------------------------------------------------------------------
@@ -486,5 +571,82 @@ mod tests {
         let report = detect_drift(&base_spec(), &base_snapshot());
         assert_eq!(report.environment, "testnet");
         assert_eq!(report.snapshot_captured_at, 9999);
+    }
+
+    // ── Fix 3: detect_drift_logged emits one event on positive drift ─────────
+
+    #[test]
+    fn drift_detected_event_emitted_when_drift_found() {
+        use crate::structured_log::{StructuredLogger, FieldValue, events};
+
+        let mut snap = base_snapshot();
+        snap.observed_version = "0.2.0".into(); // introduce drift
+
+        let logger = StructuredLogger::new();
+        let report = super::detect_drift_logged(&base_spec(), &snap, &logger, 1234);
+
+        assert!(!report.is_clean, "report must show drift");
+        assert_eq!(logger.len(), 1, "exactly one event must be emitted");
+
+        let record = &logger.records()[0];
+        assert_eq!(record.event, events::DEPLOYMENT_DRIFT_DETECTED);
+        assert_eq!(
+            record.field("environment"),
+            Some(&FieldValue::Str("testnet".into()))
+        );
+        assert_eq!(record.timestamp, 1234);
+    }
+
+    #[test]
+    fn no_event_emitted_when_no_drift() {
+        use crate::structured_log::StructuredLogger;
+
+        let logger = StructuredLogger::new();
+        let report = super::detect_drift_logged(&base_spec(), &base_snapshot(), &logger, 1234);
+
+        assert!(report.is_clean, "clean deployment must produce no drift");
+        assert_eq!(logger.len(), 0, "no event must be emitted for a clean result");
+    }
+
+    // ── Fix 4: equivalent addresses must not produce false drift ─────────────
+
+    #[test]
+    fn equivalent_address_different_case_does_not_drift() {
+        let mut snap = base_snapshot();
+        // Same address as spec's "GABC123" but in lowercase — must not drift.
+        snap.observed_admin = Some("gabc123".into());
+
+        let report = detect_drift(&base_spec(), &snap);
+        assert!(
+            report.is_clean,
+            "addresses equal after normalization must not produce a drift item"
+        );
+    }
+
+    #[test]
+    fn equivalent_address_with_whitespace_does_not_drift() {
+        let mut snap = base_snapshot();
+        snap.observed_admin = Some("  GABC123  ".into());
+
+        let report = detect_drift(&base_spec(), &snap);
+        assert!(
+            report.is_clean,
+            "addresses equal after trimming must not produce a drift item"
+        );
+    }
+
+    #[test]
+    fn genuinely_different_address_still_drifts() {
+        let mut snap = base_snapshot();
+        snap.observed_admin = Some("GDIFFERENTADDRESS".into());
+
+        let report = detect_drift(&base_spec(), &snap);
+        assert!(!report.is_clean);
+        assert!(report.has_critical());
+        let item = report.items.iter().find(|i| i.field == "admin").unwrap();
+        assert_eq!(item.severity, DriftSeverity::Critical);
+        // Original (un-normalized) strings preserved in output.
+        assert_eq!(item.expected.as_deref(), Some("GABC123"));
+        assert_eq!(item.observed.as_deref(), Some("GDIFFERENTADDRESS"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,7 @@ pub use artifact_provenance::{
 // ── Issue #673: deployment drift detection ────────────────────────────────────
 #[cfg(not(feature = "wasm"))]
 pub use deployment_drift::{
-    detect_drift, ConfigEntry, DeploymentSpec, DeploymentSnapshot,
+    detect_drift, detect_drift_logged, ConfigEntry, DeploymentSpec, DeploymentSnapshot,
     DriftReport, DriftItem, DriftSeverity,
 };
 

--- a/src/multi_asset_routing.rs
+++ b/src/multi_asset_routing.rs
@@ -239,6 +239,18 @@ pub fn route_multi_asset(
     all_quotes: &[CandidateQuote],
     now_timestamp: u64,
 ) -> Result<MultiAssetRoutingResult, Error> {
+    // Reject any candidate whose asset pair is empty.  An anchor that submitted
+    // a quote with blank asset codes cannot represent a real corridor and must
+    // not enter the scoring pool; doing so could produce a misleading
+    // successful selection against an empty-pair request.
+    for q in all_quotes {
+        if normalize_asset_code(&q.base_asset).is_empty()
+            || normalize_asset_code(&q.quote_asset).is_empty()
+        {
+            return Err(Error::InvalidAssetCode);
+        }
+    }
+
     let mut result = MultiAssetRoutingResult::default();
 
     for req in requests {
@@ -248,12 +260,18 @@ pub fn route_multi_asset(
         let quote = normalize_asset_code(&req.quote_asset);
         let key = pair_key(&base, &quote);
 
-        // Filter candidates for this pair
+        // Filter candidates for this pair.
+        // Self-routes (base_asset == quote_asset) are excluded: a candidate
+        // that quotes an asset against itself has no conversion value and must
+        // not win selection regardless of how its other fields score.
         let candidates: Vec<&CandidateQuote> = all_quotes
             .iter()
             .filter(|q| {
-                normalize_asset_code(&q.base_asset) == base
-                    && normalize_asset_code(&q.quote_asset) == quote
+                let q_base = normalize_asset_code(&q.base_asset);
+                let q_quote = normalize_asset_code(&q.quote_asset);
+                q_base != q_quote                              // exclude self-routes
+                    && q_base == base
+                    && q_quote == quote
                     && q.valid_until > now_timestamp
                     && req.amount >= q.minimum_amount
                     && (q.maximum_amount == 0 || req.amount <= q.maximum_amount)

--- a/src/structured_log.rs
+++ b/src/structured_log.rs
@@ -70,6 +70,9 @@ pub mod events {
     pub const WEBHOOK_DELIVERY_FAILED: &str = "webhook.delivery_failed";
     pub const WEBHOOK_DLQ_ENTRY_ADDED: &str = "webhook.dlq_entry_added";
 
+    // Deployment drift detection.
+    pub const DEPLOYMENT_DRIFT_DETECTED: &str = "deployment.drift_detected";
+
     // Cache governance.
     pub const CACHE_POLICY_UPDATED: &str = "cache.policy_updated";
     pub const CACHE_POLICY_REJECTED: &str = "cache.policy_rejected";

--- a/tests/multi_asset_routing_tests.rs
+++ b/tests/multi_asset_routing_tests.rs
@@ -508,6 +508,69 @@ fn test_route_mixed_strategies_in_single_call() {
     assert_eq!(btc.anchor, "anchor-c");
 }
 
+// ── Self-route exclusion ──────────────────────────────────────────────────────
+
+/// A CandidateQuote where base_asset == quote_asset is a self-route and must
+/// never be selected, even when it would otherwise score best.
+#[test]
+fn test_route_self_route_candidate_is_excluded() {
+    let quotes = vec![
+        // Self-route: XLM → XLM.  Has perfect fee and reputation scores; must
+        // be filtered out before selection despite this favourable profile.
+        make_quote(1, "anchor-self", "XLM", "XLM", 0, 1_000_000, 100, 1, 1, 0, NOW + 3600),
+        // Valid distinct-pair quote that should win.
+        make_quote(2, "anchor-valid", "XLM", "USDC", 20, 1_000_000, 80, 60, 1, 0, NOW + 3600),
+    ];
+    let requests = vec![req("XLM", "USDC", 100, "LowestFee")];
+    let result = route_multi_asset(&requests, &quotes, NOW).unwrap();
+
+    assert_eq!(result.filled.len(), 1, "self-route must not fill the corridor");
+    assert_eq!(result.filled[0].anchor, "anchor-valid");
+}
+
+/// When the only available candidate is a self-route the corridor is unfilled,
+/// not erroneously filled with the self-routing anchor.
+#[test]
+fn test_route_only_self_route_produces_unfilled() {
+    let quotes = vec![
+        make_quote(1, "anchor-self", "USDC", "USDC", 0, 1_000_000, 100, 1, 1, 0, NOW + 3600),
+    ];
+    let requests = vec![req("USDC", "USDC_COPY", 100, "LowestFee")];
+    let result = route_multi_asset(&requests, &quotes, NOW).unwrap();
+
+    assert_eq!(result.filled.len(), 0);
+    assert_eq!(result.unfilled.len(), 1);
+}
+
+// ── Empty-route input rejection ───────────────────────────────────────────────
+
+/// A CandidateQuote with an empty base_asset is an invalid empty-route input
+/// and must be rejected before scoring, regardless of the request.
+#[test]
+fn test_route_empty_base_asset_in_candidate_returns_error() {
+    let quotes = vec![
+        // Candidate with blank base_asset — this is the malformed input.
+        make_quote(1, "anchor-bad", "", "USDC", 10, 1_000_000, 80, 60, 1, 0, NOW + 3600),
+        // A perfectly valid quote in the same pool.
+        make_quote(2, "anchor-ok", "XLM", "USDC", 20, 1_000_000, 80, 60, 1, 0, NOW + 3600),
+    ];
+    let requests = vec![req("XLM", "USDC", 100, "LowestFee")];
+    let err = route_multi_asset(&requests, &quotes, NOW).unwrap_err();
+    assert_eq!(err, Error::InvalidAssetCode);
+}
+
+/// A CandidateQuote with an empty quote_asset must likewise be rejected before
+/// any scoring occurs.
+#[test]
+fn test_route_empty_quote_asset_in_candidate_returns_error() {
+    let quotes = vec![
+        make_quote(1, "anchor-bad", "XLM", "", 10, 1_000_000, 80, 60, 1, 0, NOW + 3600),
+    ];
+    let requests = vec![req("XLM", "USDC", 100, "LowestFee")];
+    let err = route_multi_asset(&requests, &quotes, NOW).unwrap_err();
+    assert_eq!(err, Error::InvalidAssetCode);
+}
+
 // ── Quote fields are propagated correctly ─────────────────────────────────────
 
 #[test]


### PR DESCRIPTION

Closes #870
Closes #871
Closes #872
Closes #873

- multi_asset_routing: exclude CandidateQuote entries where base_asset == quote_asset from the candidate filter; a self-route has no conversion value and must not win selection regardless of score (#870)
- multi_asset_routing: reject CandidateQuote entries with empty base_asset or quote_asset before scoring begins; blank asset codes cannot represent a real corridor and would produce a misleading successful selection (#871)
- deployment_drift: add detect_drift_logged() wrapper that emits one structured deployment.drift_detected warning via StructuredLogger when drift is detected; clean results emit nothing; detect_drift() itself is unchanged (#872)
- deployment_drift: normalize admin addresses with trim()+to_ascii_uppercase() before equality comparison so equivalent representations do not produce false-positive drift items; original strings preserved in DriftItem output (#873)

