### PR TITLE
Bound audit-log retention to the storage policy maximum (#874)

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1726,6 +1726,15 @@ const KYC_EXPIRY_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days
 /// unpredictable.
 const MAX_QUOTE_VALIDITY_SECONDS: u64 = 30 * 24 * 60 * 60;
 
+/// Upper bound (in days) for the configurable audit-log retention period.
+///
+/// Matches the `audit_log_retention_days.maximum` enforced by
+/// `config_schema.json`. Values above this are rejected by
+/// [`set_audit_log_retention`](AnchorKitContract::set_audit_log_retention)
+/// because they would otherwise keep sensitive request data indefinitely and
+/// bloat the expiry arithmetic (`retention_days * 86400`) used by auto-pruning.
+pub const MAX_AUDIT_LOG_RETENTION_DAYS: u64 = 3650;
+
 fn current_kyc_status(env: &Env, record: &KycRecord) -> KycStatus {
     if let Some(expiry) = record.expiry {
         if env.ledger().timestamp() > expiry {
@@ -6237,8 +6246,16 @@ impl AnchorKitContract {
 
     /// Set the audit log retention policy in days (admin-only).
     /// A value of 0 means no automatic retention limit is enforced.
+    ///
+    /// Rejects [`retention_days`] above [`MAX_AUDIT_LOG_RETENTION_DAYS`] with a
+    /// validation error: an unbounded retention period would retain sensitive
+    /// request data indefinitely and overflow the `days * 86400` expiry
+    /// arithmetic used during auto-pruning.
     pub fn set_audit_log_retention(env: Env, retention_days: u64) {
         Self::require_admin(&env);
+        if retention_days > MAX_AUDIT_LOG_RETENTION_DAYS {
+            panic_with_error!(&env, ErrorCode::ValidationError);
+        }
         let key = audit_retention_key(&env);
         env.storage().instance().set(&key, &retention_days);
         env.storage().instance().extend_ttl(INSTANCE_TTL, INSTANCE_TTL);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -179,11 +179,10 @@ pub enum ErrorCode {
     /// No SLO has been configured for this anchor.
     SloNotConfigured          = 76,
 
-    // Retirement transition errors (77-78)
-    /// The requested retirement transition is invalid for the current state.
-    InvalidRetirementTransition = 77,
-    /// Environment fingerprint collection failed.
-    FingerprintCollectionFailed = 78,
+    // Registration input errors (80)
+    /// Registration was rejected because a required text field is blank
+    /// (e.g. the SEP-10 token supplied to `register_attestor` is empty).
+    InvalidRegistration       = 80,
 }
 
 impl ErrorCode {
@@ -270,6 +269,7 @@ impl ErrorCode {
             ErrorCode::SloNotConfigured          => "No SLO has been configured for this anchor",
             ErrorCode::InvalidRetirementTransition => "Invalid retirement transition for current state",
             ErrorCode::FingerprintCollectionFailed => "Environment fingerprint collection failed",
+            ErrorCode::InvalidRegistration       => "Registration rejected: a required text field is blank",
         }
     }
 }
@@ -766,8 +766,9 @@ mod tests {
         assert_eq!(ErrorCode::QuoteExpired          as u32, 60);
         assert_eq!(ErrorCode::SignatureVerificationFailed as u32, 61);
         assert_eq!(ErrorCode::BatchSizeExceeded     as u32, 62);
-        assert_eq!(ErrorCode::InvalidRetirementTransition as u32, 77);
-        assert_eq!(ErrorCode::FingerprintCollectionFailed as u32, 78);
+        assert_eq!(ErrorCode::InvalidRetirementTransition as u32, 65);
+        assert_eq!(ErrorCode::FingerprintCollectionFailed as u32, 66);
+        assert_eq!(ErrorCode::InvalidRegistration as u32, 80);
     }
 
     #[test]

--- a/tests/audit_log_retention_tests.rs
+++ b/tests/audit_log_retention_tests.rs
@@ -93,6 +93,30 @@ mod audit_log_retention_tests {
         assert_eq!(client.get_audit_log_retention(), 7);
     }
 
+    /// Binding the retention policy (#874): an over-limit retention duration
+    /// must be rejected before it is stored. Overflowing the `days * 86400`
+    /// expiry arithmetic would otherwise keep sensitive request data
+    /// indefinitely and exceed the storage policy's supported maximum.
+    #[test]
+    #[should_panic(expected = "#15")]
+    fn test_over_limit_retention_is_rejected() {
+        let env = make_env(); let (_admin, client) = setup(&env);
+        // MAX_AUDIT_LOG_RETENTION_DAYS = 3650; anything above must be rejected
+        // with ErrorCode::ValidationError (contract code 15).
+        client.set_audit_log_retention(&(3650 + 1));
+    }
+
+    /// Regression guard (#874): the boundary value itself and values below it
+    /// remain valid and are stored exactly.
+    #[test]
+    fn test_max_retention_boundary_is_accepted_exactly() {
+        let env = make_env(); let (admin, client) = setup(&env);
+        client.set_audit_log_retention(&3650);
+        assert_eq!(client.get_audit_log_retention(), 3650);
+        client.set_audit_log_retention(&1);
+        assert_eq!(client.get_audit_log_retention(), 1);
+    }
+
     // ── Audit log count ───────────────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## What this fixes

An operator can no longer configure an audit-log retention period beyond the
storage policy's supported maximum. Over-limit retention durations are now
rejected before any state is written, so sensitive request data can never be
retained effectively forever, and the `retention_days * 86400` expiry
arithmetic used by auto-pruning can no longer overflow.

## Root cause

`AnchorKitContract::set_audit_log_retention` stored whatever `u64` it was
handed with no upper bound. The storage policy (`config_schema.json`) caps
`audit_log_retention_days` at `3650`, but the same cap was never enforced at
the on-chain configuration boundary:

- An operator could set a retention of e.g. `u64::MAX` days.
- `get_audit_log_count`'s auto-prune path computes `retention_days * 86400`;
  for large inputs this overflows, defeating the `saturating_sub` guard and
  either panicking or silently wrapping the cutoff.
- A huge retention also keeps sensitive request data around indefinitely,
  directly contradicting the retention policy's purpose.

## The fix and why

- Introduce `pub const MAX_AUDIT_LOG_RETENTION_DAYS: u64 = 3650` in
  `src/contract.rs`, mirroring the `config_schema.json` maximum so the
  documented storage policy and the on-chain enforcement cannot drift apart.
- In `set_audit_log_retention`, validate **before** any storage mutation:
  values above the maximum panic with `ErrorCode::ValidationError` (contract
  code 15). Because the value is bounded before it is written, the
  downstream `retention_days * 86400` arithmetic can never overflow.
- Valid retention values (including `0` = unlimited, and the boundary `3650`)
  are stored exactly as before; deletion/export/prune behavior is unchanged.

This is a single upper-bound validation using the existing retention policy
constant's supported maximum, and it introduces no archival, storage-schema,
or architecture change.

## How it was tested

- `cargo check` (native) — passes.
- `cargo test --test audit_log_retention_tests` — **22 passed** including:
  - `test_over_limit_retention_is_rejected` — `3651` days panics with
    `ValidationError` (`#15`) and is not stored.
  - `test_max_retention_boundary_is_accepted_exactly` — `3650` and below are
    stored and read back exactly.
- All pre-existing retention, pruning, pagination, and export tests continue
  to pass unchanged.

## Pre-existing, out-of-scope observations (not caused by this change)

- `main` does not compile without a supporting `src/errors.rs` repair (a
  conflicting merge left duplicate `InvalidRetirementTransition` /
  `FingerprintCollectionFailed` discriminants and dropped the
  `InvalidRegistration` variant). This PR includes that minimal repair so the
  crate and the focused retention tests can build.
- `rustfmt`, strict clippy config, and the wasm target build trip on
  **toolchain-version incompatibilities** (stable Rust 1.98 vs. the repo's
  older-stable config), not on this change. With the version-mismatched
  clippy option neutralized, `cargo clippy` reports no errors from this PR.

## Follow-up worth filing separately

- The `src/request_record.rs` host-side `RequestRetentionPolicy` is a
  separate, in-memory retention controller from the on-chain audit-log
  retention this PR bounds. If the intent is to also cap that host-side
  policy's `max_age_seconds`, it would be a distinct, complementary change
  and is best tracked as its own issue.
- Pin a Rust toolchain in CI (rust-toolchain.toml) so formatting, linting,
  and the wasm build are reproducible across toolchain releases.

Closes #874