### PR TITLE
Harden SEP-6 amount/status normalization and response-body diagnostics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,8 @@ pub use response_validator::{
     SchemaVersion, VALIDATOR_SCHEMA_V1,
     // Issue #831: unknown SEP-6 status strings classify as Unknown, never success
     Sep6StatusClass, sep6_status_class,
+    // Issues #829 / #830: bounded, stable diagnostics for raw response bodies
+    validate_response_body, BodyRequirement, MAX_ERROR_BODY_LEN,
     // Issue #661: response shape compatibility checks for older anchors
     CompatibilityLevel, CompatibilityReport,
     check_deposit_compatibility, check_withdraw_compatibility,
@@ -299,6 +301,8 @@ pub use sep6::{
     poll_transaction_status, PollConfig, PollResult,
     StatusCategory, classify_status_str,
     VendorStatusMap, VendorStatusEntry,
+    // Issue #834: negative amount strings are rejected before typed conversion
+    parse_sep6_amount,
 };
 #[cfg(not(feature = "wasm"))]
 pub use sep31::{

--- a/src/response_validator.rs
+++ b/src/response_validator.rs
@@ -188,6 +188,80 @@ fn is_valid_positive_decimal(s: &str) -> bool {
     s.parse::<f64>().map(|v| v > 0.0).unwrap_or(false)
 }
 
+// ── Raw response body guards (#829, #830) ─────────────────────────────────────
+
+/// Maximum number of bytes of an untrusted response body echoed back inside an
+/// error message.
+///
+/// Diagnostic context is capped at this small limit so a pathological multi-
+/// megabyte body from an anchor cannot inflate log volume or error-string
+/// allocations. Bodies at or below this length are included verbatim.
+pub const MAX_ERROR_BODY_LEN: usize = 256;
+
+/// Whether an endpoint's response body is required to contain JSON.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BodyRequirement {
+    /// The endpoint must return a JSON body (e.g. `/deposit`, `/info`).
+    Required,
+    /// The endpoint may legitimately return an empty body (e.g. a `204`).
+    Optional,
+}
+
+/// Truncate an untrusted body to [`MAX_ERROR_BODY_LEN`] bytes for safe
+/// inclusion in an error message, appending an elision marker when bytes were
+/// dropped. The cut is made on a UTF-8 character boundary so the result is
+/// always valid text.
+fn body_for_error(body: &str) -> alloc::string::String {
+    if body.len() <= MAX_ERROR_BODY_LEN {
+        return alloc::string::String::from(body);
+    }
+    let mut end = MAX_ERROR_BODY_LEN;
+    while end > 0 && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = alloc::string::String::from(&body[..end]);
+    out.push_str("… (truncated)");
+    out
+}
+
+/// Validate a raw anchor response body before any field-level parsing.
+///
+/// This is the JSON validation entry point: callers pass the untrusted body
+/// string exactly as received from the anchor's HTTP response.
+///
+/// # Rules
+///
+/// - When `requirement` is [`BodyRequirement::Required`] an empty or
+///   whitespace-only body fails immediately with a stable reason, so callers
+///   get "response body is empty" instead of a generic parse failure and no
+///   parsing work is attempted (#829).
+/// - When `requirement` is [`BodyRequirement::Optional`] an empty body is
+///   accepted unchanged, preserving optional-empty response behavior (#829).
+/// - A non-empty body must look like a JSON object or array (its first
+///   non-whitespace byte is `{` or `[`); otherwise only the first
+///   [`MAX_ERROR_BODY_LEN`] bytes of the body appear in the error context
+///   (#830).
+/// - JSON-shaped bodies pass through untouched; full structural validation
+///   remains the responsibility of the field-level validators.
+pub fn validate_response_body(body: &str, requirement: BodyRequirement) -> Result<(), Error> {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return match requirement {
+            BodyRequirement::Required => Err(Error::validation_error(
+                "response body is empty but a JSON body is required",
+            )),
+            BodyRequirement::Optional => Ok(()),
+        };
+    }
+    match trimmed.as_bytes()[0] {
+        b'{' | b'[' => Ok(()),
+        _ => Err(Error::validation_error(&alloc::format!(
+            "response body is not JSON: {}",
+            body_for_error(body),
+        ))),
+    }
+}
+
 // ── Validation functions (backward-compatible originals) ───────────────────────
 // Each existing function delegates to its versioned counterpart with
 // `SchemaVersion::LATEST`.
@@ -1747,5 +1821,67 @@ mod tests {
         assert!(validate_deposit_response("d1", unknown, "GADDR...", 0, 0).is_err());
         assert!(validate_withdraw_response("w1", unknown, 0).is_err());
         assert!(validate_transaction_status_response("t1", unknown, "deposit").is_err());
+    }
+
+    // ── Issue #829: reject empty response body where required ─────────────────
+
+    #[test]
+    fn test_required_body_rejects_empty_with_stable_reason() {
+        let e = validate_response_body("", BodyRequirement::Required).unwrap_err();
+        assert_eq!(e.code, crate::errors::ErrorCode::ValidationError);
+        assert!(e.context.as_deref().unwrap_or("").contains("empty"));
+    }
+
+    #[test]
+    fn test_required_body_rejects_whitespace_only() {
+        assert!(validate_response_body("   \n\t ", BodyRequirement::Required).is_err());
+    }
+
+    #[test]
+    fn test_optional_body_allows_empty() {
+        assert!(validate_response_body("", BodyRequirement::Optional).is_ok());
+        assert!(validate_response_body("   ", BodyRequirement::Optional).is_ok());
+    }
+
+    #[test]
+    fn test_valid_json_body_passes_unchanged() {
+        assert!(validate_response_body(r#"{"transaction_id":"x"}"#, BodyRequirement::Required).is_ok());
+        assert!(validate_response_body("  [1,2,3]  ", BodyRequirement::Required).is_ok());
+        assert!(validate_response_body(r#"{"a":1}"#, BodyRequirement::Optional).is_ok());
+    }
+
+    // ── Issue #830: error context from an untrusted body is bounded ──────────
+
+    #[test]
+    fn test_error_body_is_truncated_to_limit() {
+        let huge = "x".repeat(50_000); // not JSON-shaped
+        let e = validate_response_body(&huge, BodyRequirement::Required).unwrap_err();
+        let ctx = e.context.as_deref().unwrap_or("");
+        assert!(ctx.len() < huge.len(), "error context must not grow with the body");
+        // Fixed prefix + at most MAX_ERROR_BODY_LEN body bytes + elision marker.
+        assert!(ctx.len() <= MAX_ERROR_BODY_LEN + 64);
+        assert!(ctx.contains("truncated"));
+    }
+
+    #[test]
+    fn test_error_body_short_diagnostic_unchanged() {
+        let e = validate_response_body("nope", BodyRequirement::Required).unwrap_err();
+        let ctx = e.context.as_deref().unwrap_or("");
+        assert!(ctx.contains("nope"));
+        assert!(!ctx.contains("truncated"));
+    }
+
+    #[test]
+    fn test_body_for_error_respects_char_boundary() {
+        let s = "é".repeat(400); // 2 bytes each
+        let out = body_for_error(&s);
+        assert!(out.starts_with('é'));
+        assert!(out.len() <= MAX_ERROR_BODY_LEN + "… (truncated)".len());
+        assert!(out.ends_with("… (truncated)"));
+    }
+
+    #[test]
+    fn test_body_for_error_leaves_short_body_intact() {
+        assert_eq!(body_for_error("{\"ok\":true}"), "{\"ok\":true}");
     }
 }

--- a/src/sep6.rs
+++ b/src/sep6.rs
@@ -9,6 +9,20 @@ use alloc::string::String;
 use crate::errors::Error;
 use crate::errors::normalize_asset_code;
 
+// ── Status normalization ──────────────────────────────────────────────────────
+
+/// Normalize a raw anchor status token before it is matched.
+///
+/// Anchors are inconsistent about the capitalization and surrounding
+/// whitespace of status strings (`"PENDING_USER"`, `" pending_user "`), so the
+/// token is trimmed and ASCII-lowercased at the single point where SEP-6
+/// status parsing and classification happen. Only the status token passes
+/// through here — free-form fields such as a transaction `message` are never
+/// normalized.
+fn normalize_status_token(s: &str) -> String {
+    s.trim().to_ascii_lowercase()
+}
+
 // ── Status classification ─────────────────────────────────────────────────────
 
 /// High-level category that a [`TransactionStatus`] belongs to.
@@ -41,7 +55,7 @@ pub enum StatusCategory {
 /// [`StatusCategory::Unknown`] rather than being silently treated as
 /// successful.
 pub fn classify_status_str(s: &str) -> StatusCategory {
-    let normalized = s.trim().to_ascii_lowercase();
+    let normalized = normalize_status_token(s);
     match normalized.as_str() {
         "pending_external"
         | "pending_anchor"
@@ -126,7 +140,7 @@ impl VendorStatusMap {
     /// If `vendor_status` is already registered the existing mapping is
     /// replaced.
     pub fn register(&mut self, vendor_status: &str, canonical: TransactionStatus) {
-        let key = vendor_status.trim().to_ascii_lowercase();
+        let key = normalize_status_token(vendor_status);
         if let Some(pos) = self.entries.iter().position(|e| e.vendor_status == key) {
             self.entries[pos].canonical = canonical;
         } else {
@@ -146,7 +160,7 @@ impl VendorStatusMap {
     /// The returned [`VendorStatusEntry`] always carries the original
     /// (trimmed) raw string so callers can log or forward vendor detail.
     pub fn resolve(&self, raw: &str) -> VendorStatusEntry {
-        let key = raw.trim().to_ascii_lowercase();
+        let key = normalize_status_token(raw);
         if let Some(entry) = self.entries.iter().find(|e| e.vendor_status == key) {
             return VendorStatusEntry {
                 vendor_status: raw.trim().into(),
@@ -161,13 +175,13 @@ impl VendorStatusMap {
 
     /// Returns `true` if the map contains a custom mapping for `vendor_status`.
     pub fn contains(&self, vendor_status: &str) -> bool {
-        let key = vendor_status.trim().to_ascii_lowercase();
+        let key = normalize_status_token(vendor_status);
         self.entries.iter().any(|e| e.vendor_status == key)
     }
 
     /// Remove the mapping for `vendor_status`. Returns `true` if it existed.
     pub fn remove(&mut self, vendor_status: &str) -> bool {
-        let key = vendor_status.trim().to_ascii_lowercase();
+        let key = normalize_status_token(vendor_status);
         if let Some(pos) = self.entries.iter().position(|e| e.vendor_status == key) {
             self.entries.remove(pos);
             true
@@ -253,7 +267,7 @@ impl TransactionStatus {
     /// assert_eq!(TransactionStatus::from_str("garbage"), TransactionStatus::Error);
     /// ```
     pub fn from_str(s: &str) -> Self {
-        let s = s.trim().to_ascii_lowercase();
+        let s = normalize_status_token(s);
         match s.as_str() {
             "pending_external" => Self::PendingExternal,
             "pending_anchor" => Self::PendingAnchor,
@@ -534,6 +548,60 @@ fn validate_amount_ordering(min_amount: Option<u64>, max_amount: Option<u64>) ->
         }
     }
     Ok(())
+}
+
+/// Parse a raw SEP-6 amount string into the canonical integer unit
+/// representation used by the `*_amount` fields of [`RawDepositResponse`],
+/// [`RawWithdrawalResponse`] and [`RawTransactionResponse`].
+///
+/// Anchors return amounts as JSON strings. This is the normalization boundary
+/// callers use to convert them before typed conversion, so an invalid sign
+/// never reaches a `u64` field.
+///
+/// # Policy
+///
+/// - A leading sign is rejected: the first character must be an ASCII digit.
+///   In particular a leading `-` (a negative deposit or withdrawal amount) is
+///   never a valid SEP-6 value even when it would parse numerically.
+/// - `"0"` is accepted and maps to `0`, matching the existing treatment of
+///   zero-valued amount bounds.
+/// - A fractional part is accepted only when every fractional digit is `0`
+///   (e.g. `"10.0"` → `10`); a non-zero fraction is rejected rather than
+///   silently truncated, so decimal precision is never dropped.
+/// - Surrounding whitespace is trimmed; an empty string is rejected.
+///
+/// # Errors
+///
+/// Returns [`Error::invalid_transaction_intent`] — the classification the rest
+/// of this module uses for malformed amount data — for any input that is
+/// empty, negative, non-numeric, overflows `u64`, or carries a non-zero
+/// fractional part.
+pub fn parse_sep6_amount(raw: &str) -> Result<u64, Error> {
+    let s = raw.trim();
+    // Reject empty input and any leading sign (notably `-`).
+    if !matches!(s.as_bytes().first(), Some(b) if b.is_ascii_digit()) {
+        return Err(Error::invalid_transaction_intent());
+    }
+    let (int_part, frac_part) = match s.split_once('.') {
+        Some((i, f)) => (i, Some(f)),
+        None => (s, None),
+    };
+    if !int_part.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(Error::invalid_transaction_intent());
+    }
+    if let Some(frac) = frac_part {
+        // A fractional part must be all digits and carry no precision we would
+        // otherwise have to drop.
+        if frac.is_empty()
+            || !frac.bytes().all(|b| b.is_ascii_digit())
+            || frac.bytes().any(|b| b != b'0')
+        {
+            return Err(Error::invalid_transaction_intent());
+        }
+    }
+    int_part
+        .parse::<u64>()
+        .map_err(|_| Error::invalid_transaction_intent())
 }
 
 // ── Service functions ─────────────────────────────────────────────────────────
@@ -1577,5 +1645,89 @@ mod tests {
         raw2.min_amount = Some(1_000_000);
         raw2.max_amount = None;
         assert!(initiate_withdrawal(raw2).is_ok());
+    }
+
+    // ── #832 SEP-6 status case normalization ────────────────────────────────
+
+    #[test]
+    fn test_normalize_status_token_trims_and_lowercases() {
+        assert_eq!(normalize_status_token("  PENDING_USER  "), "pending_user");
+        assert_eq!(normalize_status_token("Completed"), "completed");
+    }
+
+    #[test]
+    fn test_status_case_variants_map_identically() {
+        // Equivalent status casing must produce the same typed status.
+        for variant in ["completed", "COMPLETED", "Completed", "  cOmPlEtEd  "] {
+            let mut raw = raw_tx_status();
+            raw.status = variant.to_string();
+            assert_eq!(
+                fetch_transaction_status(raw).unwrap().status,
+                TransactionStatus::Completed,
+                "casing variant '{}' must map identically",
+                variant,
+            );
+        }
+    }
+
+    #[test]
+    fn test_status_case_normalization_preserves_message_byte_for_byte() {
+        let mut raw = raw_tx_status();
+        raw.status = "PENDING_EXTERNAL".to_string();
+        raw.message = Some("Awaiting BANK Transfer #42  ".to_string());
+        let resp = fetch_transaction_status(raw).unwrap();
+        assert_eq!(resp.status, TransactionStatus::PendingExternal);
+        // The free-form description must not be lowercased or trimmed.
+        assert_eq!(resp.message.as_deref(), Some("Awaiting BANK Transfer #42  "));
+    }
+
+    #[test]
+    fn test_status_case_unknown_stays_unknown_regardless_of_casing() {
+        for variant in ["Totally_Unknown", "TOTALLY_UNKNOWN", "  totally_unknown  "] {
+            assert_eq!(TransactionStatus::from_str(variant), TransactionStatus::Error);
+            assert_eq!(classify_status_str(variant), StatusCategory::Unknown);
+        }
+    }
+
+    #[test]
+    fn test_vendor_status_map_lookup_is_case_insensitive() {
+        let mut map = VendorStatusMap::new();
+        map.register("ACH_Processing", TransactionStatus::PendingExternal);
+        assert_eq!(map.resolve("ach_processing").canonical, TransactionStatus::PendingExternal);
+        assert_eq!(map.resolve("ACH_PROCESSING").canonical, TransactionStatus::PendingExternal);
+        assert!(map.contains("Ach_Processing"));
+    }
+
+    // ── #834 Reject negative SEP-6 amount text ──────────────────────────────
+
+    #[test]
+    fn test_parse_sep6_amount_rejects_negative() {
+        for neg in ["-1", "-0", "-0.0", "  -100  ", "-999999999"] {
+            assert!(parse_sep6_amount(neg).is_err(), "'{}' must be rejected", neg);
+        }
+        assert_eq!(
+            parse_sep6_amount("-5").unwrap_err(),
+            Error::invalid_transaction_intent(),
+        );
+    }
+
+    #[test]
+    fn test_parse_sep6_amount_accepts_positive_and_zero() {
+        assert_eq!(parse_sep6_amount("0").unwrap(), 0);
+        assert_eq!(parse_sep6_amount("1").unwrap(), 1);
+        assert_eq!(parse_sep6_amount("  10000  ").unwrap(), 10_000);
+        // A zero fractional part carries no precision and is accepted.
+        assert_eq!(parse_sep6_amount("10.0").unwrap(), 10);
+        assert_eq!(parse_sep6_amount("0.000").unwrap(), 0);
+    }
+
+    #[test]
+    fn test_parse_sep6_amount_rejects_malformed_and_lossy() {
+        for bad in [
+            "", "   ", "+1", "abc", "1.5", "1.", ".5", "1_000", "1e3", "1 000",
+            "99999999999999999999999999",
+        ] {
+            assert!(parse_sep6_amount(bad).is_err(), "'{}' must be rejected", bad);
+        }
     }
 }


### PR DESCRIPTION
Harden SEP-6 amount/status normalization and response-body diagnostics

Addresses four SEP normalization gaps (#834, #832, #830, #829). All four
land on one branch and only touch src/sep6.rs, src/response_validator.rs
and the matching pub-use lists in src/lib.rs.

#834 Reject negative SEP-6 amount text
  - Add `sep6::parse_sep6_amount`, the normalization boundary callers use to
    turn an anchor's raw amount string into the `u64` unit representation of
    the `*_amount` fields before typed conversion.
  - A leading sign is rejected: the first character must be an ASCII digit,
    so `-1`, `-0`, `-0.0` and ` -100 ` all fail even though they parse
    numerically. `"0"` still maps to `0`, matching the existing treatment of
    zero-valued amount bounds. A fractional part is accepted only when every
    fractional digit is `0` (`"10.0"` -> `10`); a non-zero fraction is
    rejected rather than silently truncated, so decimal precision is never
    dropped. Empty, non-numeric and `u64`-overflowing inputs are rejected.
  - Failures use `Error::invalid_transaction_intent()`, the same
    classification the rest of the module already uses for malformed amount
    data, so error classification stays consistent.
  - Tests: negative fixtures (incl. a whitespace-wrapped one), positive and
    allowed-zero fixtures asserting the exact returned value, and a
    malformed/lossy fixture set (`+1`, `1.5`, `1.`, `.5`, `1_000`, `1e3`,
    overflow).

#832 Normalize SEP-6 status case
  - SEP-6 status matching was already trimming and lowercasing, but the
    `s.trim().to_ascii_lowercase()` call was duplicated across
    `TransactionStatus::from_str`, `classify_status_str` and every
    `VendorStatusMap` method. Extract it into a single private
    `normalize_status_token` helper and route all status matching through
    that one boundary.
  - Only the status token is normalized; free-form fields such as a
    transaction `message` are untouched.
  - Tests: mixed-case fixtures (`completed` / `COMPLETED` / `Completed` /
    `  cOmPlEtEd  `) mapping to one typed status through
    `fetch_transaction_status`; a fixture asserting `message` is preserved
    byte-for-byte (no lowercasing, no trimming) while its status is
    normalized; unknown statuses staying `Error` / `Unknown` regardless of
    casing; and case-insensitive `VendorStatusMap` lookup.

#830 Bound response error body
  - Add `response_validator::MAX_ERROR_BODY_LEN` (256) and a private
    `body_for_error` helper that caps an untrusted body to that limit before
    it is embedded in an error message, appending a `(truncated)` marker and
    cutting on a UTF-8 character boundary so the result is always valid
    text. Bodies at or below the limit are echoed verbatim, so short
    diagnostics are unchanged. The limit follows the existing
    `pub const MAX_*` bounding style used elsewhere in the crate.
  - The new `validate_response_body` parse-error path (see #829) routes its
    body snippet through this helper, so a multi-megabyte body can no longer
    produce unbounded error text or error-string allocations. Error
    classification (`ErrorCode::ValidationError`) is retained.
  - Tests: a 50 000-byte non-JSON body producing bounded error context that
    contains `truncated`; a short body left intact with no marker; and
    direct `body_for_error` coverage for the char-boundary cut and the
    short-body pass-through.

#829 Reject empty response body where required
  - Add `response_validator::validate_response_body(body, BodyRequirement)`,
    the JSON validation entry point callers run on the raw response string
    before field-level validation.
  - With `BodyRequirement::Required` an empty or whitespace-only body fails
    immediately with a stable reason ("response body is empty but a JSON
    body is required") and no parsing is attempted. With
    `BodyRequirement::Optional` an empty body is accepted unchanged, so
    optional-empty response behavior is preserved. A non-empty body must
    look like a JSON object or array; JSON-shaped bodies pass through
    untouched and full structural validation stays with the field-level
    validators.
  - Tests: required + empty and required + whitespace-only both rejected
    with `ErrorCode::ValidationError`; optional + empty accepted; valid
    JSON object/array bodies accepted under both requirements.

Notes
  - This environment has no Rust toolchain by default and the repository
    does not build on `main` (pre-existing duplicate `ErrorCode`
    discriminants 77/78 in src/errors.rs, a missing
    `ErrorCode::InvalidRegistration` referenced by src/contract.rs, and
    several pre-existing test-compile errors in retry_budget.rs,
    distributed_correlation.rs and synthetic_probe.rs). Those are unrelated
    to this change. The new tests were run against a locally patched build
    that works around only the pre-existing breakage: 16 new tests pass, and
    the two touched modules keep their prior pass counts (the sole existing
    failures, `sep6::tests::test_poll_retries_transient_error_then_succeeds`
    and `response_validator::tests::test_quote_fee_equals_amount_rejected`,
    predate this change).


Closes #834
Closes #832
Closes #830
Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)
